### PR TITLE
Feature MemsetBufferJob<T> Batch Calculator

### DIFF
--- a/Scripts/Runtime/Entities/AbstractAnvilSystemBase.cs
+++ b/Scripts/Runtime/Entities/AbstractAnvilSystemBase.cs
@@ -105,6 +105,7 @@ namespace Anvil.Unity.DOTS.Entities
         /// <typeparam name="T">The element type of the <see cref="DynamicBuffer{T}" />.</typeparam>
         /// <param name="dependsOn">The <see cref="JobHandle"/> to wait for.</param>
         /// <param name="outputBuffer">The <see cref="NativeArray{T}" /> to copy to.</param>
+        /// <returns>A <see cref="JobHandle"/> that represents when the buffer copy is complete.</returns>
         /// <remarks>Actual copy is performed by <see cref="CopyFromSingletonBuffer{T}" /></remarks>
         protected JobHandle CopyFromSingletonBufferAsync<T>(in JobHandle dependsOn, in NativeArray<T> outputBuffer) where T : struct, IBufferElementData
         {
@@ -137,6 +138,7 @@ namespace Anvil.Unity.DOTS.Entities
         /// <typeparam name="T">The element type of the <see cref="DynamicBuffer{T}" />.</typeparam>
         /// <param name="dependsOn">The <see cref="JobHandle"/> to wait for.</param>
         /// <param name="inputBuffer">The <see cref="NativeArray{T}" /> to copy from.</param>
+        /// <returns>A <see cref="JobHandle"/> that represents when the buffer copy is complete.</returns>
         /// <remarks>Actual copy is performed by <see cref="CopyToSingletonBuffer{T}" /></remarks>
         protected JobHandle CopyToSingletonBufferAsync<T>(in JobHandle dependsOn, in NativeArray<T> inputBuffer) where T : struct, IBufferElementData
         {

--- a/Scripts/Runtime/Entities/MemsetBufferJob.cs
+++ b/Scripts/Runtime/Entities/MemsetBufferJob.cs
@@ -29,7 +29,7 @@ namespace Anvil.Unity.DOTS.Entities
         /// <summary>
         /// Calculate an ideal batch size per thread.
         /// Aim to spread work across as many threads as possible while satisfying (in order of importance):
-        ///  - Aligning batch size to cache line size
+        ///  - Aligning batch size to chunk size
         ///  - Keeping batch sizes large enough to overcome the cost of splitting.
         ///  - Minimizing the number of batches (there's overhead in each batch run)
         /// </summary>

--- a/Scripts/Runtime/Entities/MemsetBufferJob.cs
+++ b/Scripts/Runtime/Entities/MemsetBufferJob.cs
@@ -22,9 +22,9 @@ namespace Anvil.Unity.DOTS.Entities
         //
         // Ex: We shouldn't split a set of 10 across 5 threads.
         //
-        // Re CacheSize: If generalizing to a 64kb cache size is good enough for Unity it's good 
-        // enough for us.
-        private static readonly float MIN_BATCH_SIZE_PER_THREAD = math.max(1f, JobsUtility.CacheLineSize * 1024 / (float)UnsafeUtility.SizeOf<T>());
+        // Re CacheSize: If generalizing to a 16kb cache size is good enough for Unity it's good 
+        // enough for us. If this isn't good enough #12 will allow us to get the actual cache size.
+        private static readonly float MIN_BATCH_SIZE_PER_THREAD = math.max(1f, 16 * 1024 / (float)UnsafeUtility.SizeOf<T>());
 
         /// <summary>
         /// Calculate an ideal batch size per thread.

--- a/Scripts/Runtime/Entities/MemsetBufferJob.cs
+++ b/Scripts/Runtime/Entities/MemsetBufferJob.cs
@@ -2,6 +2,8 @@ using Unity.Entities;
 using Unity.Jobs;
 using Unity.Burst;
 using Unity.Collections;
+using Unity.Jobs.LowLevel.Unsafe;
+using Unity.Mathematics;
 
 namespace Anvil.Unity.DOTS.Entities
 {
@@ -13,6 +15,22 @@ namespace Anvil.Unity.DOTS.Entities
     [BurstCompile]
     public struct MemsetBufferJob<T> : IJobParallelForBatch where T : struct, IBufferElementData
     {
+        //TODO: Measuere an ideal value.
+        private const float MIN_BATCH_SIZE_PER_THREAD = 50_000;
+
+        /// <summary>
+        /// Calculate an ideal batch size per thread.
+        /// Aim to spread work across as many threads as possible unless the batch is too small to 
+        /// overcome the prformance cost of a batch's initialization.
+        /// </summary>
+        /// <param name="length"></param>
+        /// <returns></returns>
+        public static int CalculateOptimalBatchSize(int length)
+        {
+            float optimalWorkerCount = math.clamp(length / MIN_BATCH_SIZE_PER_THREAD, 1, JobsUtility.JobWorkerCount);
+            return (int)math.ceil(length / optimalWorkerCount);
+        }
+
         /// <summary>
         /// The buffer to write to.
         /// </summary>
@@ -30,6 +48,18 @@ namespace Anvil.Unity.DOTS.Entities
             {
                 buffer[i] = Value;
             }
+        }
+
+        /// <summary>
+        /// Schedule the job with an optimimal batch size
+        /// </summary>
+        /// <param name="arrayLength">The length of the buffer</param>
+        /// <param name="dependsOn">The <see cref="JobHandle"/> to wait for.</param>
+        /// <returns>A <see cref="JobHandle"/> that represents when the work is complete.</returns>
+        public JobHandle ScheduleWithOptimalBatchSize(int arrayLength, JobHandle dependsOn = default)
+        {
+            int batchSize = CalculateOptimalBatchSize(arrayLength);
+            return this.ScheduleBatch(arrayLength, batchSize, dependsOn);
         }
     }
 }

--- a/Scripts/Runtime/Jobs/ValueAccessController/AbstractValueAccessController.cs
+++ b/Scripts/Runtime/Jobs/ValueAccessController/AbstractValueAccessController.cs
@@ -54,13 +54,13 @@ namespace Anvil.Unity.DOTS.Jobs
         }
 
         /// <summary>
-        /// Get the value of the <see cref="AbstractValueAccessController{T}"/> returning a JobHandle to wait on before consuming.
+        /// Get the value of the <see cref="AbstractValueAccessController{T}"/> returning a <see cref="JobHandle"/> to wait on before consuming.
         /// After the work with the value is scheduled <see cref="ReleaseAsync"/> must be called before any other calls to 
         /// <see cref="AcquireAsync" /> or <see cref="Acquire" /> are made for this value.
         /// </summary>
         /// <param name="isReadOnly">The access level rquired for the value. Accessing readonly will tend to require less waiting.</param>
         /// <param name="value">The value of the <see cref="AbstractValueAccessController{T}"/>.</param>
-        /// <returns>A JobHandle to wait on before consuming the value.</returns>
+        /// <returns>A <see cref="JobHandle"/> to wait on before consuming the value.</returns>
         public JobHandle AcquireAsync(bool isReadOnly, out T value)
         {
             Debug.Assert(!IsDisposed);
@@ -75,7 +75,7 @@ namespace Anvil.Unity.DOTS.Jobs
         /// <summary>
         /// Schedule the release of the value's ownership after an asynchronous operation.
         /// </summary>
-        /// <param name="releaseAccessDependency">The JobHandle that describes when work with the value is complete.</param>
+        /// <param name="releaseAccessDependency">The <see cref="JobHandle"/> that describes when work with the value is complete.</param>
         public void ReleaseAsync(JobHandle releaseAccessDependency)
         {
             Debug.Assert(!IsDisposed);


### PR DESCRIPTION
Add a method to calculate a best effort optimal batch size for `MemsetBufferJob<T>` that aims for minimum real world processing time (not minimum total computation time). If minimum total computation time is desired single thread is almost always the only solution.

The intention of this method is to provide a good default batch size for the job that is pretty good and avoids over provisioning worker threads for small data sets.
**Note:** Frequently a better batch size can be tune for a specific execution/application context but this is better left to optimization passes later in development. If required.

#### Tag Along
 - Documentation omissions and spelling.

### What is the current behaviour?
Developer is left to define their own batch size.

### What is the new behaviour?
Developer can call `MemsetBufferJob<T>.ScheduleWithOptimalBatchSize()` to have the batch size calculated for them. Alternatively, developers can call `MemsetBufferJob<T>.CalculateOptimalBatchSize(dataSize)` to get the ideal batch size themselves.

### What issues does this resolve?
Having to think about defining a reasonable batch size for the workload.

### What PRs does this depend on?
 - None

### Does this introduce a breaking change?
 - [ ] Yes
 - [x] No - but switching to the calculated batch size is recommended unless there's a reason for the current batch size.
