### PR TITLE
BusyWorkJob - Force synchronous burst compile

### DIFF
--- a/Scripts/Runtime/Jobs/Debug/BusyWorkJob.cs
+++ b/Scripts/Runtime/Jobs/Debug/BusyWorkJob.cs
@@ -9,7 +9,7 @@ namespace Anvil.Unity.DOTS.Jobs
     /// Useful for artificially increasing the time a job takes to help with debugging scheduling or profiling.
     /// <seealso cref="DebugUtil.FindPrimeNumber"/>
     /// </summary>
-    [BurstCompile]
+    [BurstCompile(CompileSynchronously = true)]
     public struct BusyWorkJob : IJobFor
     {
         private readonly int m_NthPrimeNumberToFind;


### PR DESCRIPTION
Set `BusyWorkJob` to always compile synchronously.

### What is the current behaviour?
Since `BusyWorkJob` is commonly used to really tax the system it can lock up the editor if async compiled since the first execution(s) will run without burst and substantially slower.

### What is the new behaviour?
`BusyWorkJob` will be compiled before application execution starts.

### What issues does this resolve?
A particularly taxing `BusyWorkJob` request would cause the editor to lock up when executed.
Ex: `new BusyWorkJob(20_000).Schedule(2250, Dependency)`

### What PRs does this depend on?
 - None

### Does this introduce a breaking change?
 - [ ] Yes <!-- If so, what are the migration considerations? -->
 - [x] No
