### PR TITLE
Entities 0.50 upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,14 +12,15 @@ The code is reasonably clean but documentation and examples are sparse. Feel fre
 ⚠️ We welcome PRs and bug reports but making this repo a public success is not our priority. No promises on when it will be addressed!
 
 # Dependencies
-- [Unity (2021.1.9)](https://unity.com/)
+- [Unity 2020 LTS (2020.3.30+)](https://unity.com/)
 - [anvil-csharp-core (main...usually 😬)](https://github.com/decline-cookies/anvil-csharp-core)
 - [anvil-unity-core (main...usually 😬)](https://github.com/decline-cookies/anvil-unity-core)
 - *DOTS Packages*
+    - [com.unity.entities (0.50.1-preview2)](https://docs.unity3d.com/Packages/com.unity.entities@0.50/manual/index.html)
+    - [com.unity.rendering.hybrid (0.50.0-preview.44)](https://docs.unity3d.com/Packages/com.unity.rendering.hybrid@0.50/manual/index.html)
     - [com.unity.burst (1.6.4)](https://docs.unity3d.com/Packages/com.unity.burst@1.6/manual/index.html)
-    - [com.unity.collections (0.15.0-preview21)](https://docs.unity3d.com/Packages/com.unity.collections@0.15/manual/index.html)
-    - [com.unity.entities (0.17.0-preview42)](https://docs.unity3d.com/Packages/com.unity.entities@0.17/manual/index.html)
-    - [com.unity.jobs (0.8.0-preview23)](https://docs.unity3d.com/Packages/com.unity.jobs@0.8/manual/index.html)
+    - [com.unity.collections (1.2.3)](https://docs.unity3d.com/Packages/com.unity.collections@1.2/manual/index.html)
+    - [com.unity.jobs (0.50.0-preview.9)](https://docs.unity3d.com/Packages/com.unity.jobs@0.50/manual/index.html)
     - [com.unity.mathematics (1.2.5)](https://docs.unity3d.com/Packages/com.unity.mathematics@1.2/manual/index.html)
     
 At this point in time, all DOTS related functionality is in this one repository. In the future, we may split the functionality into specialized repositories. Maintaining a repository per Unity DOTS package seems overly tedious at the moment.
@@ -40,3 +41,6 @@ This is the recommended Unity project folder structure:
     - unity
       - anvil-unity-core
       - anvil-unity-dots
+
+# Known Issues
+ - [#24 Systems Editor Panel throws exceptions](https://github.com/decline-cookies/anvil-unity-dots/issues/24) - Waiting on a fix from Unity

--- a/Scripts/Runtime/Entities/AbstractAnvilSystemBase.cs
+++ b/Scripts/Runtime/Entities/AbstractAnvilSystemBase.cs
@@ -10,7 +10,7 @@ namespace Anvil.Unity.DOTS.Entities
     /// Adds some convenience functionality non-release safety checks for 
     /// <see cref="SystemBase"/> implementations.
     /// </summary>
-    public abstract class AbstractAnvilSystemBase : SystemBase
+    public abstract partial class AbstractAnvilSystemBase : SystemBase
     {
 #if ENABLE_UNITY_COLLECTIONS_CHECKS
         /// <inheritdoc/>

--- a/Scripts/Runtime/Entities/Util/WorldUtil.cs
+++ b/Scripts/Runtime/Entities/Util/WorldUtil.cs
@@ -130,7 +130,7 @@ namespace Anvil.Unity.DOTS.Entities
                 Debug.Assert(world.GetExistingSystem(systemGroupType) == null, $"System group cannot already exist in world {world.Name}. There is no way of knowing if a top level group for an individual world has been added to the player loop already.");
                 topLevelGroups[i] = (ComponentSystemGroup)world.CreateSystem(systemGroupType);
 
-                ScriptBehaviourUpdateOrder.AppendSystemToPlayerLoopList(topLevelGroups[i], ref playerLoop, playerLoopSystemType);
+                ScriptBehaviourUpdateOrder.AppendSystemToPlayerLoop(topLevelGroups[i], ref playerLoop, playerLoopSystemType);
             }
 
             PlayerLoop.SetPlayerLoop(playerLoop);


### PR DESCRIPTION
Upgrades required for Entities 0.50 compatibility.

### What is the current behaviour?
No Entities 0.50 support

### What is the new behaviour?
Entities 0.50 support

### What issues does this resolve?
Incompatibility with Entities 0.50

### What PRs does this depend on?
 - None

### Does this introduce a breaking change?
 - [x] Yes - Not backwards compatible. Stay on the [entities-0.17 tag](https://github.com/decline-cookies/anvil-unity-dots/releases/tag/entities-0.17) if you don't want to upgrade to Entities 0.50
 - [ ] No
