### PR TITLE
Create AbstractAnvilSystemBase and supporting types

### DIFF
--- a/Scripts/Runtime/Entities.meta
+++ b/Scripts/Runtime/Entities.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 1121970bd102843f4a2e4378607a6091
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/Runtime/Entities/AbstractAnvilSystemBase.cs
+++ b/Scripts/Runtime/Entities/AbstractAnvilSystemBase.cs
@@ -20,7 +20,7 @@ namespace Anvil.Unity.DOTS.Entities
             {
                 return base.Dependency;
             }
-            // Detects situations where the existing dependency is overwritten rather than chained or cominbed.
+            // Detects situations where the existing dependency is overwritten rather than chained or combined.
             set
             {
                 // Note: The arguments to JobHandle.CheckFenceIsDependencyOrDidSyncFence seem backward.
@@ -43,7 +43,7 @@ namespace Anvil.Unity.DOTS.Entities
         /// Builds a container to provide in job access to a singleton <see cref="DynamicBuffer{T}" />.
         /// </summary>
         /// <typeparam name="T">The element type of the <see cref="DynamicBuffer{T}" />.</typeparam>
-        /// <param name="isReadOnly">true if the data will not be written too.</param>
+        /// <param name="isReadOnly">true if the data will not be written to.</param>
         /// <returns>A container that provides in job access to the requested <see cref="DynamicBuffer{T}" />.</returns>
         protected BufferFromSingleEntity<T> GetBufferFromSingletonEntity<T>(bool isReadOnly = false) where T : struct, IBufferElementData
         {
@@ -55,7 +55,7 @@ namespace Anvil.Unity.DOTS.Entities
         /// </summary>
         /// <typeparam name="T">The element type of the <see cref="DynamicBuffer{T}" />.</typeparam>
         /// <param name="entity">The <see cref="Entity" /> to get the <see cref="DynamicBuffer{T}" /> from.</param>
-        /// <param name="isReadOnly">true if the data will not be written too.</param>
+        /// <param name="isReadOnly">true if the data will not be written to.</param>
         /// <returns>A container that provides in job access to the requested <see cref="DynamicBuffer{T}" />.</returns>
         protected BufferFromSingleEntity<T> GetBufferFromSingleEntity<T>(Entity entity, bool isReadOnly = false) where T : struct, IBufferElementData
         {
@@ -66,7 +66,7 @@ namespace Anvil.Unity.DOTS.Entities
         /// Builds a container to provide in job access to a singleton <see cref="IComponentData" />.
         /// </summary>
         /// <typeparam name="T">The type that implements <see cref="IComponentData" />.</typeparam>
-        /// <param name="isReadOnly">true if the data will not be written too.</param>
+        /// <param name="isReadOnly">true if the data will not be written to.</param>
         /// <returns>A container that provides in job access to the requested <see cref="T" />.</returns>
         protected ComponentDataFromSingleEntity<T> GetComponentDataFromSingletonEntity<T>(bool isReadOnly) where T : struct, IComponentData
         {
@@ -78,7 +78,7 @@ namespace Anvil.Unity.DOTS.Entities
         /// </summary>
         /// <typeparam name="T">The element type of the <see cref="IComponentData" />.</typeparam>
         /// <param name="entity">The <see cref="Entity" /> to get the <see cref="T" /> from.</param>
-        /// <param name="isReadOnly">true if the data will not be written too.</param>
+        /// <param name="isReadOnly">true if the data will not be written to.</param>
         /// <returns>A container that provides in job access to the requested <see cref="T" />.</returns>
         protected ComponentDataFromSingleEntity<T> GetComponentDataFromSingleEntity<T>(Entity entity, bool isReadOnly) where T : struct, IComponentData
         {
@@ -87,11 +87,11 @@ namespace Anvil.Unity.DOTS.Entities
 
         // ----- Copy From Buffers ----- //
         /// <summary>
-        /// Schedule a job to asyncronously copy a singleton <see cref="DynamicBuffer{T}" /> to 
+        /// Schedule a job to asynchronously copy a singleton <see cref="DynamicBuffer{T}" /> to 
         /// a <see cref="NativeArray{T}" /> after <see cref="Dependency"/> has completed.
         /// </summary>
         /// <typeparam name="T">The element type of the <see cref="DynamicBuffer{T}" />.</typeparam>
-        /// <param name="outputBuffer">The <see cref="NativeArray{T}" /> to copy too.</param>
+        /// <param name="outputBuffer">The <see cref="NativeArray{T}" /> to copy to.</param>
         /// <remarks>Actual copy is performed by <see cref="CopyFromSingletonBuffer{T}" /></remarks>
         protected void CopyFromSingletonBufferAsync<T>(NativeArray<T> outputBuffer) where T : struct, IBufferElementData
         {
@@ -99,12 +99,12 @@ namespace Anvil.Unity.DOTS.Entities
         }
 
         /// <summary>
-        /// Schedule a job to asyncronously copy a singleton <see cref="DynamicBuffer{T}" /> to 
+        /// Schedule a job to asynchronously copy a singleton <see cref="DynamicBuffer{T}" /> to 
         /// a <see cref="NativeArray{T}" /> after the provided <see cref="JobHandle"/> has completed.
         /// </summary>
         /// <typeparam name="T">The element type of the <see cref="DynamicBuffer{T}" />.</typeparam>
         /// <param name="dependsOn">The <see cref="JobHandle"/> to wait for.</param>
-        /// <param name="outputBuffer">The <see cref="NativeArray{T}" /> to copy too.</param>
+        /// <param name="outputBuffer">The <see cref="NativeArray{T}" /> to copy to.</param>
         /// <remarks>Actual copy is performed by <see cref="CopyFromSingletonBuffer{T}" /></remarks>
         protected JobHandle CopyFromSingletonBufferAsync<T>(in JobHandle dependsOn, in NativeArray<T> outputBuffer) where T : struct, IBufferElementData
         {
@@ -119,7 +119,7 @@ namespace Anvil.Unity.DOTS.Entities
 
         // ----- Copy To Buffers ----- //
         /// <summary>
-        /// Schedule a job to asyncronously copy a <see cref="NativeArray{T}" /> to a
+        /// Schedule a job to asynchronously copy a <see cref="NativeArray{T}" /> to a
         /// singleton <see cref="DynamicBuffer{T}" /> after <see cref="Dependency"/> has completed.
         /// </summary>
         /// <typeparam name="T">The element type of the <see cref="DynamicBuffer{T}" />.</typeparam>
@@ -131,7 +131,7 @@ namespace Anvil.Unity.DOTS.Entities
         }
 
         /// /// <summary>
-        /// Schedule a job to asyncronously copy a <see cref="NativeArray{T}" /> to a
+        /// Schedule a job to asynchronously copy a <see cref="NativeArray{T}" /> to a
         /// singleton <see cref="DynamicBuffer{T}" /> after the provided <see cref="JobHandle"/> has completed.
         /// </summary>
         /// <typeparam name="T">The element type of the <see cref="DynamicBuffer{T}" />.</typeparam>

--- a/Scripts/Runtime/Entities/AbstractAnvilSystemBase.cs
+++ b/Scripts/Runtime/Entities/AbstractAnvilSystemBase.cs
@@ -1,0 +1,153 @@
+using Unity.Entities;
+using Unity.Collections;
+using Unity.Jobs;
+using UnityEngine;
+
+namespace Anvil.Unity.DOTS.Entities
+{
+    /// <summary>
+    /// The base class for Systems when using the Anvil Framework.
+    /// Adds some convenience functionality non-release safety checks for 
+    /// <see cref="SystemBase"/> implementations.
+    /// </summary>
+    public abstract class AbstractAnvilSystemBase : SystemBase
+    {
+#if ENABLE_UNITY_COLLECTIONS_CHECKS
+        /// <inheritdoc/>
+        protected new JobHandle Dependency
+        {
+            get
+            {
+                return base.Dependency;
+            }
+            // Detects situations where the existing dependency is overwritten rather than chained or cominbed.
+            set
+            {
+                // Note: The arguments to JobHandle.CheckFenceIsDependencyOrDidSyncFence seem backward.
+                // This checks whether the incoming value depends on base.Dependency
+                Debug.Assert(JobHandle.CheckFenceIsDependencyOrDidSyncFence(base.Dependency, value), "Dependency Chain Broken: The incoming dependency does not contain the existing dependency in the chain.");
+                base.Dependency = value;
+            }
+        }
+#endif
+
+        /// <summary>
+        /// Creates a new <see cref="AbstractAnvilSystemBase"/> instance.
+        /// </summary>
+        public AbstractAnvilSystemBase() : base()
+        {
+        }
+
+        // ----- Buffer and Component Getters for Jobs ----- //
+        /// <summary>
+        /// Builds a container to provide in job access to a singleton <see cref="DynamicBuffer{T}" />.
+        /// </summary>
+        /// <typeparam name="T">The element type of the <see cref="DynamicBuffer{T}" />.</typeparam>
+        /// <param name="isReadOnly">true if the data will not be written too.</param>
+        /// <returns>A container that provides in job access to the requested <see cref="DynamicBuffer{T}" />.</returns>
+        protected BufferFromSingleEntity<T> GetBufferFromSingletonEntity<T>(bool isReadOnly = false) where T : struct, IBufferElementData
+        {
+            return new BufferFromSingleEntity<T>(GetBufferFromEntity<T>(isReadOnly), GetSingletonEntity<T>());
+        }
+
+        /// <summary>
+        /// Builds a container to provide in job access to a <see cref="DynamicBuffer{T}" /> on an entity.
+        /// </summary>
+        /// <typeparam name="T">The element type of the <see cref="DynamicBuffer{T}" />.</typeparam>
+        /// <param name="entity">The <see cref="Entity" /> to get the <see cref="DynamicBuffer{T}" /> from.</param>
+        /// <param name="isReadOnly">true if the data will not be written too.</param>
+        /// <returns>A container that provides in job access to the requested <see cref="DynamicBuffer{T}" />.</returns>
+        protected BufferFromSingleEntity<T> GetBufferFromSingleEntity<T>(Entity entity, bool isReadOnly = false) where T : struct, IBufferElementData
+        {
+            return new BufferFromSingleEntity<T>(GetBufferFromEntity<T>(isReadOnly), entity);
+        }
+
+        /// <summary>
+        /// Builds a container to provide in job access to a singleton <see cref="IComponentData" />.
+        /// </summary>
+        /// <typeparam name="T">The type that implements <see cref="IComponentData" />.</typeparam>
+        /// <param name="isReadOnly">true if the data will not be written too.</param>
+        /// <returns>A container that provides in job access to the requested <see cref="T" />.</returns>
+        protected ComponentDataFromSingleEntity<T> GetComponentDataFromSingletonEntity<T>(bool isReadOnly) where T : struct, IComponentData
+        {
+            return new ComponentDataFromSingleEntity<T>(GetComponentDataFromEntity<T>(isReadOnly), GetSingletonEntity<T>());
+        }
+
+        /// <summary>
+        /// Builds a container to provide in job access to a <see cref="IComponentData{T}" /> on an entity.
+        /// </summary>
+        /// <typeparam name="T">The element type of the <see cref="IComponentData" />.</typeparam>
+        /// <param name="entity">The <see cref="Entity" /> to get the <see cref="T" /> from.</param>
+        /// <param name="isReadOnly">true if the data will not be written too.</param>
+        /// <returns>A container that provides in job access to the requested <see cref="T" />.</returns>
+        protected ComponentDataFromSingleEntity<T> GetComponentDataFromSingleEntity<T>(Entity entity, bool isReadOnly) where T : struct, IComponentData
+        {
+            return new ComponentDataFromSingleEntity<T>(GetComponentDataFromEntity<T>(isReadOnly), entity);
+        }
+
+        // ----- Copy From Buffers ----- //
+        /// <summary>
+        /// Schedule a job to asyncronously copy a singleton <see cref="DynamicBuffer{T}" /> to 
+        /// a <see cref="NativeArray{T}" /> after <see cref="Dependency"/> has completed.
+        /// </summary>
+        /// <typeparam name="T">The element type of the <see cref="DynamicBuffer{T}" />.</typeparam>
+        /// <param name="outputBuffer">The <see cref="NativeArray{T}" /> to copy too.</param>
+        /// <remarks>Actual copy is performed by <see cref="CopyFromSingletonBuffer{T}" /></remarks>
+        protected void CopyFromSingletonBufferAsync<T>(NativeArray<T> outputBuffer) where T : struct, IBufferElementData
+        {
+            Dependency = CopyFromSingletonBufferAsync<T>(Dependency, outputBuffer);
+        }
+
+        /// <summary>
+        /// Schedule a job to asyncronously copy a singleton <see cref="DynamicBuffer{T}" /> to 
+        /// a <see cref="NativeArray{T}" /> after the provided <see cref="JobHandle"/> has completed.
+        /// </summary>
+        /// <typeparam name="T">The element type of the <see cref="DynamicBuffer{T}" />.</typeparam>
+        /// <param name="dependsOn">The <see cref="JobHandle"/> to wait for.</param>
+        /// <param name="outputBuffer">The <see cref="NativeArray{T}" /> to copy too.</param>
+        /// <remarks>Actual copy is performed by <see cref="CopyFromSingletonBuffer{T}" /></remarks>
+        protected JobHandle CopyFromSingletonBufferAsync<T>(in JobHandle dependsOn, in NativeArray<T> outputBuffer) where T : struct, IBufferElementData
+        {
+            EntityQuery query = GetEntityQuery(ComponentType.ReadOnly<T>());
+            CopyFromSingletonBuffer<T> job = new CopyFromSingletonBuffer<T>()
+            {
+                InputBufferTypeHandle = GetBufferTypeHandle<T>(),
+                OutputBuffer = outputBuffer
+            };
+            return job.Schedule(query, dependsOn);
+        }
+
+        // ----- Copy To Buffers ----- //
+        /// <summary>
+        /// Schedule a job to asyncronously copy a <see cref="NativeArray{T}" /> to a
+        /// singleton <see cref="DynamicBuffer{T}" /> after <see cref="Dependency"/> has completed.
+        /// </summary>
+        /// <typeparam name="T">The element type of the <see cref="DynamicBuffer{T}" />.</typeparam>
+        /// <param name="inputBuffer">The <see cref="NativeArray{T}" /> to copy from.</param>
+        /// <remarks>Actual copy is performed by <see cref="CopyToSingletonBuffer{T}" /></remarks>
+        protected void CopyToSingletonBufferAsync<T>(in NativeArray<T> inputBuffer) where T : struct, IBufferElementData
+        {
+            Dependency = CopyToSingletonBufferAsync<T>(Dependency, inputBuffer);
+        }
+
+        /// /// <summary>
+        /// Schedule a job to asyncronously copy a <see cref="NativeArray{T}" /> to a
+        /// singleton <see cref="DynamicBuffer{T}" /> after the provided <see cref="JobHandle"/> has completed.
+        /// </summary>
+        /// <typeparam name="T">The element type of the <see cref="DynamicBuffer{T}" />.</typeparam>
+        /// <param name="dependsOn">The <see cref="JobHandle"/> to wait for.</param>
+        /// <param name="inputBuffer">The <see cref="NativeArray{T}" /> to copy from.</param>
+        /// <remarks>Actual copy is performed by <see cref="CopyToSingletonBuffer{T}" /></remarks>
+        protected JobHandle CopyToSingletonBufferAsync<T>(in JobHandle dependsOn, in NativeArray<T> inputBuffer) where T : struct, IBufferElementData
+        {
+            EntityQuery query = GetEntityQuery(ComponentType.ReadWrite<T>());
+            CopyToSingletonBuffer<T> job = new CopyToSingletonBuffer<T>()
+            {
+                InputBuffer = inputBuffer,
+                OutputBufferTypeHandle = GetBufferTypeHandle<T>()
+            };
+            return job.Schedule(query, dependsOn);
+        }
+
+    }
+}

--- a/Scripts/Runtime/Entities/AbstractAnvilSystemBase.cs.meta
+++ b/Scripts/Runtime/Entities/AbstractAnvilSystemBase.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f0705f06c97384a0ea41248f8eb89053
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/Runtime/Entities/BufferFromSingleEntity.cs
+++ b/Scripts/Runtime/Entities/BufferFromSingleEntity.cs
@@ -1,0 +1,38 @@
+using Unity.Entities;
+
+
+namespace Anvil.Unity.DOTS.Entities
+{
+    /// <summary>
+    /// A container that provides access to a <see cref="DynamicBuffer{T}" from a single entitiy.
+    /// </summary>
+    /// <typeparam name="T">The element type of the buffer</typeparam>
+    /// <remarks>Allows developers to define jobs with fewer parameters that clearly communicate intent.</remarks>
+    public readonly struct BufferFromSingleEntity<T> where T : struct, IBufferElementData
+    {
+        private readonly BufferFromEntity<T> m_Lookup;
+        private readonly Entity m_Entity;
+
+        /// <summary>
+        /// Creates a new <see cref="BufferFromSingleEntity{T}"/>.
+        /// </summary>
+        /// <param name="lookup">The <see cref="BufferFromEntity{T}" /> lookup to read the buffer reference from.</param>
+        /// <param name="entity">The <see cref="Entity" /> that the <see cref="DynamicBuffer{T}" /> is on.</param>
+        public BufferFromSingleEntity(BufferFromEntity<T> lookup, Entity entity)
+        {
+            m_Lookup = lookup;
+            m_Entity = entity;
+        }
+
+        /// <summary>
+        /// Gets the <see cref="DynamicBuffer{T}" />. 
+        /// Call during job execution.
+        /// </summary>
+        /// <returns>The <see cref="DynamicBuffer{T}" /> instance</returns>
+        public DynamicBuffer<T> GetBuffer()
+        {
+            return m_Lookup[m_Entity];
+        }
+    }
+
+}

--- a/Scripts/Runtime/Entities/BufferFromSingleEntity.cs
+++ b/Scripts/Runtime/Entities/BufferFromSingleEntity.cs
@@ -4,7 +4,7 @@ using Unity.Entities;
 namespace Anvil.Unity.DOTS.Entities
 {
     /// <summary>
-    /// A container that provides access to a <see cref="DynamicBuffer{T}" from a single entitiy.
+    /// A container that provides access to a <see cref="DynamicBuffer{T}" from a single entity.
     /// </summary>
     /// <typeparam name="T">The element type of the buffer</typeparam>
     /// <remarks>Allows developers to define jobs with fewer parameters that clearly communicate intent.</remarks>

--- a/Scripts/Runtime/Entities/BufferFromSingleEntity.cs.meta
+++ b/Scripts/Runtime/Entities/BufferFromSingleEntity.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 841c18293d556423283fbbe7a268ab84
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/Runtime/Entities/ComponentDataFromSingleEntity.cs
+++ b/Scripts/Runtime/Entities/ComponentDataFromSingleEntity.cs
@@ -4,7 +4,7 @@ using Unity.Entities;
 namespace Anvil.Unity.DOTS.Entities
 {
     /// <summary>
-    /// A container that provides access to an <see cref="IComponentData" /> from a single entitiy.
+    /// A container that provides access to an <see cref="IComponentData" /> from a single entity.
     /// </summary>
     /// <typeparam name="T">The type that implements <see cref="IComponentData" /></typeparam>
     /// <remarks>Allows developers to define jobs with fewer parameters that clearly communicate intent.</remarks>

--- a/Scripts/Runtime/Entities/ComponentDataFromSingleEntity.cs
+++ b/Scripts/Runtime/Entities/ComponentDataFromSingleEntity.cs
@@ -1,0 +1,37 @@
+using Unity.Entities;
+
+
+namespace Anvil.Unity.DOTS.Entities
+{
+    /// <summary>
+    /// A container that provides access to an <see cref="IComponentData" /> from a single entitiy.
+    /// </summary>
+    /// <typeparam name="T">The type that implements <see cref="IComponentData" /></typeparam>
+    /// <remarks>Allows developers to define jobs with fewer parameters that clearly communicate intent.</remarks>
+    public readonly struct ComponentDataFromSingleEntity<T> where T : struct, IComponentData
+    {
+        private readonly ComponentDataFromEntity<T> m_Lookup;
+        private readonly Entity m_Entity;
+
+        /// <summary>
+        /// Creates a new <see cref="ComponentDataFromSingleEntity{T}"/>.
+        /// </summary>
+        /// <param name="lookup">The <see cref="ComponentDataFromEntity{T}" /> lookup to read the component reference from.</param>
+        /// <param name="entity">The <see cref="Entity" /> that the <see cref="{T}" /> is on.</param>
+        public ComponentDataFromSingleEntity(ComponentDataFromEntity<T> lookup, Entity entity)
+        {
+            m_Lookup = lookup;
+            m_Entity = entity;
+        }
+
+        /// <summary>
+        /// Gets the <see cref="DynamicBuffer{T}" />. 
+        /// Call during job execution.
+        /// </summary>
+        /// <returns>The <see cref="T" /> instance</returns>
+        public T GetComponent()
+        {
+            return m_Lookup[m_Entity];
+        }
+    }
+}

--- a/Scripts/Runtime/Entities/ComponentDataFromSingleEntity.cs.meta
+++ b/Scripts/Runtime/Entities/ComponentDataFromSingleEntity.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: cfcd07de57f1e4c55afb52a5dd6991a1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/Runtime/Entities/CopyBuffer.meta
+++ b/Scripts/Runtime/Entities/CopyBuffer.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 29514e21aaa124c02baf88dff87287a0
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/Runtime/Entities/CopyBuffer/CopyFromSingletonBufferJob.cs
+++ b/Scripts/Runtime/Entities/CopyBuffer/CopyFromSingletonBufferJob.cs
@@ -9,7 +9,7 @@ namespace Anvil.Unity.DOTS.Entities
     /// <summary>
     /// Copy a singleton <see cref="DynamicBuffer{T}" /> to a <see cref="NativeArray{T}" />.
     /// </summary>
-    // <remarks>
+    /// <remarks>
     /// <see cref="DynamicBuffer{T}" /> and <see cref="NativeArray{T}" /> must have the same length.
     /// </remarks>
     [BurstCompile]

--- a/Scripts/Runtime/Entities/CopyBuffer/CopyFromSingletonBufferJob.cs
+++ b/Scripts/Runtime/Entities/CopyBuffer/CopyFromSingletonBufferJob.cs
@@ -1,0 +1,38 @@
+using Unity.Entities;
+using Unity.Collections;
+using Unity.Jobs;
+using UnityEngine;
+using Unity.Burst;
+
+namespace Anvil.Unity.DOTS.Entities
+{
+    /// <summary>
+    /// Copy a singleton <see cref="DynamicBuffer{T}" /> to a <see cref="NativeArray{T}" />.
+    /// </summary>
+    // <remarks>
+    /// <see cref="DynamicBuffer{T}" /> and <see cref="NativeArray{T}" /> must have the same length.
+    /// </remarks>
+    [BurstCompile]
+    public struct CopyFromSingletonBuffer<T> : IJobEntityBatch where T : struct, IBufferElementData
+    {
+        /// <summary>
+        /// The type handle for the <see cref="DynamicBuffer{T}" /> to copy from.
+        /// </summary>
+        [ReadOnly] public BufferTypeHandle<T> InputBufferTypeHandle;
+        /// <summary>
+        /// The <see cref="NativeArray{T}" to copy to.
+        /// </summary>
+        [WriteOnly] public NativeArray<T> OutputBuffer;
+
+        /// <inheritdoc/>
+        public void Execute(ArchetypeChunk batchInChunk, int batchIndex)
+        {
+            BufferAccessor<T> buffers = batchInChunk.GetBufferAccessor(InputBufferTypeHandle);
+            Debug.Assert(buffers.Length == 1, "Expected singleton buffer");
+            // Could be modified to support mismatched lengths usign `NativeArray<T>.Copy()` but it's not
+            // necessary for the indended use case and adds complexity. Add support if the need arises.
+            Debug.Assert(buffers[0].Length == OutputBuffer.Length, "Output buffer must be the same size as the singleton buffer");
+            OutputBuffer.CopyFrom(buffers[0].AsNativeArray());
+        }
+    }
+}

--- a/Scripts/Runtime/Entities/CopyBuffer/CopyFromSingletonBufferJob.cs.meta
+++ b/Scripts/Runtime/Entities/CopyBuffer/CopyFromSingletonBufferJob.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ce5ce9fd50023411697abf1c06e6cd5e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/Runtime/Entities/CopyBuffer/CopyToSingletonBufferJob.cs
+++ b/Scripts/Runtime/Entities/CopyBuffer/CopyToSingletonBufferJob.cs
@@ -1,0 +1,37 @@
+using Unity.Entities;
+using Unity.Collections;
+using UnityEngine;
+using Unity.Burst;
+
+namespace Anvil.Unity.DOTS.Entities
+{
+    /// <summary>
+    /// Copy a <see cref="NativeArray{T}" /> to a singleton <see cref="DynamicBuffer{T}" />.
+    /// </summary>
+    // <remarks>
+    /// <see cref="DynamicBuffer{T}" /> and <see cref="NativeArray{T}" /> must have the same length.
+    /// </remarks>
+    [BurstCompile]
+    public struct CopyToSingletonBuffer<T> : IJobEntityBatch where T : struct, IBufferElementData
+    {
+        /// <summary>
+        /// The <see cref="NativeArray{T}" /> to copy from.
+        /// </summary>
+        [ReadOnly] public NativeArray<T> InputBuffer;
+        /// <summary>
+        /// The type handle for the <see cref="DynamicBuffer{T}" /> to copy to.
+        /// </summary>
+        [WriteOnly] public BufferTypeHandle<T> OutputBufferTypeHandle;
+
+        /// <inheritdoc/>
+        public void Execute(ArchetypeChunk batchInChunk, int batchIndex)
+        {
+            BufferAccessor<T> buffers = batchInChunk.GetBufferAccessor(OutputBufferTypeHandle);
+            Debug.Assert(buffers.Length == 1, "Expected singleton buffer");
+            // Could be modified to support mismatched lengths using `NativeArray<T>.Copy()` but it's not
+            // necessary for the indended use case and adds complexity. Add support if the need arises.
+            Debug.Assert(buffers[0].Length == InputBuffer.Length, "Output buffer must be the same size as the singleton buffer");
+            NativeArray<T>.Copy(InputBuffer, buffers[0].AsNativeArray());
+        }
+    }
+}

--- a/Scripts/Runtime/Entities/CopyBuffer/CopyToSingletonBufferJob.cs
+++ b/Scripts/Runtime/Entities/CopyBuffer/CopyToSingletonBufferJob.cs
@@ -8,7 +8,7 @@ namespace Anvil.Unity.DOTS.Entities
     /// <summary>
     /// Copy a <see cref="NativeArray{T}" /> to a singleton <see cref="DynamicBuffer{T}" />.
     /// </summary>
-    // <remarks>
+    /// <remarks>
     /// <see cref="DynamicBuffer{T}" /> and <see cref="NativeArray{T}" /> must have the same length.
     /// </remarks>
     [BurstCompile]

--- a/Scripts/Runtime/Entities/CopyBuffer/CopyToSingletonBufferJob.cs.meta
+++ b/Scripts/Runtime/Entities/CopyBuffer/CopyToSingletonBufferJob.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 580182c4f451d4a90bfb384cf9a35ea7
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
 - Ported over project agnostic features from the TwistedDOTS project
 - Added documentation and namespaces

### What is the current behaviour?
N/A

### What is the new behaviour?
`AbstractAnvilSystemBase`
 - Adds convenience methods to
    - Copy to/from singleton dynamic buffers
    - Build `BufferFromSingleEntity<T>` and `ComponentDataFromSingleEntity<T>`
    - Detect and error when a System's `Dependency` property has been overwritten without being chained or combined off it's previous value. (Only when `ENABLE_UNITY_COLLECTIONS_CHECKS` is present)


`BufferFromSingleEntity<T>` and `ComponentDataFromSingleEntity<T>`
 - Encapsulate the intent to read a buffer or component off of a single entity. This is used to reduce boilerplate in jobs that require a single value to be referenced along side a query and more clearly express intent.

### What issues does this resolve?
None

### What PRs does this depend on?
 - PR22 in TwistedDOTS

### Does this introduce a breaking change?
 - [ ] Yes <!-- If so, what are the migration considerations? -->
 - [x] No - but you should probably change the base class of all your existing systems from `SystemBase` to `AbstractAnvilSystemBase`
