### PR TITLE
Parallel Collection Util

### DIFF
--- a/Scripts/Runtime/Collections/UnsafeTypedStream.cs
+++ b/Scripts/Runtime/Collections/UnsafeTypedStream.cs
@@ -1,3 +1,4 @@
+using Anvil.Unity.DOTS.Util;
 using System.Runtime.InteropServices;
 using Unity.Assertions;
 using Unity.Burst;
@@ -129,7 +130,7 @@ namespace Anvil.Unity.DOTS.Collections
         /// <see cref="JobsUtility.JobWorkerMaximumCount"/> + 1
         /// </summary>
         /// <param name="allocator">The <see cref="Allocator" /> to use when allocating memory.</param>
-        public UnsafeTypedStream(Allocator allocator) : this(math.max(CHUNK_SIZE / UnsafeUtility.SizeOf<T>(), 1), allocator, JobsUtility.JobWorkerMaximumCount + 1)
+        public UnsafeTypedStream(Allocator allocator) : this(math.max(CHUNK_SIZE / UnsafeUtility.SizeOf<T>(), 1), allocator, ParallelCollectionUtil.CollectionSizeForMaxThreads())
         {
         }
 
@@ -269,26 +270,11 @@ namespace Anvil.Unity.DOTS.Collections
         }
 
         /// <summary>
-        /// Returns a lightweight <see cref="LaneWriter"/> instance.
-        /// </summary>
-        /// <param name="threadIndex">The lane index to lock the lane writer into.
-        /// Starts at 1 and goes up to AND including <see cref="LaneCount"/></param>
-        /// <remarks>Unity returns thread indexes starting at 1 and you often want to use the thread index
-        /// as the lane to read/write. However most things in programming are 0 indexed so this helper
-        /// function handles allowing you to use thread indexes while keeping the internals consistent with
-        /// 0 indexing.</remarks>
-        /// <returns>A <see cref="LaneWriter" /> instance.</returns>
-        public LaneWriter AsLaneWriterFromNativeThreadIndex(int threadIndex)
-        {
-            return AsLaneWriter(threadIndex - 1);
-        }
-
-        /// <summary>
         /// Returns a lightweight <see cref="LaneWriter" /> instance
         /// </summary>
         /// <param name="laneIndex">The lane index to lock the lane writer into.
         /// Starts at 0 and goes up to but NOT including <see cref="LaneCount"/>
-        /// See <see cref="AsLaneWriterFromNativeThreadIndex"/> if lanes are based on different threads.
+        /// See <see cref="ParallelCollectionUtil.CollectionIndexForThread"/> if lanes are based on different threads.
         /// </param>
         /// <returns>A <see cref="LaneWriter" /> instance.</returns>
         public LaneWriter AsLaneWriter(int laneIndex)
@@ -313,28 +299,13 @@ namespace Anvil.Unity.DOTS.Collections
 #endif
             return new Reader(ref this);
         }
-
-        /// <summary>
-        /// Returns a lightweight <see cref="LaneReader"/> instance.
-        /// </summary>
-        /// <param name="threadIndex">The lane index to lock the lane reader into.
-        /// Starts at 1 and goes up to AND including <see cref="LaneCount"/></param>
-        /// <remarks>Unity returns thread indexes starting at 1 and you often want to use the thread index
-        /// as the lane to read/write. However most things in programming are 0 indexed so this helper
-        /// function handles allowing you to use thread indexes while keeping the internals consistent with
-        /// 0 indexing.</remarks>
-        /// <returns>A <see cref="LaneReader" /> instance.</returns>
-        public LaneReader AsLaneReaderFromNativeThreadIndex(int threadIndex)
-        {
-            return AsLaneReader(threadIndex - 1);
-        }
-
+        
         /// <summary>
         /// Returns a lightweight <see cref="LaneReader" /> instance
         /// </summary>
         /// <param name="laneIndex">The lane index to lock the lane reader into.
         /// Starts at 0 and goes up to but NOT including <see cref="LaneCount"/>
-        /// See <see cref="AsLaneReaderFromNativeThreadIndex"/> if lanes are based on different threads.</param>
+        /// See <see cref="ParallelCollectionUtil.CollectionIndexForThread"/> if lanes are based on different threads.</param>
         /// <returns>A <see cref="LaneWriter" /> instance.</returns>
         public LaneReader AsLaneReader(int laneIndex)
         {
@@ -402,26 +373,11 @@ namespace Anvil.Unity.DOTS.Collections
             }
 
             /// <summary>
-            /// Returns a lightweight <see cref="LaneWriter"/> instance.
-            /// </summary>
-            /// <param name="threadIndex">The lane index to lock the lane writer into.
-            /// Starts at 1 and goes up to AND including <see cref="LaneCount"/></param>
-            /// <remarks>Unity returns thread indexes starting at 1 and you often want to use the thread index
-            /// as the lane to read/write. However most things in programming are 0 indexed so this helper
-            /// function handles allowing you to use thread indexes while keeping the internals consistent with
-            /// 0 indexing.</remarks>
-            /// <returns>A <see cref="LaneWriter" /> instance.</returns>
-            public LaneWriter AsLaneWriterFromNativeThreadIndex(int threadIndex)
-            {
-                return AsLaneWriter(threadIndex - 1);
-            }
-
-            /// <summary>
             /// Returns a lightweight <see cref="LaneWriter" /> instance
             /// </summary>
             /// <param name="laneIndex">The lane index to lock the lane writer into.
             /// Starts at 0 and goes up to but NOT including <see cref="LaneCount"/>
-            /// See <see cref="AsLaneWriterFromNativeThreadIndex"/> if lanes are based on different threads.
+            /// See <see cref="ParallelCollectionUtil.CollectionIndexForThread"/> if lanes are based on different threads.
             /// </param>
             /// <returns>A <see cref="LaneWriter" /> instance.</returns>
             public LaneWriter AsLaneWriter(int laneIndex)
@@ -523,26 +479,11 @@ namespace Anvil.Unity.DOTS.Collections
             }
 
             /// <summary>
-            /// Returns a lightweight <see cref="LaneReader"/> instance.
-            /// </summary>
-            /// <param name="threadIndex">The lane index to lock the lane reader into.
-            /// Starts at 1 and goes up to AND including <see cref="LaneCount"/></param>
-            /// <remarks>Unity returns thread indexes starting at 1 and you often want to use the thread index
-            /// as the lane to read/write. However most things in programming are 0 indexed so this helper
-            /// function handles allowing you to use thread indexes while keeping the internals consistent with
-            /// 0 indexing.</remarks>
-            /// <returns>A <see cref="LaneReader" /> instance.</returns>
-            public LaneReader AsLaneReaderFromNativeThreadIndex(int threadIndex)
-            {
-                return AsLaneReader(threadIndex - 1);
-            }
-
-            /// <summary>
             /// Returns a lightweight <see cref="LaneReader" /> instance
             /// </summary>
             /// <param name="laneIndex">The lane index to lock the lane reader into.
             /// Starts at 0 and goes up to but NOT including <see cref="LaneCount"/>
-            /// See <see cref="AsLaneReaderFromNativeThreadIndex"/> if lanes are based on different threads.</param>
+            /// See <see cref="ParallelCollectionUtil.CollectionIndexForThread"/> if lanes are based on different threads.</param>
             /// <returns>A <see cref="LaneWriter" /> instance.</returns>
             public LaneReader AsLaneReader(int laneIndex)
             {

--- a/Scripts/Runtime/Collections/UnsafeTypedStream.cs
+++ b/Scripts/Runtime/Collections/UnsafeTypedStream.cs
@@ -130,7 +130,7 @@ namespace Anvil.Unity.DOTS.Collections
         /// <see cref="JobsUtility.JobWorkerMaximumCount"/> + 1
         /// </summary>
         /// <param name="allocator">The <see cref="Allocator" /> to use when allocating memory.</param>
-        public UnsafeTypedStream(Allocator allocator) : this(math.max(CHUNK_SIZE / UnsafeUtility.SizeOf<T>(), 1), allocator, ParallelCollectionUtil.CollectionSizeForMaxThreads())
+        public UnsafeTypedStream(Allocator allocator) : this(math.max(CHUNK_SIZE / UnsafeUtility.SizeOf<T>(), 1), allocator, ParallelCollectionUtil.CollectionSizeForMaxThreads)
         {
         }
 

--- a/Scripts/Runtime/Util/Jobs.meta
+++ b/Scripts/Runtime/Util/Jobs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 1ad8f874d754494eb0cbc9a6b8416794
+timeCreated: 1650640220

--- a/Scripts/Runtime/Util/Jobs/ParallelCollectionUtil.cs
+++ b/Scripts/Runtime/Util/Jobs/ParallelCollectionUtil.cs
@@ -119,13 +119,13 @@ namespace Anvil.Unity.DOTS.Util
 #if ENABLE_UNITY_COLLECTIONS_CHECKS
     internal static class ThreadHelper
     {
+        private static ConcurrentBag<int> s_ThreadIndicesSeen = new ConcurrentBag<int>();
+        
         [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.SubsystemRegistration)]
         private static void Init()
         {
             s_ThreadIndicesSeen = new ConcurrentBag<int>();
         }
-
-        private static ConcurrentBag<int> s_ThreadIndicesSeen = new ConcurrentBag<int>();
 
         [BurstDiscard]
         public static void DetectMultipleXThreads(int nativeThreadIndex, int maxSize)

--- a/Scripts/Runtime/Util/Jobs/ParallelCollectionUtil.cs
+++ b/Scripts/Runtime/Util/Jobs/ParallelCollectionUtil.cs
@@ -32,6 +32,7 @@ namespace Anvil.Unity.DOTS.Util
         /// <seealso cref="https://docs.unity3d.com/Packages/com.unity.burst@1.7/manual/docs/AdvancedUsages.html#shared-static"/>
         /// </remarks>
         private static readonly SharedStatic<int> JOB_WORKER_MAXIMUM_COUNT = SharedStatic<int>.GetOrCreate<InternalClassJobWorkerMaximumCount>();
+
         private class InternalClassJobWorkerMaximumCount
         {
         }
@@ -45,7 +46,7 @@ namespace Anvil.Unity.DOTS.Util
             Debug.Assert(JOB_WORKER_MAXIMUM_COUNT.Data > 0);
         }
 
-    
+
         /// <summary>
         /// Returns an ideal size for the number of buckets a collection should have
         /// to account for all possible threads that could write to it at once.
@@ -105,21 +106,27 @@ namespace Anvil.Unity.DOTS.Util
             Debug.Assert(nativeThreadIndex > 0 && nativeThreadIndex <= JobsUtility.MaxJobThreadCount);
             return math.min(nativeThreadIndex - 1, JOB_WORKER_MAXIMUM_COUNT.Data);
         }
-
-
+        
         [Conditional("ENABLE_UNITY_COLLECTIONS_CHECKS")]
         [BurstDiscard]
         private static void DetectMultipleXThreads(int nativeThreadIndex)
         {
             ThreadHelper.DetectMultipleXThreads(nativeThreadIndex, CollectionSizeForMaxThreads);
         }
+
     }
 
-    
+#if ENABLE_UNITY_COLLECTIONS_CHECKS
     internal static class ThreadHelper
     {
-        private static readonly ConcurrentBag<int> s_ThreadIndicesSeen = new ConcurrentBag<int>();
-        
+        [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.SubsystemRegistration)]
+        private static void Init()
+        {
+            s_ThreadIndicesSeen = new ConcurrentBag<int>();
+        }
+
+        private static ConcurrentBag<int> s_ThreadIndicesSeen = new ConcurrentBag<int>();
+
         [BurstDiscard]
         public static void DetectMultipleXThreads(int nativeThreadIndex, int maxSize)
         {
@@ -134,4 +141,5 @@ namespace Anvil.Unity.DOTS.Util
             return output;
         }
     }
+#endif
 }

--- a/Scripts/Runtime/Util/Jobs/ParallelCollectionUtil.cs
+++ b/Scripts/Runtime/Util/Jobs/ParallelCollectionUtil.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Reflection;
+using Unity.Jobs.LowLevel.Unsafe;
+using UnityEngine;
+
+namespace Anvil.Unity.DOTS.Util
+{
+    public static class ParallelCollectionUtil
+    {
+        private static readonly int JOB_WORKER_MAXIMUM_COUNT = -1;
+
+        [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.SubsystemRegistration)]
+        private static void Init()
+        {
+            Type type = typeof(ParallelCollectionUtil);
+            FieldInfo field = type.GetField(nameof(JOB_WORKER_MAXIMUM_COUNT), BindingFlags.Static | BindingFlags.NonPublic); 
+            field.SetValue(null, JobsUtility.JobWorkerMaximumCount);
+        }
+
+        public static int CollectionIndexForThread(int nativeThreadIndex)
+        {
+            // JobsUtility.JobWorkerMaximumCount = 15
+            // index  0, 1, 2, 3, 4, 5, 6, 7, 8, 9,  10, 11, 12, 13, 14, 15
+            // thread 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 17
+            return (nativeThreadIndex <= JOB_WORKER_MAXIMUM_COUNT)
+                ? nativeThreadIndex - 1
+                : JOB_WORKER_MAXIMUM_COUNT;
+        }
+
+        public static int CollectionSizeForMaxThreads()
+        {
+            return JOB_WORKER_MAXIMUM_COUNT + 1;
+        }
+    }
+}

--- a/Scripts/Runtime/Util/Jobs/ParallelCollectionUtil.cs
+++ b/Scripts/Runtime/Util/Jobs/ParallelCollectionUtil.cs
@@ -5,18 +5,91 @@ using UnityEngine;
 
 namespace Anvil.Unity.DOTS.Util
 {
+    /// <summary>
+    /// Utility methods for working with Native Collections in a parallel manner.
+    /// </summary>
     public static class ParallelCollectionUtil
     {
+        /// <remarks>
+        /// This is static readonly because Burst will only read from a static variable if it is readonly.
+        /// We are unable to set it directly to <see cref="JobsUtility.JobWorkerMaximumCount"/> because that function
+        /// is an external function and external functions are not allowed to be called from a static constructor which
+        /// is where static readonly variables get assigned.
+        /// We are also unable to lazy instantiate or call <see cref="JobsUtility.JobWorkerMaximumCount"/> within the
+        /// functions in this class that use it because an external function can only be called from the main thread
+        /// and these functions are intended for use inside bursted jobs that run on many different worker threads.
+        ///
+        /// To avoid this, we have a <see cref="RuntimeInitializeOnLoadMethodAttribute"/> on the
+        /// <see cref="ParallelCollectionUtil.Init"/> method which uses reflection to assign the static readonly
+        /// variable.
+        ///
+        /// While a bit hacky, it is ensured to run before any potential jobs execute. The external call is allowed
+        /// and we get the correct value and inject it into the static readonly field. Subsequent bursted jobs are then
+        /// allowed to access it.
+        /// </remarks>
         private static readonly int JOB_WORKER_MAXIMUM_COUNT = -1;
 
         [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.SubsystemRegistration)]
         private static void Init()
         {
             Type type = typeof(ParallelCollectionUtil);
-            FieldInfo field = type.GetField(nameof(JOB_WORKER_MAXIMUM_COUNT), BindingFlags.Static | BindingFlags.NonPublic); 
+            FieldInfo field = type.GetField(nameof(JOB_WORKER_MAXIMUM_COUNT), BindingFlags.Static | BindingFlags.NonPublic);
             field.SetValue(null, JobsUtility.JobWorkerMaximumCount);
         }
 
+        /// <summary>
+        /// Returns an ideal size for the number of buckets a collection should have
+        /// to account for all possible threads that could write to it at once.
+        /// </summary>
+        /// <remarks>
+        /// There is a lot of different terminology for the "buckets".
+        /// <see cref="NativeStream"/> has foreachCount
+        /// <see cref="UnsafeTypedStream"/> has lanes
+        /// etc
+        /// It's the number of separate "buckets" that can be written to in parallel.
+        /// </remarks>
+        /// <returns>The number of buckets a collection should have.</returns>
+        public static int CollectionSizeForMaxThreads()
+        {
+            return JOB_WORKER_MAXIMUM_COUNT + 1;
+        }
+
+        /// <summary>
+        /// Returns the correct index for the collection based on the <paramref name="nativeThreadIndex"/> passed in.
+        /// </summary>
+        /// <remarks>
+        /// This function assumes that the collection being used was sized appropriately via
+        /// <see cref="ParallelCollectionUtil.CollectionSizeForMaxThreads"/>. Larger sized collections will still work
+        /// but the intended usage is to create a small tightly packed collection sized for the specific hardware the
+        /// program is running on. Smaller sized collections will error sporadically as the scheduler assigns jobs to
+        /// out of range thread indexes.
+        ///
+        /// This function also assumes that you are never running your job on the main thread via
+        /// <see cref="IJobExtensions.Run"/>. In that case the thread index will be 0 and this function will
+        /// return -1 which will cause an error.
+        ///
+        /// When scheduling your job, Unity will place your job on one of the available worker threads in which case
+        /// the native thread index you receive will be from 1 to <see cref="JobsUtility.JobWorkerMaximumCount"/>.
+        /// There are two special cases.
+        /// 1. The scheduler may place your job on the main thread. In this case the native thread index will be
+        /// <see cref="JobsUtility.JobWorkerMaximumCount"/> + 2.
+        /// 2. The scheduler may place your job on a profiler thread in the editor. In this case the native thread index
+        /// will also be <see cref="JobsUtility.JobWorkerMaximumCount"/> + 2.
+        /// It is unknown why this is. 
+        ///
+        /// Our goal is to have a tightly packed collection so in the example of an 8 core machine with
+        /// <see cref="JobsUtility.JobWorkerMaximumCount"/> equal to 15, we would have the following mapping.
+        ///
+        /// thread 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 17 
+        /// index  0, 1, 2, 3, 4, 5, 6, 7, 8, 9,  10, 11, 12, 13, 14, 15
+        ///
+        /// We have a tightly packed collection with index 0 through 15 for a total of 16 buckets.
+        /// Thread indexes map directly without having to remember the special rules.
+        /// </remarks>
+        /// <param name="nativeThreadIndex">
+        /// The native thread index to figure out the collection index from. Must be greater than 0.
+        /// </param>
+        /// <returns>The collection index to use</returns>
         public static int CollectionIndexForThread(int nativeThreadIndex)
         {
             // JobsUtility.JobWorkerMaximumCount = 15
@@ -25,11 +98,6 @@ namespace Anvil.Unity.DOTS.Util
             return (nativeThreadIndex <= JOB_WORKER_MAXIMUM_COUNT)
                 ? nativeThreadIndex - 1
                 : JOB_WORKER_MAXIMUM_COUNT;
-        }
-
-        public static int CollectionSizeForMaxThreads()
-        {
-            return JOB_WORKER_MAXIMUM_COUNT + 1;
         }
     }
 }

--- a/Scripts/Runtime/Util/Jobs/ParallelCollectionUtil.cs.meta
+++ b/Scripts/Runtime/Util/Jobs/ParallelCollectionUtil.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: f2dae8270a3b469eacfd667400feb7a5
+timeCreated: 1650640239


### PR DESCRIPTION
A nice helper class for sizing collections for writing in parallel and being able to nicely map `NativeThreadIndex` to the index in the collection. 

Currently the defacto way to do this is to size your collection to have 128 buckets and you mostly just fill up 1 to X where X is the number of threads you have. There's a lot of waste there that isn't necessary both from memory usage of the collection and iteration time going through all the buckets.

### What is the current behaviour?

This didn't exist before so you had the remember the rules and manually size or adjust your indices.

### What is the new behaviour?

You can just use this helper.

### What issues does this resolve?
- None

### What PRs does this depend on?
 - None

### Does this introduce a breaking change?
 - [ ] Yes
 - [x] No

### Tag Along

Updated the `UnsafeTypedStream` to get rid of `FromNativeThreadIndex` functions as they are no longer needed. Cleaner and less maintenance to just use these new utility methods instead.
