### PR TITLE
Random Utils

### DIFF
--- a/Scripts/Runtime/Util.meta
+++ b/Scripts/Runtime/Util.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 10b6dfe2a11b74e77be18892f2c10a02
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/Runtime/Util/Random.meta
+++ b/Scripts/Runtime/Util/Random.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: be59a250a06b46dca3de2de47742687d
+timeCreated: 1643643743

--- a/Scripts/Runtime/Util/Random/RandomExtensions.cs
+++ b/Scripts/Runtime/Util/Random/RandomExtensions.cs
@@ -11,14 +11,15 @@ namespace Anvil.Unity.DOTS.Util
     {
         private const uint SPREAD = uint.MaxValue / JobsUtility.MaxJobThreadCount;
         
+        //TODO: Revisit when we get C# 8 support in Unity ECS https://github.com/decline-cookies/anvil-unity-dots/issues/3
         /// <summary>
         /// Given an instance of <see cref="Random"/>, this extension modifies the <see cref="Random"/>'s state so that
-        /// multiple threads using the same initial state will have output different random values based on the thread
+        /// multiple threads using the same initial state will output different random values based on the thread
         /// index.
         /// </summary>
         /// <remarks>
         /// A typical use case with <see cref="Random"/> is to create an instance on the main thread with a given seed.
-        /// Then pass that instance into a job which will get split across many different threads to do some work that
+        /// Then pass that instance into a job which will get copied across many different threads to do some work that
         /// requires randomized values.
         ///
         /// Because the instance is copied into each of the threads they all have the same state and will all output the

--- a/Scripts/Runtime/Util/Random/RandomExtensions.cs
+++ b/Scripts/Runtime/Util/Random/RandomExtensions.cs
@@ -1,0 +1,38 @@
+using System.Runtime.CompilerServices;
+using Unity.Jobs.LowLevel.Unsafe;
+using Unity.Mathematics;
+
+namespace Anvil.Unity.DOTS.Util
+{
+    /// <summary>
+    /// Extension methods for use with a <see cref="Random"/> instance.
+    /// </summary>
+    public static class RandomExtensions
+    {
+        private const uint SPREAD = uint.MaxValue / JobsUtility.MaxJobThreadCount;
+        
+        /// <summary>
+        /// Given an instance of <see cref="Random"/>, this extension modifies the <see cref="Random"/>'s state so that
+        /// multiple threads using the same initial state will have output different random values based on the thread
+        /// index.
+        /// </summary>
+        /// <remarks>
+        /// A typical use case with <see cref="Random"/> is to create an instance on the main thread with a given seed.
+        /// Then pass that instance into a job which will get split across many different threads to do some work that
+        /// requires randomized values.
+        ///
+        /// Because the instance is copied into each of the threads they all have the same state and will all output the
+        /// exact same "random" values which defeats the purpose. This function uses the unique thread index and
+        /// multiplies it by a spread to take up an evenly distributed wide range of bits of
+        /// an <see cref="uint.MaxValue"/>. This value is then XOR'd with the existing state resulting in each thread
+        /// having it's own unique state capable of producing widely divergent random numbers from each other.
+        /// </remarks>
+        /// <param name="random">A ref to the <see cref="Random"/> instance to modify</param>
+        /// <param name="nativeThreadIndex">The thread index to modify this the state with</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void UpdateSeedWithNativeThreadIndex(this ref Random random, int nativeThreadIndex)
+        {
+            random.InitState((uint)(random.state ^ (nativeThreadIndex * SPREAD)));
+        }
+    }
+}

--- a/Scripts/Runtime/Util/Random/RandomExtensions.cs.meta
+++ b/Scripts/Runtime/Util/Random/RandomExtensions.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: afdfd72768fa40819af59b6fafdd90fb
+timeCreated: 1643745381

--- a/Scripts/Runtime/Util/Random/RandomUtil.cs
+++ b/Scripts/Runtime/Util/Random/RandomUtil.cs
@@ -12,11 +12,11 @@ namespace Anvil.Unity.DOTS.Util
     {
         private static Random s_InternalRandom;
 
-        //With DOTS, it's recommended to disable the Domain Reload when entering play mode as it will be pretty slow.
-        //https://docs.unity3d.com/Packages/com.unity.entities@0.17/manual/install_setup.html
-        //Because of this, statics will preserve state across play sessions. By using the RuntimeInitializeOnLoadMethod
-        //we can ensure we reset the state on every play session.
-        //RuntimeInitializeLoadType.SubsystemRegistration represents the earliest moment of all the entries in the enum.
+        // With the Burst compiler, it's common to disable the Domain Reload step when entering play mode to increase iteration time.
+        // https://docs.unity3d.com/Packages/com.unity.entities@0.17/manual/install_setup.html
+        // Because of this, statics will preserve state across play sessions.
+        // `RuntimeInitializeOnLoadMethod` ensures we reset the state on every play session.
+        // `RuntimeInitializeLoadType.SubsystemRegistration` represents the earliest moment of all the entries in the enum.
         [UnityEngine.RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.SubsystemRegistration)]
         private static void Init()
         {
@@ -24,16 +24,16 @@ namespace Anvil.Unity.DOTS.Util
         }
         
         /// <summary>
-        /// Creates a new instance of a <see cref="Random"/> and gives it a random seed between 1 and uint.MaxValue
+        /// Creates a new instance of a <see cref="Random"/> and gives it a random seed between 1 and
+        /// <see cref="uint.MaxValue"/>
         /// </summary>
         /// <remarks>
         /// While you could create a new instance yourself, choosing the seed can be annoying. Common approaches are to
         /// use a different random number generator to generate the seed value or use some aspect of the current time.
-        /// The issue with using the current time is that if you create a bunch of <see cref="Random"/> instance at the
-        /// same time in a loop, the seeds will all be the same and the random numbers generated will all be the same.
+        /// Using current time when generating multiple random instances quickly (or in parallel) risks multiple
+        /// instances sharing the same seed value and will therefore generate the same random numbers.
         /// This method uses an internal instance of <see cref="Random"/> to generate a new seed and ensures that it
-        /// fits the range requirements of the seed not being 0. You are guaranteed to have different seeds each time
-        /// this is called.
+        /// fits the range requirements of the seed not being 0.
         /// </remarks>
         /// <returns>A <see cref="Random"/> instance seeded with a random seed.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/Scripts/Runtime/Util/Random/RandomUtil.cs
+++ b/Scripts/Runtime/Util/Random/RandomUtil.cs
@@ -1,0 +1,45 @@
+using System.Runtime.CompilerServices;
+using Unity.Mathematics;
+using DateTime = System.DateTime;
+using RuntimeInitializeLoadType = UnityEngine.RuntimeInitializeLoadType;
+
+namespace Anvil.Unity.DOTS.Util
+{
+    /// <summary>
+    /// Utility class for simplifying getting access to a <see cref="Random"/> instance.
+    /// </summary>
+    public static class RandomUtil
+    {
+        private static Random s_InternalRandom;
+
+        //With DOTS, it's recommended to disable the Domain Reload when entering play mode as it will be pretty slow.
+        //https://docs.unity3d.com/Packages/com.unity.entities@0.17/manual/install_setup.html
+        //Because of this, statics will preserve state across play sessions. By using the RuntimeInitializeOnLoadMethod
+        //we can ensure we reset the state on every play session.
+        //RuntimeInitializeLoadType.SubsystemRegistration represents the earliest moment of all the entries in the enum.
+        [UnityEngine.RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.SubsystemRegistration)]
+        private static void Init()
+        {
+            s_InternalRandom = new Random((uint)DateTime.Now.Ticks);
+        }
+        
+        /// <summary>
+        /// Creates a new instance of a <see cref="Random"/> and gives it a random seed between 1 and uint.MaxValue
+        /// </summary>
+        /// <remarks>
+        /// While you could create a new instance yourself, choosing the seed can be annoying. Common approaches are to
+        /// use a different random number generator to generate the seed value or use some aspect of the current time.
+        /// The issue with using the current time is that if you create a bunch of <see cref="Random"/> instance at the
+        /// same time in a loop, the seeds will all be the same and the random numbers generated will all be the same.
+        /// This method uses an internal instance of <see cref="Random"/> to generate a new seed and ensures that it
+        /// fits the range requirements of the seed not being 0. You are guaranteed to have different seeds each time
+        /// this is called.
+        /// </remarks>
+        /// <returns>A <see cref="Random"/> instance seeded with a random seed.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Random CreateSeeded()
+        {
+            return new Random(s_InternalRandom.NextUInt(1, uint.MaxValue));
+        }
+    }
+}

--- a/Scripts/Runtime/Util/Random/RandomUtil.cs.meta
+++ b/Scripts/Runtime/Util/Random/RandomUtil.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 62181d4e19d943319203d1b5851443ae
+timeCreated: 1643732834


### PR DESCRIPTION
Added some utility methods to make working `Random` instances in a DOTS/Entities context easier to manage.

### What is the current behaviour?

**Creation**
Currently when you create an instance of `Random` you need to supply a seed. Doing so is annoying because you either need to use a different random number generator to get that seed or more commonly, you use a function of the current date and time. 

You can run into a few issues with this:

1. If you create multiple instances of `Random` at the same time and you are using a function of time for your seed, you will have the same seed for all of them, making them not very random. 
2. If you get unlucky and generate a `0` for your seed, the `Random` instance will crash.
3. Depending on how you're generating your seed, it's an unnecessary extra performance cost.  ex: `DateTime.Now`
    3a. Or just confusing if you're using a different Random number generator

**Threading**
Because `Random` is a struct and it gets copied into multiple threads when running in parallel, all the copied instances have the same state and will generate the same random numbers making it not very random at all. 


### What is the new behaviour?

**Creation**
By using `RandomUtil.CreateSeeded()` you will get a new instance of `Random` returned that has already been seeded with a random seed between `1` and `uint.MaxValue`. 

1. If you create multiple instances with this function at the same time, they will all have different seeds. 
2. You cannot ever get a `0` for a seed.
3. No performance hit or confusion, it uses an internal `Random` instance under the hood.

**Threading**
At the beginning of your `ForEach` or the `Execute` of your `IJob`, you can call `myRandomInstance.UpdateSeedWithNativeThreadIndex` and pass in the thread index. This will ensure that all of your threads who started on the same random state will now have unique states relative to their thread indexes. The values from those randoms will be widely distributed as well.


### What issues does this resolve?
 - None

### What PRs does this depend on?
 - None

### Does this introduce a breaking change?
 - [ ] Yes 
 - [x] No

### Usage

```
            //Create the instance on the main thread
            Random random = RandomUtil.CreateSeeded();

            Entities.WithName(nameof(MakeDecisionSystem))
                    .ForEach((Entity entity,
                              int entityInQueryIndex,
                              ref ModelDecision modelDecision,
                              in EntityParentLink entityParentLink,
                              in int nativeThreadIndex) =>
                             {
                                 //Modify to be unique per thread
                                 random.UpdateSeedWithNativeThreadIndex(nativeThreadIndex);
                                 
                                 //Then use as you normally would
                                 float choice = random.NextFloat(0.0f, 1.0f);
                                 
                                 modelDecision.TimeToDecision += choice < 0.5f
                                     ? -random.NextFloat(0.0f, 3.0f)
                                     : random.NextFloat(0.0f, 3.0f);
                             })
                    .ScheduleParallel(Dependency);
```

### Additional Notes

There are quite a few forum posts on the Unity ECS Forums about Random number generation and one of the approaches is to pre-allocate a `NativeArray` of different `Random` instances indexed by the thread index. 

https://forum.unity.com/threads/solved-gen-random-number-in-job-execute-causes-hang.779987/#post-5191244

The purpose here is be able to preserve the state of a `Random` instance after it exits the thread. We found that writing back to the `NativeArray` caused performance to drop by an order of magnitude. 0.05ms increased to 0.5ms for parallel jobs across 100,000 entities. 

Having the state preserved offered no real benefit since it's simple and cheap to create a new instance with a random seed.

Additionally calling `random.UpdateSeedWithNativeThreadIndex(nativeThreadIndex);` will get executed everytime the ForEach loops which is unnecessary but the method is cheap and better than doing an if check to see if you've called it before. 

When C#8 is available in Unity (note the version of Unity which ECS currently supports which at the time of writing is 2020.1.9 instead of the latest 2022 version), this could be done once per thread. 
https://forum.unity.com/threads/is-it-possible-to-allocate-a-new-temp-nativelist-per-thread-in-entities-foreach.885940/



