### PR TITLE
Add `WorldUtils`

### DIFF
--- a/Scripts/Runtime/Entities/Util.meta
+++ b/Scripts/Runtime/Entities/Util.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 0bc46c4f7831d42d4b5368fa4a8668b7
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/Runtime/Entities/Util/WorldUtil.cs
+++ b/Scripts/Runtime/Entities/Util/WorldUtil.cs
@@ -15,7 +15,7 @@ namespace Anvil.Unity.DOTS.Entities
     /// </summary>
     /// <remarks>Kept outside <see cref="WorldUtil"/> so their names read better in the editor.</remarks>
     [DisableAutoCreation]
-    internal class EndInitializationCommandBufferSystemGroup : ComponentSystemGroup { }
+    internal class EndInitializationCommandBufferSystemGroup_Anvil : ComponentSystemGroup { }
 
     /// <summary>
     /// A system group to house a <see cref="World"/>s <see cref="EndSimulationEntityCommandBufferSystem"/>.
@@ -23,13 +23,13 @@ namespace Anvil.Unity.DOTS.Entities
     /// </summary>
     /// <remarks>Kept outside <see cref="WorldUtil"/> so their names read better in the editor.</remarks>
     [DisableAutoCreation]
-    internal class EndSimulationCommandBufferSystemGroup : ComponentSystemGroup { }
+    internal class EndSimulationCommandBufferSystemGroup_Anvil : ComponentSystemGroup { }
 
     /// <summary>
     /// A <see cref="PlayerLoop"/> phase inserted immediately after <see cref="Update"/>.
     /// Add via <see cref="WorldUtil.AddCustomPhasesToCurrentPlayerLoop" />.
     /// </summary>
-    internal class PostUpdate
+    internal class PostUpdate_Anvil
     {
         /// <summary>
         /// Provides a <see cref="PlayerLoopSystem" /> instance to to identify this phase.
@@ -38,7 +38,7 @@ namespace Anvil.Unity.DOTS.Entities
         {
             get => new PlayerLoopSystem()
             {
-                type = typeof(PostUpdate)
+                type = typeof(PostUpdate_Anvil)
             };
         }
     }
@@ -47,7 +47,7 @@ namespace Anvil.Unity.DOTS.Entities
     /// A <see cref="PlayerLoop"/> phase inserted immediately after <see cref="Initialization"/>.
     /// Add via <see cref="WorldUtil.AddCustomPhasesToCurrentPlayerLoop" />.
     /// </summary>
-    internal class PostInitialization
+    internal class PostInitialization_Anvil
     {
         /// <summary>
         /// Provides a <see cref="PlayerLoopSystem" /> instance to to identify this phase.
@@ -56,7 +56,7 @@ namespace Anvil.Unity.DOTS.Entities
         {
             get => new PlayerLoopSystem()
             {
-                type = typeof(PostInitialization)
+                type = typeof(PostInitialization_Anvil)
             };
         }
     }
@@ -73,7 +73,7 @@ namespace Anvil.Unity.DOTS.Entities
 
         /// <summary>
         /// Add custom phases to the <see cref="PlayerLoop"/>.
-        /// <see cref="PostInitialization"/> and <see cref="PostUpdate"/>.
+        /// <see cref="PostInitialization_Anvil"/> and <see cref="PostUpdate_Anvil"/>.
         /// </summary>
         public static void AddCustomPhasesToCurrentPlayerLoop()
         {
@@ -88,13 +88,13 @@ namespace Anvil.Unity.DOTS.Entities
 
             int initializationPhaseIndex = topLevelPhases.FindIndex((phase) => phase.type == typeof(Initialization));
             Debug.Assert(initializationPhaseIndex != -1, $"{nameof(Initialization)} phase not found");
-            Debug.Assert(!topLevelPhases.Any((phase) => phase.type == typeof(PostInitialization)), $"{nameof(PostInitialization)} phase already added");
-            topLevelPhases.Insert(initializationPhaseIndex + 1, PostInitialization.PlayerLoopSystem);
+            Debug.Assert(!topLevelPhases.Any((phase) => phase.type == typeof(PostInitialization_Anvil)), $"{nameof(PostInitialization_Anvil)} phase already added");
+            topLevelPhases.Insert(initializationPhaseIndex + 1, PostInitialization_Anvil.PlayerLoopSystem);
 
             int updatePhaseIndex = topLevelPhases.FindIndex((phase) => phase.type == typeof(Update));
             Debug.Assert(updatePhaseIndex != -1, "Update phase not found");
-            Debug.Assert(!topLevelPhases.Any((phase) => phase.type == typeof(PostUpdate)), $"{nameof(PostUpdate)} phase already added");
-            topLevelPhases.Insert(updatePhaseIndex + 1, PostUpdate.PlayerLoopSystem);
+            Debug.Assert(!topLevelPhases.Any((phase) => phase.type == typeof(PostUpdate_Anvil)), $"{nameof(PostUpdate_Anvil)} phase already added");
+            topLevelPhases.Insert(updatePhaseIndex + 1, PostUpdate_Anvil.PlayerLoopSystem);
 
             playerLoop.subSystemList = topLevelPhases.ToArray();
             PlayerLoop.SetPlayerLoop(playerLoop);
@@ -110,7 +110,7 @@ namespace Anvil.Unity.DOTS.Entities
         /// A collection of value pairs where the first value is the PlayerLoop phase to place the system in and the second value is the 
         /// system to create.
         /// </param>
-        /// <returns></returns>
+        /// <returns>A collection of the system groups created.</returns>
         /// <remarks>
         /// Groups must not already exist in the world. This is a limitation of our ability to detect whether a system has already been 
         /// added to the palyer loop.
@@ -154,13 +154,13 @@ namespace Anvil.Unity.DOTS.Entities
         }
 
         private static readonly (Type PlayerLoopSystemType, Type SystemGroupType)[] s_MultiWorldTopLevelGroupTypes = new[]{
-            (typeof(PostInitialization), typeof(EndInitializationCommandBufferSystemGroup)),
-            (typeof(PostUpdate), typeof(EndSimulationCommandBufferSystemGroup)),
+            (typeof(PostInitialization_Anvil), typeof(EndInitializationCommandBufferSystemGroup_Anvil)),
+            (typeof(PostUpdate_Anvil), typeof(EndSimulationCommandBufferSystemGroup_Anvil)),
         };
         /// <summary>
         /// Optimizes a <see cref="World"/>'s <see cref="ComponentSystemGroup"/>s for multi-world applications.
         /// Groups end command buffers into their own <see cref="PlayerLoop"/> phase just after their default phase. 
-        /// (Ex: <see cref="Update"/> -> <see cref="PostUpdate"/>)
+        /// (Ex: <see cref="Update"/> -> <see cref="PostUpdate_Anvil"/>)
         /// This allows end command buffers for all worlds to be evaluated after all worlds have scheduled their work for the phase.
         /// The result is that other worlds can compute their jobified work while one world is executing its end command buffer on the main thread.
         /// </summary>
@@ -174,8 +174,8 @@ namespace Anvil.Unity.DOTS.Entities
             AddCustomPhasesToCurrentPlayerLoop();
             AddTopLevelGroupsToCurrentPlayerLoop(world, s_MultiWorldTopLevelGroupTypes);
 
-            MoveSystemFromToGroup<EndInitializationEntityCommandBufferSystem, InitializationSystemGroup, EndInitializationCommandBufferSystemGroup>(world);
-            MoveSystemFromToGroup<EndSimulationEntityCommandBufferSystem, SimulationSystemGroup, EndSimulationCommandBufferSystemGroup>(world);
+            MoveSystemFromToGroup<EndInitializationEntityCommandBufferSystem, InitializationSystemGroup, EndInitializationCommandBufferSystemGroup_Anvil>(world);
+            MoveSystemFromToGroup<EndSimulationEntityCommandBufferSystem, SimulationSystemGroup, EndSimulationCommandBufferSystemGroup_Anvil>(world);
 
             // Suppress the logging during sort so we don't see complaints about systems that position themselves based on
             // the systems that we're moving. So far, the configured above are at the end of the group and don't cause issues

--- a/Scripts/Runtime/Entities/Util/WorldUtil.cs
+++ b/Scripts/Runtime/Entities/Util/WorldUtil.cs
@@ -1,0 +1,230 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Anvil.CSharp.Logging;
+using Unity.Entities;
+using UnityEngine;
+using UnityEngine.LowLevel;
+using UnityEngine.PlayerLoop;
+
+namespace Anvil.Unity.DOTS.Entities
+{
+    /// <summary>
+    /// A system group to house a <see cref="World"/>s <see cref="EndInitializationEntityCommandBufferSystem"/>.
+    /// Used for mutli-world playerloop optimization.
+    /// </summary>
+    /// <remarks>Kept outside <see cref="WorldUtil"/> so their names read better in the editor.</remarks>
+    [DisableAutoCreation]
+    internal class EndInitializationCommandBufferSystemGroup : ComponentSystemGroup { }
+
+    /// <summary>
+    /// A system group to house a <see cref="World"/>s <see cref="EndSimulationEntityCommandBufferSystem"/>.
+    /// Used for mutli-world playerloop optimization.
+    /// </summary>
+    /// <remarks>Kept outside <see cref="WorldUtil"/> so their names read better in the editor.</remarks>
+    [DisableAutoCreation]
+    internal class EndSimulationCommandBufferSystemGroup : ComponentSystemGroup { }
+
+    /// <summary>
+    /// A <see cref="PlayerLoop"/> phase inserted immediately after <see cref="Update"/>.
+    /// Add via <see cref="WorldUtil.AddCustomPhasesToCurrentPlayerLoop" />.
+    /// </summary>
+    internal class PostUpdate
+    {
+        /// <summary>
+        /// Provides a <see cref="PlayerLoopSystem" /> instance to to identify this phase.
+        /// </summary>
+        public static PlayerLoopSystem PlayerLoopSystem
+        {
+            get => new PlayerLoopSystem()
+            {
+                type = typeof(PostUpdate)
+            };
+        }
+    }
+
+    /// <summary>
+    /// A <see cref="PlayerLoop"/> phase inserted immediately after <see cref="Initialization"/>.
+    /// Add via <see cref="WorldUtil.AddCustomPhasesToCurrentPlayerLoop" />.
+    /// </summary>
+    internal class PostInitialization
+    {
+        /// <summary>
+        /// Provides a <see cref="PlayerLoopSystem" /> instance to to identify this phase.
+        /// </summary>
+        public static PlayerLoopSystem PlayerLoopSystem
+        {
+            get => new PlayerLoopSystem()
+            {
+                type = typeof(PostInitialization)
+            };
+        }
+    }
+
+    /// <summary>
+    /// A collection of utilities to manipulate and augments <see cref="World"/>s.
+    /// The Anvil compliment to <see cref="ScriptBehaviourUpdateOrder"/>.
+    /// </summary>
+    public static class WorldUtil
+    {
+        // Not need to reset between play sessions because PlayerLoop systems are stateless and 
+        // persist between sessions when domain reloading is disabled.
+        private static bool s_AreCustomPlayerLoopPhasesAdded = false;
+
+        /// <summary>
+        /// Add custom phases to the <see cref="PlayerLoop"/>.
+        /// <see cref="PostInitialization"/> and <see cref="PostUpdate"/>.
+        /// </summary>
+        public static void AddCustomPhasesToCurrentPlayerLoop()
+        {
+            if (s_AreCustomPlayerLoopPhasesAdded)
+            {
+                return;
+            }
+
+            // Create new top level player loop phases
+            PlayerLoopSystem playerLoop = PlayerLoop.GetCurrentPlayerLoop();
+            List<PlayerLoopSystem> topLevelPhases = playerLoop.subSystemList.ToList();
+
+            int initializationPhaseIndex = topLevelPhases.FindIndex((phase) => phase.type == typeof(Initialization));
+            Debug.Assert(initializationPhaseIndex != -1, "Initialization phase not found");
+            Debug.Assert(!topLevelPhases.Any((phase) => phase.type == typeof(PostInitialization)), $"{nameof(PostInitialization)} phase already added");
+            topLevelPhases.Insert(initializationPhaseIndex + 1, PostInitialization.PlayerLoopSystem);
+
+            int updatePhaseIndex = topLevelPhases.FindIndex((phase) => phase.type == typeof(Update));
+            Debug.Assert(updatePhaseIndex != -1, "Update phase not found");
+            Debug.Assert(!topLevelPhases.Any((phase) => phase.type == typeof(PostUpdate)), $"{nameof(PostUpdate)} phase already added");
+            topLevelPhases.Insert(updatePhaseIndex + 1, PostUpdate.PlayerLoopSystem);
+
+            playerLoop.subSystemList = topLevelPhases.ToArray();
+            PlayerLoop.SetPlayerLoop(playerLoop);
+
+            s_AreCustomPlayerLoopPhasesAdded = true;
+        }
+
+        /// <summary>
+        /// Create a collection of top level <see cref="ComponentSystemGroup" />s and add them to the current <see cref="PlayerLoop"/>.
+        /// </summary>
+        /// <param name="world">The world to create top level groups in.</param>
+        /// <param name="topLevelGroupTypes">
+        /// A collection of value pairs where the first value is the PlayerLoop phase to place the system in and the second value is the 
+        /// system to create.
+        /// </param>
+        /// <returns></returns>
+        /// <remarks>
+        /// Groups must not already exist in the world. This is a limitation of our ability to detect whether a system has already been 
+        /// added to the palyer loop.
+        /// </remarks>
+        public static ComponentSystemGroup[] AddTopLevelGroupsToCurrentPlayerLoop(World world, (Type PlayerLoopSystemType, Type SystemGroupType)[] topLevelGroupTypes)
+        {
+            PlayerLoopSystem playerLoop = PlayerLoop.GetCurrentPlayerLoop();
+
+            // Create and Add top level system groups to the player loop
+            ComponentSystemGroup[] topLevelGroups = new ComponentSystemGroup[topLevelGroupTypes.Length];
+            for (int i = 0; i < topLevelGroupTypes.Length; i++)
+            {
+                (Type playerLoopSystemType, Type systemGroupType) = topLevelGroupTypes[i];
+                Debug.Assert(systemGroupType.IsSubclassOf(typeof(ComponentSystemGroup)));
+
+                // If we had access to ScriptBehaviourUpdateOrder.DummyDelegateWrapper we could detect if the system has already been added to the PlayerLoop.
+                Debug.Assert(world.GetExistingSystem(systemGroupType) == null, $"System group cannot already exists in world {world.Name}. There is no way of knowing if a top level group for an individual world has been added to the player loop already.");
+                topLevelGroups[i] = (ComponentSystemGroup)world.CreateSystem(systemGroupType);
+
+                ScriptBehaviourUpdateOrder.AppendSystemToPlayerLoopList(topLevelGroups[i], ref playerLoop, playerLoopSystemType);
+            }
+
+            PlayerLoop.SetPlayerLoop(playerLoop);
+
+            return topLevelGroups;
+        }
+
+        /// <summary>
+        /// Sort all groups in a <see cref="World"/>.
+        /// </summary>
+        public static void SortAllGroupsInWorld(World world)
+        {
+            // This implementation is a bit overkill since calling ComponentSystemGroup.SortSystems() calls recursively down to subgroups
+            // but the way ScriptBehaviourUpdateOrder adds systems to the PlayerLoop prevents us from inspecting instances and any logic 
+            // to calculate which systems are top level (check if not a child of other systems) is likely more expensive than just overcalling SortSystems().
+            // SortSystems exits early of no sorting is required.
+            foreach (ComponentSystemBase system in world.Systems)
+            {
+                (system as ComponentSystemGroup)?.SortSystems();
+            }
+        }
+
+        private static readonly (Type PlayerLoopSystemType, Type SystemGroupType)[] s_MultiWorldTopLevelGroupTypes = new[]{
+            (typeof(PostInitialization), typeof(EndInitializationCommandBufferSystemGroup)),
+            (typeof(PostUpdate), typeof(EndSimulationCommandBufferSystemGroup)),
+        };
+        /// <summary>
+        /// Optimizes a <see cref="World"/>'s <see cref="ComponentSystemGroup"/>s for multi-world applications.
+        /// Groups end command buffers into their own <see cref="PlayerLoop"/> phase just after their default phase. 
+        /// (Ex: <see cref="Update"/> -> <see cref="PostUpdate"/>)
+        /// This allows end command buffers for all worlds to be evaluated after all worlds have scheduled their work for the phase.
+        /// The result is that other worlds can compute their jobified work while one world is executing its end command buffer on the main thread.
+        /// </summary>
+        /// <param name="world">The world instance to optimize.</param>
+        /// <remarks>
+        /// This method doesn't move <see cref="EndFixedStepSimulationEntityCommandBufferSystem" because it's embedded in the <see cref="SimulationSystemGroup"/>.
+        /// making it impractical to group with the other worlds. There shouldn't be any expensive work in that command buffer anyway.
+        /// </remarks>
+        public static void OptimizeWorldForMultiWorldInCurrentPlayerLoop(World world)
+        {
+            AddCustomPhasesToCurrentPlayerLoop();
+            AddTopLevelGroupsToCurrentPlayerLoop(world, s_MultiWorldTopLevelGroupTypes);
+
+            MoveSystemFromToGroup<EndInitializationEntityCommandBufferSystem, InitializationSystemGroup, EndInitializationCommandBufferSystemGroup>(world);
+            MoveSystemFromToGroup<EndSimulationEntityCommandBufferSystem, SimulationSystemGroup, EndSimulationCommandBufferSystemGroup>(world);
+
+            // Suppress the logging during sort so we don't see complaints about systems that position themselves based on
+            // the systems that we're moving. So far, the configured above are at the end of the group and don't cause issues
+            // aside from the warnings. (dependent systems end up in the right place anyway)
+            try
+            {
+#if LOG_VERBOSE
+                UnityEngine.Debug.LogWarning($"Sorting {nameof(PlayerLoopSystem)}s. Warning expected with systems trying to position against ${nameof(EndSimulationEntityCommandBufferSystem)}");
+#else
+                Log.SupressLogging = true;
+#endif
+                SortAllGroupsInWorld(world);
+            }
+            catch (Exception e)
+            {
+                throw e;
+            }
+            finally
+            {
+                Log.SupressLogging = false;
+            }
+        }
+
+        /// <summary>
+        /// Moves a system from one group to another.
+        /// </summary>
+        /// <typeparam name="System">The system type to move</typeparam>
+        /// <typeparam name="SrcGroup">The system's existing group.</typeparam>
+        /// <typeparam name="DestGroup">The system's destination group.</typeparam>
+        /// <param name="world">The world instance to perform the move in.</param>
+        public static void MoveSystemFromToGroup<System, SrcGroup, DestGroup>(World world)
+                where System : ComponentSystemBase
+                where SrcGroup : ComponentSystemGroup
+                where DestGroup : ComponentSystemGroup
+        {
+            ComponentSystemBase system = world.GetExistingSystem<System>();
+            ComponentSystemGroup srcGroup = world.GetExistingSystem<SrcGroup>();
+            ComponentSystemGroup destGroup = world.GetExistingSystem<DestGroup>();
+
+            // Skip if there are missing elements
+            if (system == null || srcGroup == null || destGroup == null)
+            {
+                throw new ArgumentNullException($"{nameof(MoveSystemFromToGroup)}: One or more of the provided system and groups do not exist. {nameof(System)}:{system}, {nameof(SrcGroup)}:{srcGroup}, {nameof(DestGroup)}:{destGroup}");
+            }
+
+            Debug.Assert(srcGroup.Systems.Contains(system), $"{system} is not part of the source group: {srcGroup}");
+            srcGroup.RemoveSystemFromUpdateList(system);
+
+            destGroup.AddSystemToUpdateList(system);
+        }
+    }
+}

--- a/Scripts/Runtime/Entities/Util/WorldUtil.cs
+++ b/Scripts/Runtime/Entities/Util/WorldUtil.cs
@@ -67,7 +67,7 @@ namespace Anvil.Unity.DOTS.Entities
     /// </summary>
     public static class WorldUtil
     {
-        // Not need to reset between play sessions because PlayerLoop systems are stateless and 
+        // No need to reset between play sessions because PlayerLoop systems are stateless and 
         // persist between sessions when domain reloading is disabled.
         private static bool s_AreCustomPlayerLoopPhasesAdded = false;
 
@@ -87,7 +87,7 @@ namespace Anvil.Unity.DOTS.Entities
             List<PlayerLoopSystem> topLevelPhases = playerLoop.subSystemList.ToList();
 
             int initializationPhaseIndex = topLevelPhases.FindIndex((phase) => phase.type == typeof(Initialization));
-            Debug.Assert(initializationPhaseIndex != -1, "Initialization phase not found");
+            Debug.Assert(initializationPhaseIndex != -1, $"{nameof(Initialization)} phase not found");
             Debug.Assert(!topLevelPhases.Any((phase) => phase.type == typeof(PostInitialization)), $"{nameof(PostInitialization)} phase already added");
             topLevelPhases.Insert(initializationPhaseIndex + 1, PostInitialization.PlayerLoopSystem);
 
@@ -127,7 +127,7 @@ namespace Anvil.Unity.DOTS.Entities
                 Debug.Assert(systemGroupType.IsSubclassOf(typeof(ComponentSystemGroup)));
 
                 // If we had access to ScriptBehaviourUpdateOrder.DummyDelegateWrapper we could detect if the system has already been added to the PlayerLoop.
-                Debug.Assert(world.GetExistingSystem(systemGroupType) == null, $"System group cannot already exists in world {world.Name}. There is no way of knowing if a top level group for an individual world has been added to the player loop already.");
+                Debug.Assert(world.GetExistingSystem(systemGroupType) == null, $"System group cannot already exist in world {world.Name}. There is no way of knowing if a top level group for an individual world has been added to the player loop already.");
                 topLevelGroups[i] = (ComponentSystemGroup)world.CreateSystem(systemGroupType);
 
                 ScriptBehaviourUpdateOrder.AppendSystemToPlayerLoopList(topLevelGroups[i], ref playerLoop, playerLoopSystemType);
@@ -146,7 +146,7 @@ namespace Anvil.Unity.DOTS.Entities
             // This implementation is a bit overkill since calling ComponentSystemGroup.SortSystems() calls recursively down to subgroups
             // but the way ScriptBehaviourUpdateOrder adds systems to the PlayerLoop prevents us from inspecting instances and any logic 
             // to calculate which systems are top level (check if not a child of other systems) is likely more expensive than just overcalling SortSystems().
-            // SortSystems exits early of no sorting is required.
+            // SortSystems exits early if no sorting is required.
             foreach (ComponentSystemBase system in world.Systems)
             {
                 (system as ComponentSystemGroup)?.SortSystems();
@@ -166,7 +166,7 @@ namespace Anvil.Unity.DOTS.Entities
         /// </summary>
         /// <param name="world">The world instance to optimize.</param>
         /// <remarks>
-        /// This method doesn't move <see cref="EndFixedStepSimulationEntityCommandBufferSystem" because it's embedded in the <see cref="SimulationSystemGroup"/>.
+        /// This method doesn't move <see cref="EndFixedStepSimulationEntityCommandBufferSystem"/> because it's embedded in the <see cref="SimulationSystemGroup"/>.
         /// making it impractical to group with the other worlds. There shouldn't be any expensive work in that command buffer anyway.
         /// </remarks>
         public static void OptimizeWorldForMultiWorldInCurrentPlayerLoop(World world)

--- a/Scripts/Runtime/Entities/Util/WorldUtil.cs
+++ b/Scripts/Runtime/Entities/Util/WorldUtil.cs
@@ -211,6 +211,9 @@ namespace Anvil.Unity.DOTS.Entities
                 where SrcGroup : ComponentSystemGroup
                 where DestGroup : ComponentSystemGroup
         {
+
+            Debug.Assert(typeof(SrcGroup) != typeof(DestGroup), "Source and destination groups should not be the same.");
+
             ComponentSystemBase system = world.GetExistingSystem<System>();
             ComponentSystemGroup srcGroup = world.GetExistingSystem<SrcGroup>();
             ComponentSystemGroup destGroup = world.GetExistingSystem<DestGroup>();

--- a/Scripts/Runtime/Entities/Util/WorldUtil.cs.meta
+++ b/Scripts/Runtime/Entities/Util/WorldUtil.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2f30d99e7f0a346f6a804c11d03400ac
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Add a collection of utilities to manipulate and augment worlds
 - `PlayerLoop` optimization for multi-world applications
 - Move system between groups
 - Add top level system groups to `PlayerLoop`
 - Add additional top level `PlayerLoop` phases `PostInitialization` and `PostUpdate`
 - Bulk system group sorting.

This is an Anvil compliment to `ScriptBehaviourUpdateOrder`

### What is the current behaviour?
Developer's are left to their own implementations to perform somewhat common tasks on World instances.

### What is the new behaviour?
Utilities help developers get on with their intent.

### What issues does this resolve?
Tedium.

### What PRs does this depend on?
 - None

### Does this introduce a breaking change?
 - [ ] Yes <!-- If so, what are the migration considerations? -->
 - [x] No
