### PR TITLE
Create MemsetBufferJob

### DIFF
--- a/Scripts/Runtime/Entities/MemsetBufferJob.cs
+++ b/Scripts/Runtime/Entities/MemsetBufferJob.cs
@@ -1,0 +1,34 @@
+using Unity.Entities;
+using Unity.Jobs;
+using Unity.Burst;
+using Unity.Collections;
+
+namespace Anvil.Unity.DOTS.Entities
+{
+    /// <summary>
+    /// Sets all elements of a <see cref="DynamicBuffer{T}"/> to a given value.
+    /// </summary>
+    /// <typeparam name="T">The element type of the <see cref="DynamicBuffer{T}"/></typeparam>
+    /// <remarks>The <see cref="DynamicBuffer{T}"/> compliement to <see cref="MemsetNativeArray{T}"/>.</remarks>
+    [BurstCompile]
+    public struct MemsetBufferJob<T> : IJobParallelForBatch where T : struct, IBufferElementData
+    {
+        /// <summary>
+        /// The buffer to write to.
+        /// </summary>
+        [WriteOnly] public BufferFromSingleEntity<T> Source;
+        /// <summary>
+        /// The value to write to the buffer.
+        /// </summary>
+        [ReadOnly] public T Value;
+
+        public void Execute(int startIndex, int count)
+        {
+            NativeArray<T> buffer = Source.GetBuffer().AsNativeArray();
+            for (int i = startIndex; i < startIndex + count; i++)
+            {
+                buffer[i] = Value;
+            }
+        }
+    }
+}

--- a/Scripts/Runtime/Entities/MemsetBufferJob.cs.meta
+++ b/Scripts/Runtime/Entities/MemsetBufferJob.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b619ba88118a543c2bdd80765fed1b13
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Sets all elements of a `DynamicBuffer<T>` to a given value.
This is a compliment to Unity's built in `MemsetNativeArray<T>`

### What is the current behaviour?
New feature

### What is the new behaviour?
New Feature

### What issues does this resolve?
None

### What PRs does this depend on?
 - None

### Does this introduce a breaking change?
 - [ ] Yes <!-- If so, what are the migration considerations? -->
 - [x] No
