### PR TITLE
Logging - Add Burst Compatible Logger

### DIFF
--- a/Scripts/Runtime/Entities/AbstractAnvilSystemBase.cs
+++ b/Scripts/Runtime/Entities/AbstractAnvilSystemBase.cs
@@ -2,6 +2,7 @@ using Unity.Entities;
 using Unity.Collections;
 using Unity.Jobs;
 using UnityEngine;
+using Anvil.CSharp.Logging;
 
 namespace Anvil.Unity.DOTS.Entities
 {
@@ -12,6 +13,17 @@ namespace Anvil.Unity.DOTS.Entities
     /// </summary>
     public abstract partial class AbstractAnvilSystemBase : SystemBase
     {
+        private Log.Logger? m_Logger;
+        /// <summary>
+        /// Returns a <see cref="Log.Logger"/> for this instance to emit log messages with.
+        /// Lazy instantiated.
+        /// </summary>
+        protected Log.Logger Logger
+        {
+            get => m_Logger ?? (m_Logger = Log.GetLogger(this)).Value;
+            set => m_Logger = value;
+        }
+
 #if ENABLE_UNITY_COLLECTIONS_CHECKS
         /// <inheritdoc/>
         protected new JobHandle Dependency

--- a/Scripts/Runtime/Logging.meta
+++ b/Scripts/Runtime/Logging.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b2e6cc092019742439321e7081e47877
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/Runtime/Logging/BurstableLogger.cs
+++ b/Scripts/Runtime/Logging/BurstableLogger.cs
@@ -1,0 +1,87 @@
+using System;
+using Anvil.CSharp.Logging;
+using Unity.Collections;
+
+namespace Anvil.Unity.DOTS.Logging
+{
+    [BurstCompatible]
+    public readonly struct BurstableLogger<PrefixStringType> where PrefixStringType : struct, INativeList<byte>, IUTF8Bytes
+    {
+        public readonly PrefixStringType MessagePrefix;
+
+        [NotBurstCompatible]
+        public BurstableLogger(Log.Logger logger, string appendToMessagePrefix)
+        {
+            string managedMessagePrefix = logger.MessagePrefix + appendToMessagePrefix;
+            MessagePrefix = default;
+            CopyError error = FixedStringMethods.CopyFrom(ref MessagePrefix, managedMessagePrefix);
+
+            switch (error)
+            {
+                case CopyError.None:
+                    break;
+
+                case CopyError.Truncation:
+                    logger.Error($"The message prefix is too long for this {nameof(BurstableLogger<PrefixStringType>)} and will be truncated (MaxLength:{MessagePrefix.Capacity} PrefixLength:{managedMessagePrefix.Length}). Select a different larger prefix string type for this logger.");
+                    break;
+
+                default:
+                    throw new Exception("Unknown message prefix error: " + error);
+            }
+        }
+
+        public BurstableLogger(in PrefixStringType messagePrefix)
+        {
+            MessagePrefix = messagePrefix;
+        }
+
+        public void Debug(in FixedString64Bytes message)
+        {
+            Debug<FixedString64Bytes>(message);
+        }
+
+        public void Debug<T>(in T message) where T : struct, INativeList<byte>, IUTF8Bytes
+        {
+            AssertMessageLength(message);
+            UnityEngine.Debug.Log($"{MessagePrefix}{message}");
+        }
+
+        public void Warning(in FixedString64Bytes message)
+        {
+            Warning<FixedString64Bytes>(message);
+        }
+
+        public void Warning<T>(in T message) where T : struct, INativeList<byte>, IUTF8Bytes
+        {
+            AssertMessageLength(message);
+            UnityEngine.Debug.LogWarning($"{MessagePrefix}{message}");
+        }
+
+        public void Error(in FixedString64Bytes message)
+        {
+            Error<FixedString64Bytes>(message);
+        }
+
+        public void Error<T>(in T message) where T : struct, INativeList<byte>, IUTF8Bytes
+        {
+            AssertMessageLength(message);
+            UnityEngine.Debug.LogError($"{MessagePrefix}{message}");
+        }
+
+        private void AssertMessageLength<T>(in T message) where T : struct, INativeList<byte>, IUTF8Bytes
+        {
+#if UNITY_ASSERTIONS
+            //Manually assert since Debug.Assert doesn't provide any useful information and does not support custom messages.
+            if (message.Length == message.Capacity)
+            {
+                UnityEngine.Debug.LogError($"The next logged message is too long and will be truncated. Consider using a larger FixedString type. MaxLength: {message.Capacity}");
+            }
+
+            if (message.Length + MessagePrefix.Length > FixedString4096Bytes.UTF8MaxLengthInBytes)
+            {
+                UnityEngine.Debug.LogError($"The next MessagePrefix + Message is larger than the largest fixed string({FixedString4096Bytes.UTF8MaxLengthInBytes}) and will be truncated. MessageLength:{message.Length} MessagePrefix: {MessagePrefix.Length}");
+            }
+#endif
+        }
+    }
+}

--- a/Scripts/Runtime/Logging/BurstableLogger.cs
+++ b/Scripts/Runtime/Logging/BurstableLogger.cs
@@ -10,7 +10,7 @@ namespace Anvil.Unity.DOTS.Logging
     /// Automatically decorates log messages with contextual information including:
     ///  - Optional, per instance, message prefix
     /// </summary>
-    /// <typeparam name="PrefixStringType">
+    /// <typeparam name="TPrefixStringType">
     /// The FixedString type to use for the message prefix
     /// Select the shortest fixed string that will fit the prefix length.
     /// (usually <see cref="FixedString32Bytes" />)
@@ -25,12 +25,12 @@ namespace Anvil.Unity.DOTS.Logging
     /// This is a Burst limitation.
     /// </remarks>
     [BurstCompatible]
-    public readonly struct BurstableLogger<PrefixStringType> where PrefixStringType : struct, INativeList<byte>, IUTF8Bytes
+    public readonly struct BurstableLogger<TPrefixStringType> where TPrefixStringType : struct, INativeList<byte>, IUTF8Bytes
     {
         /// <summary>
         /// The custom prefix to prepend to all messages sent through this instance.
         /// </summary>
-        public readonly PrefixStringType MessagePrefix;
+        public readonly TPrefixStringType MessagePrefix;
 
         /// <summary>
         /// Creates an instance of <see cref="BurstableLogger{PrefixStringType}"/> from a 
@@ -56,7 +56,7 @@ namespace Anvil.Unity.DOTS.Logging
                     break;
 
                 case CopyError.Truncation:
-                    logger.Error($"The message prefix is too long for this {nameof(BurstableLogger<PrefixStringType>)} and will be truncated (MaxLength:{MessagePrefix.Capacity} PrefixLength:{managedMessagePrefix.Length}). Select a different larger prefix string type for this logger.");
+                    logger.Error($"The message prefix is too long for this {nameof(BurstableLogger<TPrefixStringType>)} and will be truncated (MaxLength:{MessagePrefix.Capacity} PrefixLength:{managedMessagePrefix.Length}). Select a different larger prefix string type for this logger.");
                     break;
 
                 default:
@@ -68,7 +68,7 @@ namespace Anvil.Unity.DOTS.Logging
         /// Creates an instance of <see cref="BurstableLogger{PrefixStringType}"/>.
         /// </summary>
         /// <param name="messagePrefix">The custom prefix to prepend to all messages sent through this instance.</param>
-        public BurstableLogger(in PrefixStringType messagePrefix)
+        public BurstableLogger(in TPrefixStringType messagePrefix)
         {
             MessagePrefix = messagePrefix;
         }

--- a/Scripts/Runtime/Logging/BurstableLogger.cs
+++ b/Scripts/Runtime/Logging/BurstableLogger.cs
@@ -1,6 +1,7 @@
 using System;
 using Anvil.CSharp.Logging;
 using Unity.Collections;
+using Anvil.Unity.Logging;
 
 namespace Anvil.Unity.DOTS.Logging
 {
@@ -35,33 +36,42 @@ namespace Anvil.Unity.DOTS.Logging
             MessagePrefix = messagePrefix;
         }
 
+        [UnityLogListener.Exclude]
         public void Debug(in FixedString64Bytes message)
         {
-            Debug<FixedString64Bytes>(message);
+            AssertMessageLength(message);
+            UnityEngine.Debug.Log($"{MessagePrefix}{message}");
         }
 
+        [UnityLogListener.Exclude]
         public void Debug<T>(in T message) where T : struct, INativeList<byte>, IUTF8Bytes
         {
             AssertMessageLength(message);
             UnityEngine.Debug.Log($"{MessagePrefix}{message}");
         }
 
+        [UnityLogListener.Exclude]
         public void Warning(in FixedString64Bytes message)
         {
-            Warning<FixedString64Bytes>(message);
+            AssertMessageLength(message);
+            UnityEngine.Debug.LogWarning($"{MessagePrefix}{message}");
         }
 
+        [UnityLogListener.Exclude]
         public void Warning<T>(in T message) where T : struct, INativeList<byte>, IUTF8Bytes
         {
             AssertMessageLength(message);
             UnityEngine.Debug.LogWarning($"{MessagePrefix}{message}");
         }
 
+        [UnityLogListener.Exclude]
         public void Error(in FixedString64Bytes message)
         {
-            Error<FixedString64Bytes>(message);
+            AssertMessageLength(message);
+            UnityEngine.Debug.LogError($"{MessagePrefix}{message}");
         }
 
+        [UnityLogListener.Exclude]
         public void Error<T>(in T message) where T : struct, INativeList<byte>, IUTF8Bytes
         {
             AssertMessageLength(message);

--- a/Scripts/Runtime/Logging/BurstableLogger.cs
+++ b/Scripts/Runtime/Logging/BurstableLogger.cs
@@ -5,11 +5,44 @@ using Anvil.Unity.Logging;
 
 namespace Anvil.Unity.DOTS.Logging
 {
+    /// <summary>
+    /// A context specific instance that provides a mechanism to emit logs with minimum boilerplate.
+    /// Automatically decorates log messages with contextual information including:
+    ///  - Optional, per instance, message prefix
+    /// </summary>
+    /// <typeparam name="PrefixStringType">
+    /// The FixedString type to use for the message prefix
+    /// Select the shortest fixed string that will fit the prefix length.
+    /// (usually <see cref="FixedString32Bytes" />)
+    /// </typeparam>
+    /// <remarks>
+    /// In the future, the goal of this type is to provide all the same information that 
+    /// <see cref="Log.Logger" /> provides. That is not possible with Burst today but should be 
+    /// possible in the future without making any changes at the consuming end. At the moment, the 
+    /// contextual information is added when the message passes through <see cref="UnityLogListener"/>.
+    /// This information will appear in the output of all active <see cref="ILogHandler" /> implementations.
+    /// except for the Editor console (<see cref="UnityLogHandler"/>).
+    /// This is a Burst limitation.
+    /// </remarks>
     [BurstCompatible]
     public readonly struct BurstableLogger<PrefixStringType> where PrefixStringType : struct, INativeList<byte>, IUTF8Bytes
     {
+        /// <summary>
+        /// The custom prefix to prepend to all messages sent through this instance.
+        /// </summary>
         public readonly PrefixStringType MessagePrefix;
 
+        /// <summary>
+        /// Creates an instance of <see cref="BurstableLogger{PrefixStringType}"/> from a 
+        /// <see cref="Log.Logger" /> instance.
+        /// </summary>
+        /// <param name="logger">The <see cref="Log.Logger" /> to copy configuration from.</param>
+        /// <param name="appendToMessagePrefix">
+        /// A string to append to the <see cref="Log.Logger" />'s existing prefix.
+        /// </param>
+        /// <exception cref="Exception">
+        /// Thrown if there is an unknown error encountered when configuring the prefix string.
+        /// </exception>
         [NotBurstCompatible]
         public BurstableLogger(Log.Logger logger, string appendToMessagePrefix)
         {
@@ -31,11 +64,21 @@ namespace Anvil.Unity.DOTS.Logging
             }
         }
 
+        /// <summary>
+        /// Creates an instance of <see cref="BurstableLogger{PrefixStringType}"/>.
+        /// </summary>
+        /// <param name="messagePrefix">The custom prefix to prepend to all messages sent through this instance.</param>
         public BurstableLogger(in PrefixStringType messagePrefix)
         {
             MessagePrefix = messagePrefix;
         }
 
+        /// <summary>
+        /// Logs a message.
+        /// </summary>
+        /// <param name="message">
+        /// The message to log. (max length: <see cref="FixedString64Bytes.Capacity"/>)
+        /// </param>
         [UnityLogListener.Exclude]
         public void Debug(in FixedString64Bytes message)
         {
@@ -43,6 +86,16 @@ namespace Anvil.Unity.DOTS.Logging
             UnityEngine.Debug.Log($"{MessagePrefix}{message}");
         }
 
+        /// <summary>
+        /// Logs a message.
+        /// </summary>
+        /// <typeparam name="T">
+        /// The FixedString type for the message
+        /// Select the shortest fixed string that will fit the message length.
+        /// </typeparam>
+        /// <param name="message">
+        /// The message to log. (max length: <see cref="T.Capacity"/>)
+        /// </param>
         [UnityLogListener.Exclude]
         public void Debug<T>(in T message) where T : struct, INativeList<byte>, IUTF8Bytes
         {
@@ -50,6 +103,12 @@ namespace Anvil.Unity.DOTS.Logging
             UnityEngine.Debug.Log($"{MessagePrefix}{message}");
         }
 
+        /// <summary>
+        /// Logs a warning message.
+        /// </summary>
+        /// <param name="message">
+        /// The message to log. (max length: <see cref="FixedString64Bytes.Capacity"/>)
+        /// </param>
         [UnityLogListener.Exclude]
         public void Warning(in FixedString64Bytes message)
         {
@@ -57,6 +116,16 @@ namespace Anvil.Unity.DOTS.Logging
             UnityEngine.Debug.LogWarning($"{MessagePrefix}{message}");
         }
 
+        /// <summary>
+        /// Logs a warning message.
+        /// </summary>
+        /// <typeparam name="T">
+        /// The FixedString type for the message
+        /// Select the shortest fixed string that will fit the message length.
+        /// </typeparam>
+        /// <param name="message">
+        /// The message to log. (max length: <see cref="T.Capacity"/>)
+        /// </param>
         [UnityLogListener.Exclude]
         public void Warning<T>(in T message) where T : struct, INativeList<byte>, IUTF8Bytes
         {
@@ -64,6 +133,12 @@ namespace Anvil.Unity.DOTS.Logging
             UnityEngine.Debug.LogWarning($"{MessagePrefix}{message}");
         }
 
+        /// <summary>
+        /// Logs an error message.
+        /// </summary>
+        /// <param name="message">
+        /// The message to log. (max length: <see cref="FixedString64Bytes.Capacity"/>)
+        /// </param>
         [UnityLogListener.Exclude]
         public void Error(in FixedString64Bytes message)
         {
@@ -71,6 +146,16 @@ namespace Anvil.Unity.DOTS.Logging
             UnityEngine.Debug.LogError($"{MessagePrefix}{message}");
         }
 
+        /// <summary>
+        /// Logs an error message.
+        /// </summary>
+        /// <typeparam name="T">
+        /// The FixedString type for the message
+        /// Select the shortest fixed string that will fit the message length.
+        /// </typeparam>
+        /// <param name="message">
+        /// The message to log. (max length: <see cref="T.Capacity"/>)
+        /// </param>
         [UnityLogListener.Exclude]
         public void Error<T>(in T message) where T : struct, INativeList<byte>, IUTF8Bytes
         {

--- a/Scripts/Runtime/Logging/BurstableLogger.cs.meta
+++ b/Scripts/Runtime/Logging/BurstableLogger.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b9e51f80900ec4913a2e5601ea5b7a32
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/Runtime/Logging/LoggerExtension.cs
+++ b/Scripts/Runtime/Logging/LoggerExtension.cs
@@ -1,16 +1,42 @@
 using Anvil.CSharp.Logging;
-using Anvil.Unity.DOTS.Logging;
 using Unity.Collections;
 
-public static class LoggerExtension
+namespace Anvil.Unity.DOTS.Logging
 {
-    public static BurstableLogger<FixedString32Bytes> AsBurstable(this in Log.Logger logger, string appendToMessagePrefix = null)
+    /// <summary>
+    /// A collection of DOTS specific extension methods for <see cref="Log.Logger"/>.
+    /// </summary>
+    public static class LoggerExtension
     {
-        return AsBurstable<FixedString32Bytes>(logger, appendToMessagePrefix);
-    }
+        /// <summary>
+        /// Creates an instance of <see cref="BurstableLogger{PrefixStringType}"/> from the
+        /// <see cref="Log.Logger" /> instance.
+        /// </summary>
+        /// <param name="logger">The <see cref="Log.Logger" /> to copy configuration from.</param>
+        /// <param name="appendToMessagePrefix">
+        /// A string to append to the <see cref="Log.Logger" />'s existing prefix.
+        /// (max length: <see cref="FixedString32Bytes.Capacity"/>)
+        /// </param>
+        /// <returns>A <see cref="BurstableLogger{FixedString32Bytes}" /> instance.</returns>
+        public static BurstableLogger<FixedString32Bytes> AsBurstable(this in Log.Logger logger, string appendToMessagePrefix = null)
+        {
+            return AsBurstable<FixedString32Bytes>(logger, appendToMessagePrefix);
+        }
 
-    public static BurstableLogger<PrefixStringType> AsBurstable<PrefixStringType>(this in Log.Logger logger, string appendToMessagePrefix = null) where PrefixStringType : struct, INativeList<byte>, IUTF8Bytes
-    {
-        return new BurstableLogger<PrefixStringType>(logger, appendToMessagePrefix);
+        /// <summary>
+        /// Creates an instance of <see cref="BurstableLogger{PrefixStringType}"/> from the
+        /// <see cref="Log.Logger" /> instance.
+        /// </summary>
+        /// <typeparam name="PrefixStringType"></typeparam>
+        /// <param name="logger">The <see cref="Log.Logger" /> to copy configuration from.</param>
+        /// <param name="appendToMessagePrefix">
+        /// A string to append to the <see cref="Log.Logger" />'s existing prefix.
+        /// (max length: <see cref="PrefixStringType.Capacity"/>)
+        /// </param>
+        /// <returns>A <see cref="BurstableLogger{PrefixStringType}" /> instance.</returns>
+        public static BurstableLogger<PrefixStringType> AsBurstable<PrefixStringType>(this in Log.Logger logger, string appendToMessagePrefix = null) where PrefixStringType : struct, INativeList<byte>, IUTF8Bytes
+        {
+            return new BurstableLogger<PrefixStringType>(logger, appendToMessagePrefix);
+        }
     }
 }

--- a/Scripts/Runtime/Logging/LoggerExtension.cs
+++ b/Scripts/Runtime/Logging/LoggerExtension.cs
@@ -1,0 +1,16 @@
+using Anvil.CSharp.Logging;
+using Anvil.Unity.DOTS.Logging;
+using Unity.Collections;
+
+public static class LoggerExtension
+{
+    public static BurstableLogger<FixedString32Bytes> AsBurstable(this in Log.Logger logger, string appendToMessagePrefix = null)
+    {
+        return AsBurstable<FixedString32Bytes>(logger, appendToMessagePrefix);
+    }
+
+    public static BurstableLogger<PrefixStringType> AsBurstable<PrefixStringType>(this in Log.Logger logger, string appendToMessagePrefix = null) where PrefixStringType : struct, INativeList<byte>, IUTF8Bytes
+    {
+        return new BurstableLogger<PrefixStringType>(logger, appendToMessagePrefix);
+    }
+}

--- a/Scripts/Runtime/Logging/LoggerExtension.cs
+++ b/Scripts/Runtime/Logging/LoggerExtension.cs
@@ -27,16 +27,16 @@ namespace Anvil.Unity.DOTS.Logging
         /// Creates an instance of <see cref="BurstableLogger{PrefixStringType}"/> from the
         /// <see cref="Log.Logger" /> instance.
         /// </summary>
-        /// <typeparam name="PrefixStringType"></typeparam>
+        /// <typeparam name="TPrefixStringType"></typeparam>
         /// <param name="logger">The <see cref="Log.Logger" /> to copy configuration from.</param>
         /// <param name="appendToMessagePrefix">
         /// A string to append to the <see cref="Log.Logger" />'s existing prefix.
         /// (max length: <see cref="PrefixStringType.Capacity"/>)
         /// </param>
         /// <returns>A <see cref="BurstableLogger{PrefixStringType}" /> instance.</returns>
-        public static BurstableLogger<PrefixStringType> AsBurstable<PrefixStringType>(this in Log.Logger logger, string appendToMessagePrefix = null) where PrefixStringType : struct, INativeList<byte>, IUTF8Bytes
+        public static BurstableLogger<TPrefixStringType> AsBurstable<TPrefixStringType>(this in Log.Logger logger, string appendToMessagePrefix = null) where TPrefixStringType : struct, INativeList<byte>, IUTF8Bytes
         {
-            return new BurstableLogger<PrefixStringType>(logger, appendToMessagePrefix);
+            return new BurstableLogger<TPrefixStringType>(logger, appendToMessagePrefix);
         }
     }
 }

--- a/Scripts/Runtime/Logging/LoggerExtension.cs.meta
+++ b/Scripts/Runtime/Logging/LoggerExtension.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 45eb43f0779d5471c9b558b2407c6a3f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Add a burst compatible logger that can be brought into bursted contexts.

### What is the current behaviour?
`Log.Logger` is not burst compatible so the developer can only emit log messages via `Debug.Log` and friends.

#### Tag Alongs
 - Add a lazy initialized `Logger` property to `AbstractAnvilSystemBase`. The same pattern used in `AbstractAnvilBase`

### What is the new behaviour?
A `BurstableLogger` instance can be created either manually (within a bursted or managed context) or derived from a `Log.Logger` using the `.AsBurstable()` extension method.

At the moment the Burstable logger mainly:
 - Provides a familiar `Log.Logger` API
 - Allows for a message prefix to be defined which is prepended to all messages emitted through the logger.

However, this setup lays the groundwork for more features as they are added to the managed `Log.Logger` and as Burst adds more features to allow for more robust logging.

### What issues does this resolve?
Allowing familiar `Log.Logger` functionality and API within a Burst compiled context.
Provides a wrapper that can be used to further decorate log messages emitted from burst compiled code with minimal updates at the call site.

### What PRs does this depend on?
 - https://github.com/decline-cookies/anvil-csharp-core/pull/84
 - https://github.com/decline-cookies/anvil-unity-core/pull/62

### Does this introduce a breaking change?
 - [ ] Yes <!-- If so, what are the migration considerations? -->
 - [x] No
