### PR TITLE
BufferFromSingleEntity - Permit writing

### DIFF
--- a/Scripts/Runtime/Entities/BufferFromSingleEntity.cs
+++ b/Scripts/Runtime/Entities/BufferFromSingleEntity.cs
@@ -1,3 +1,4 @@
+using Unity.Collections;
 using Unity.Entities;
 
 
@@ -8,9 +9,10 @@ namespace Anvil.Unity.DOTS.Entities
     /// </summary>
     /// <typeparam name="T">The element type of the buffer</typeparam>
     /// <remarks>Allows developers to define jobs with fewer parameters that clearly communicate intent.</remarks>
-    public readonly struct BufferFromSingleEntity<T> where T : struct, IBufferElementData
+    public struct BufferFromSingleEntity<T> where T : struct, IBufferElementData
     {
-        private readonly BufferFromEntity<T> m_Lookup;
+        [NativeDisableParallelForRestriction]
+        private BufferFromEntity<T> m_Lookup;
         private readonly Entity m_Entity;
 
         /// <summary>


### PR DESCRIPTION
Fix bugs that prevented writing to a Buffer exposed by `BufferFromSingleEntity`

### What is the current behaviour?
Error is thrown when trying to modify the elements of a `DynamicBuffer` provided by a `BufferFromSingleEntity`.
Unity implies the `[ReadOnly]` attribute when then `readonly` keyword is used.

### What is the new behaviour?
Writing is now permitted.
Also added `[NativeDisableParallelForRestriction]` to allow parallel writing.

### What issues does this resolve?
Writing to a `BufferFromSingleEntity`

### What PRs does this depend on?
 - None

### Does this introduce a breaking change?
 - [ ] Yes <!-- If so, what are the migration considerations? -->
 - [x] No
