### PR TITLE
Busy Work Jobs and DebugUtil

### DIFF
--- a/Scripts/Runtime/Jobs/Debug.meta
+++ b/Scripts/Runtime/Jobs/Debug.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 26efde42699a44b985b9937839882b49
+timeCreated: 1650380743

--- a/Scripts/Runtime/Jobs/Debug/BusyWorkJob.cs
+++ b/Scripts/Runtime/Jobs/Debug/BusyWorkJob.cs
@@ -10,7 +10,7 @@ namespace Anvil.Unity.DOTS.Jobs
     /// <seealso cref="DebugUtil.FindPrimeNumber"/>
     /// </summary>
     [BurstCompile]
-    public struct BusyWorkJob : IJob
+    public struct BusyWorkJob : IJobFor
     {
         private readonly int m_NthPrimeNumberToFind;
 
@@ -27,41 +27,9 @@ namespace Anvil.Unity.DOTS.Jobs
             m_NthPrimeNumberToFind = nthPrimeNumberToFind;
         }
 
-        public void Execute()
+        public void Execute(int index)
         {
             DebugUtil.FindPrimeNumber(m_NthPrimeNumberToFind);
-        }
-    }
-
-    /// <summary>
-    /// An <see cref="IJobParallelForBatch"/> job that will take up CPU time by calculating the Nth prime number passed
-    /// in. Useful for artificially increasing the time a job takes to help with debugging scheduling or profiling.
-    /// <seealso cref="DebugUtil.FindPrimeNumber"/>
-    /// </summary>
-    [BurstCompile]
-    public struct BusyWorkBatchJob : IJobParallelForBatch
-    {
-        private readonly int m_NthPrimeNumberToFind;
-
-        /// <summary>
-        /// Creates a <see cref="BusyWorkBatchJob"/>
-        /// </summary>
-        /// <param name="nthPrimeNumberToFind">The Nth prime number to find.
-        /// Ex.
-        /// 1 = the first prime number or 2,
-        /// 100 = the 100th prime number or 541
-        /// </param>
-        public BusyWorkBatchJob(int nthPrimeNumberToFind)
-        {
-            m_NthPrimeNumberToFind = nthPrimeNumberToFind;
-        }
-
-        public void Execute(int startIndex, int count)
-        {
-            for (int i = 0; i < count; ++i)
-            {
-                DebugUtil.FindPrimeNumber(m_NthPrimeNumberToFind);
-            }
         }
     }
 }

--- a/Scripts/Runtime/Jobs/Debug/BusyWorkJob.cs
+++ b/Scripts/Runtime/Jobs/Debug/BusyWorkJob.cs
@@ -1,0 +1,67 @@
+using Anvil.Unity.DOTS.Util;
+using Unity.Burst;
+using Unity.Jobs;
+
+namespace Anvil.Unity.DOTS.Jobs
+{
+    /// <summary>
+    /// An <see cref="IJob"/> job that will take up CPU time by calculating the Nth prime number passed in.
+    /// Useful for artificially increasing the time a job takes to help with debugging scheduling or profiling.
+    /// <seealso cref="DebugUtil.FindPrimeNumber"/>
+    /// </summary>
+    [BurstCompile]
+    public struct BusyWorkJob : IJob
+    {
+        private readonly int m_NthPrimeNumberToFind;
+
+        /// <summary>
+        /// Creates a <see cref="BusyWorkJob"/>
+        /// </summary>
+        /// <param name="nthPrimeNumberToFind">The Nth prime number to find.
+        /// Ex.
+        /// 1 = the first prime number or 2,
+        /// 100 = the 100th prime number or 541
+        /// </param>
+        public BusyWorkJob(int nthPrimeNumberToFind)
+        {
+            m_NthPrimeNumberToFind = nthPrimeNumberToFind;
+        }
+
+        public void Execute()
+        {
+            DebugUtil.FindPrimeNumber(m_NthPrimeNumberToFind);
+        }
+    }
+
+    /// <summary>
+    /// An <see cref="IJobParallelForBatch"/> job that will take up CPU time by calculating the Nth prime number passed
+    /// in. Useful for artificially increasing the time a job takes to help with debugging scheduling or profiling.
+    /// <seealso cref="DebugUtil.FindPrimeNumber"/>
+    /// </summary>
+    [BurstCompile]
+    public struct BusyWorkBatchJob : IJobParallelForBatch
+    {
+        private readonly int m_NthPrimeNumberToFind;
+
+        /// <summary>
+        /// Creates a <see cref="BusyWorkBatchJob"/>
+        /// </summary>
+        /// <param name="nthPrimeNumberToFind">The Nth prime number to find.
+        /// Ex.
+        /// 1 = the first prime number or 2,
+        /// 100 = the 100th prime number or 541
+        /// </param>
+        public BusyWorkBatchJob(int nthPrimeNumberToFind)
+        {
+            m_NthPrimeNumberToFind = nthPrimeNumberToFind;
+        }
+
+        public void Execute(int startIndex, int count)
+        {
+            for (int i = 0; i < count; ++i)
+            {
+                DebugUtil.FindPrimeNumber(m_NthPrimeNumberToFind);
+            }
+        }
+    }
+}

--- a/Scripts/Runtime/Jobs/Debug/BusyWorkJob.cs.meta
+++ b/Scripts/Runtime/Jobs/Debug/BusyWorkJob.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: f4c4b366ca874ea49c8332823d156b99
+timeCreated: 1650380756

--- a/Scripts/Runtime/Util/Debug.meta
+++ b/Scripts/Runtime/Util/Debug.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 613e507e3ab34b519e174507402daa17
+timeCreated: 1650380821

--- a/Scripts/Runtime/Util/Debug/DebugUtil.cs
+++ b/Scripts/Runtime/Util/Debug/DebugUtil.cs
@@ -1,0 +1,47 @@
+namespace Anvil.Unity.DOTS.Util
+{
+    /// <summary>
+    /// Useful helpers to aid in debugging
+    /// </summary>
+    public static class DebugUtil
+    {
+        /// <summary>
+        /// Calculates the Nth prime number that is passed in
+        /// </summary>
+        /// <param name="nthPrimeNumberToFind">The Nth prime number to find.
+        /// Ex.
+        /// 1 = the first prime number or 2,
+        /// 100 = the 100th prime number or 541
+        /// </param>
+        /// <returns>The Nth prime number</returns>
+        public static long FindPrimeNumber(int nthPrimeNumberToFind)
+        {
+            int count = 0;
+            long a = 2;
+            while (count < nthPrimeNumberToFind)
+            {
+                long b = 2;
+                int prime = 1;
+                while (b * b <= a)
+                {
+                    if (a % b == 0)
+                    {
+                        prime = 0;
+                        break;
+                    }
+
+                    b++;
+                }
+
+                if (prime > 0)
+                {
+                    count++;
+                }
+
+                a++;
+            }
+
+            return (--a);
+        }
+    }
+}

--- a/Scripts/Runtime/Util/Debug/DebugUtil.cs.meta
+++ b/Scripts/Runtime/Util/Debug/DebugUtil.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 974c95b07f134461aace3b0b8f47c996
+timeCreated: 1650380852


### PR DESCRIPTION
Added two jobs that perform busy work plus a static function in a `DebugUtil` class to access the busy work function anywhere. 

This is useful to create work for the CPU so that you can better understand scheduling problems with jobs or just general profiling.

### What is the current behaviour?

Currently, trying to add meaningless busy work gets optimized out by the compiler.

### What is the new behaviour?

Easy, clean way to make the CPU cores work harder.

### What issues does this resolve?
 - None

### What PRs does this depend on?
 - None

### Does this introduce a breaking change?
 - [ ] Yes 
 - [ x ] No
