### PR TITLE
License - Add extension to file

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2022 Decline Cookies
+Copyright (c) 2022 Decline Cookies Corp.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
License was out of date. Now attributed to Decline Cookies in 2022.
License was also missing `.txt` extension which prevents GitHub from parsing it.

### What is the current behaviour?
Outdated license

### What is the new behaviour?
Legal compliance?

### What issues does this resolve?
Outdated license

### What PRs does this depend on?
 - None

### Does this introduce a breaking change?
 - [ ] Yes <!-- If so, what are the migration considerations? -->
 - [x] No