### PR TITLE
Add missing License.txt.meta

### DIFF
--- a/LICENSE.txt.meta
+++ b/LICENSE.txt.meta
@@ -1,6 +1,6 @@
 fileFormatVersion: 2
-guid: bac57ee7232a648859ca92c8948ed100
-DefaultImporter:
+guid: 2de25eeea15864335889246dcffde74f
+TextScriptImporter:
   externalObjects: {}
   userData: 
   assetBundleName: 


### PR DESCRIPTION
These rules are annoying...I forgot the .meta file.

### What is the current behaviour?

### What is the new behaviour?

### What issues does this resolve?
<!-- None is a perfectly valid answer -->

### What PRs does this depend on?
<!-- List PRs in other repos that need to be merged before this one -->
 - None

### Does this introduce a breaking change?
 - [ ] Yes <!-- If so, what are the migration considerations? -->
 - [x] No
