### PR TITLE
Create mechanism to manage value access dependencies in jobified code

### DIFF
--- a/Scripts/Runtime/Jobs.meta
+++ b/Scripts/Runtime/Jobs.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: db4336651c92b4949897080c295ded48
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/Runtime/Jobs/ValueAccessController.meta
+++ b/Scripts/Runtime/Jobs/ValueAccessController.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 2ea69f46a01b84df7a3a5d0f0ca95d9c
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/Runtime/Jobs/ValueAccessController/AbstractValueAccessController.cs
+++ b/Scripts/Runtime/Jobs/ValueAccessController/AbstractValueAccessController.cs
@@ -11,7 +11,7 @@ namespace Anvil.Unity.DOTS.Jobs
     /// A wrapper class for managing async access to a value.
     /// </summary>
     /// <remarks>
-    /// Take care that value type implementations propogate state through copies (usually by wrapping a pointer).
+    /// Take care that value type implementations propagate state through copies (usually by wrapping a pointer).
     /// For Example: <see cref="NativeArray{T}" />
     /// </remarks>
     public abstract class AbstractValueAccessController<T> : AbstractAnvilBase
@@ -79,7 +79,7 @@ namespace Anvil.Unity.DOTS.Jobs
         public void ReleaseAsync(JobHandle releaseAccessDependency)
         {
             Debug.Assert(!IsDisposed);
-            Debug.Assert(m_State != AcquisitionState.Unacquired, "There is no outstanding acquisition to realease.");
+            Debug.Assert(m_State != AcquisitionState.Unacquired, "There is no outstanding acquisition to release.");
 
             switch (m_State)
             {
@@ -101,10 +101,12 @@ namespace Anvil.Unity.DOTS.Jobs
         /// <summary>
         /// Get the value of the <see cref="AbstractValueAccessController{T}"/> immediately.
         /// This blocks the calling thread until the value is available.
-        /// <see cref="Release"/> must be called before any other calls to <see cref="AcquireAsync" /> or <see cref="Acquire" /> are made for this value.
+        /// <see cref="Release"/> must be called before any other calls to <see cref="AcquireAsync" /> 
+        /// or <see cref="Acquire" /> are made for this value.
         /// </summary>
         /// <remarks>
-        /// This method and its compliment <see cref="Release" /> are intended to be used for syncronous work on the main thread.
+        /// This method and its compliment <see cref="Release" /> are intended to be used for synchronous work 
+        /// on the main thread.
         /// </remarks>
         public T Acquire(bool isReadOnly)
         {
@@ -123,12 +125,14 @@ namespace Anvil.Unity.DOTS.Jobs
         /// Paired with the use of <see cref="Acquire"/>.
         /// </summary>
         /// <remarks>
-        /// This method can be called after <see cref="AcquireAsync"/> has been called but it will block the calling thread until the value's access dependency is resolved. <see cref="ReleaseAsync" /> is typically the better option.
+        /// This method can be called after <see cref="AcquireAsync"/> has been called but it will 
+        // block the calling thread until the value's access dependency is resolved. <see cref="ReleaseAsync" /> 
+        /// is typically the better option.
         /// </remarks>
         public void Release()
         {
             Debug.Assert(!IsDisposed);
-            Debug.Assert(m_State != AcquisitionState.Unacquired, "There is no outstanding acquisition to realease.");
+            Debug.Assert(m_State != AcquisitionState.Unacquired, "There is no outstanding acquisition to release.");
             m_State = AcquisitionState.Unacquired;
 
             m_ReadAccessDependency.Complete();

--- a/Scripts/Runtime/Jobs/ValueAccessController/AbstractValueAccessController.cs
+++ b/Scripts/Runtime/Jobs/ValueAccessController/AbstractValueAccessController.cs
@@ -1,0 +1,165 @@
+using System;
+using Anvil.CSharp.Core;
+using Unity.Collections;
+using Unity.Entities;
+using Unity.Jobs;
+using UnityEngine;
+
+namespace Anvil.Unity.DOTS.Jobs
+{
+    /// <summary>
+    /// A wrapper class for managing async access to a value.
+    /// </summary>
+    /// <remarks>
+    /// Take care that value type implementations propogate state through copies (usually by wrapping a pointer).
+    /// For Example: <see cref="NativeArray{T}" />
+    /// </remarks>
+    public abstract class AbstractValueAccessController<T> : AbstractAnvilBase
+    {
+        private enum AcquisitionState
+        {
+            Unacquired,
+            ReadOnly,
+            ReadWrite,
+        }
+
+        private readonly T m_Value;
+        /// <summary>
+        /// The handle to wait on before <see cref="m_Value"> can be read.
+        /// </summary>
+        private JobHandle m_ReadAccessDependency = default;
+        /// <summary>
+        /// The handle to wait on before <see cref="m_Value"> can be written to.
+        /// </summary>
+        private JobHandle m_WriteAccessDependency = default;
+        private AcquisitionState m_State = AcquisitionState.Unacquired;
+
+
+        /// <summary>
+        /// Creates a new <see cref="AbstractValueAccessController{T}"/> with a given initial value.
+        /// </summary>
+        internal AbstractValueAccessController(T initialValue)
+        {
+            m_Value = initialValue;
+        }
+
+        protected override void DisposeSelf()
+        {
+            // NOTE: If these asserts trigger we should think about calling Complete() on these job handles.
+            Debug.Assert(m_ReadAccessDependency.IsCompleted, "The read access dependency is not completed");
+            Debug.Assert(m_WriteAccessDependency.IsCompleted, "The write access dependency is not completed");
+            (m_Value as IDisposable)?.Dispose();
+
+            base.DisposeSelf();
+        }
+
+        /// <summary>
+        /// Get the value of the <see cref="AbstractValueAccessController{T}"/> returning a JobHandle to wait on before consuming.
+        /// After the work with the value is scheduled <see cref="ReleaseAsync"/> must be called before any other calls to 
+        /// <see cref="AcquireAsync" /> or <see cref="Acquire" /> are made for this value.
+        /// </summary>
+        /// <param name="isReadOnly">The access level rquired for the value. Accessing readonly will tend to require less waiting.</param>
+        /// <param name="value">The value of the <see cref="AbstractValueAccessController{T}"/>.</param>
+        /// <returns>A JobHandle to wait on before consuming the value.</returns>
+        public JobHandle AcquireAsync(bool isReadOnly, out T value)
+        {
+            Debug.Assert(!IsDisposed);
+#if ENABLE_UNITY_COLLECTIONS_CHECKS
+            ValidateAndUpdateAcquireCaller();
+#endif
+
+            value = m_Value;
+            return GetAcquisitionDependency(isReadOnly);
+        }
+
+        /// <summary>
+        /// Schedule the release of the value's ownership after an asynchronous operation.
+        /// </summary>
+        /// <param name="releaseAccessDependency">The JobHandle that describes when work with the value is complete.</param>
+        public void ReleaseAsync(JobHandle releaseAccessDependency)
+        {
+            Debug.Assert(!IsDisposed);
+            Debug.Assert(m_State != AcquisitionState.Unacquired, "There is no outstanding acquisition to realease.");
+
+            switch (m_State)
+            {
+                case AcquisitionState.ReadOnly:
+                    m_WriteAccessDependency = JobHandle.CombineDependencies(m_WriteAccessDependency, releaseAccessDependency);
+                    break;
+
+                case AcquisitionState.ReadWrite:
+                    m_ReadAccessDependency =
+                        m_WriteAccessDependency = JobHandle.CombineDependencies(m_WriteAccessDependency, releaseAccessDependency);
+                    break;
+
+                default:
+                    throw new ArgumentOutOfRangeException(Enum.GetName(typeof(AcquisitionState), m_State));
+            }
+            m_State = AcquisitionState.Unacquired;
+        }
+
+        /// <summary>
+        /// Get the value of the <see cref="AbstractValueAccessController{T}"/> immediately.
+        /// This blocks the calling thread until the value is available.
+        /// <see cref="Release"/> must be called before any other calls to <see cref="AcquireAsync" /> or <see cref="Acquire" /> are made for this value.
+        /// </summary>
+        /// <remarks>
+        /// This method and its compliment <see cref="Release" /> are intended to be used for syncronous work on the main thread.
+        /// </remarks>
+        public T Acquire(bool isReadOnly)
+        {
+            Debug.Assert(!IsDisposed);
+#if ENABLE_UNITY_COLLECTIONS_CHECKS
+            ValidateAndUpdateAcquireCaller();
+#endif
+            GetAcquisitionDependency(isReadOnly)
+                .Complete();
+
+            return m_Value;
+        }
+
+        /// <summary>
+        /// Releases access to the value immediately.
+        /// Paired with the use of <see cref="Acquire"/>.
+        /// </summary>
+        /// <remarks>
+        /// This method can be called after <see cref="AcquireAsync"/> has been called but it will block the calling thread until the value's access dependency is resolved. <see cref="ReleaseAsync" /> is typically the better option.
+        /// </remarks>
+        public void Release()
+        {
+            Debug.Assert(!IsDisposed);
+            Debug.Assert(m_State != AcquisitionState.Unacquired, "There is no outstanding acquisition to realease.");
+            m_State = AcquisitionState.Unacquired;
+
+            m_ReadAccessDependency.Complete();
+            if (m_State == AcquisitionState.ReadWrite)
+            {
+                m_WriteAccessDependency.Complete();
+            }
+        }
+
+        private JobHandle GetAcquisitionDependency(bool isReadOnly)
+        {
+            if (isReadOnly)
+            {
+                m_State = AcquisitionState.ReadOnly;
+                return m_ReadAccessDependency;
+            }
+
+            m_State = AcquisitionState.ReadWrite;
+            return m_WriteAccessDependency;
+        }
+
+#if ENABLE_UNITY_COLLECTIONS_CHECKS
+        private string m_AcquireCallerInfo;
+
+        private void ValidateAndUpdateAcquireCaller()
+        {
+            Debug.Assert(m_State == AcquisitionState.Unacquired, $"Release must be scheduled before scheduling acquisition again. Last ScheduleAcquire caller hasn't scheduled release yet. {m_AcquireCallerInfo}");
+
+            System.Diagnostics.StackFrame frame = new System.Diagnostics.StackFrame(1);
+            m_AcquireCallerInfo = $"{frame.GetMethod().Name} at {frame.GetFileName()}:{frame.GetFileLineNumber()}";
+        }
+#endif
+    }
+}

--- a/Scripts/Runtime/Jobs/ValueAccessController/AbstractValueAccessController.cs.meta
+++ b/Scripts/Runtime/Jobs/ValueAccessController/AbstractValueAccessController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6ab9c2fd6a2b54220ba899ab83914823
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/Runtime/Jobs/ValueAccessController/NativeArrayAccessController.cs
+++ b/Scripts/Runtime/Jobs/ValueAccessController/NativeArrayAccessController.cs
@@ -1,0 +1,14 @@
+using Unity.Collections;
+using Unity.Entities;
+
+namespace Anvil.Unity.DOTS.Jobs
+{
+    /// <summary>
+    /// A wrapper for NativeArray that provides a way to manage async access to the array.
+    /// </summary>
+    public class NativeArrayAccessController<T> : AbstractValueAccessController<NativeArray<T>> where T : struct, IComponentData
+    {
+        public NativeArrayAccessController(int length, NativeArrayOptions options)
+            : base(new NativeArray<T>(length, Allocator.Persistent, options)) { }
+    }
+}

--- a/Scripts/Runtime/Jobs/ValueAccessController/NativeArrayAccessController.cs
+++ b/Scripts/Runtime/Jobs/ValueAccessController/NativeArrayAccessController.cs
@@ -6,7 +6,7 @@ namespace Anvil.Unity.DOTS.Jobs
     /// <summary>
     /// A wrapper for NativeArray that provides a way to manage async access to the array.
     /// </summary>
-    public class NativeArrayAccessController<T> : AbstractValueAccessController<NativeArray<T>> where T : struct, IComponentData
+    public class NativeArrayAccessController<T> : AbstractValueAccessController<NativeArray<T>> where T : struct
     {
         public NativeArrayAccessController(int length, NativeArrayOptions options)
             : base(new NativeArray<T>(length, Allocator.Persistent, options)) { }

--- a/Scripts/Runtime/Jobs/ValueAccessController/NativeArrayAccessController.cs.meta
+++ b/Scripts/Runtime/Jobs/ValueAccessController/NativeArrayAccessController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 468dc449896324f5a82d5fae51d3ab2f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/Runtime/anvil-unity-dots-runtime.asmdef
+++ b/Scripts/Runtime/anvil-unity-dots-runtime.asmdef
@@ -1,6 +1,8 @@
 {
     "name": "anvil-unity-dots-runtime",
     "references": [
+        "anvil-csharp-core",
+        "anvil-unity-core-runtime",
         "Unity.Burst",
         "Unity.Collections",
         "Unity.Entities",


### PR DESCRIPTION
- Manage access to arbitrary values that are not stored in ECS's chunk system (Ex: Values hosted on systems).
- Provides and maintains job handles to manage safe job access to the value

Create concrete implementation for `NativeArray` (most common use case)

#### Tag Along
 - Added `anvil-csharp-core` and `anvil-unity-core` to the `asmdef`.

### What is the current behaviour?
Managing values that aren't attached to an Entity is a pain.

### What is the new behaviour?
Developers can wrap their variable in this type to allow any part of their code to schedule access in a way that's compatible with the Job system.

### What issues does this resolve?
😞  and 😢 and 😭  when managing access dependencies.

### What PRs does this depend on?
 - None

### Does this introduce a breaking change?
 - [ ] Yes
 - [x] No
