### PR TITLE
Adding clear ability to UnsafeTypedStream plus bug fixes

### DIFF
--- a/Scripts/Runtime/Jobs/AccessControl/AccessController.cs
+++ b/Scripts/Runtime/Jobs/AccessControl/AccessController.cs
@@ -223,7 +223,7 @@ namespace Anvil.Unity.DOTS.Jobs
         {
             Debug.Assert(m_State != AcquisitionState.Disposing, $"{nameof(AccessController)} is already in the {AcquisitionState.Disposing} state. No longer allowed to acquire until {nameof(Reset)} is called. Last {nameof(AcquireAsync)} was called from: {m_AcquireCallerInfo}");
             Debug.Assert(m_State == AcquisitionState.Unacquired, $"{nameof(ReleaseAsync)} must be called before {nameof(AcquireAsync)} is called again. Last {nameof(AcquireAsync)} was called from: {m_AcquireCallerInfo}");
-            StackFrame frame = new StackFrame(2, true);
+            StackFrame frame = new StackFrame(3, true);
             m_AcquireCallerInfo = $"{frame.GetMethod().Name} at {frame.GetFileName()}:{frame.GetFileLineNumber()}";
         }
 
@@ -232,7 +232,7 @@ namespace Anvil.Unity.DOTS.Jobs
         {
             Debug.Assert(m_State != AcquisitionState.Unacquired, $"{nameof(ReleaseAsync)} was called multiple times. Last {nameof(ReleaseAsync)} was called from: {m_ReleaseCallerInfo}");
             Debug.Assert(m_State != AcquisitionState.Disposing, $"{nameof(ReleaseAsync)} was called but the {nameof(AccessController)} is already in the {AcquisitionState.Disposing} state. No need to call release since no one else can write or read. Call {nameof(Reset)} if you want to reuse the controller.");
-            StackFrame frame = new StackFrame(2, true);
+            StackFrame frame = new StackFrame(3, true);
             m_ReleaseCallerInfo = $"{frame.GetMethod().Name} at {frame.GetFileName()}:{frame.GetFileLineNumber()}";
 
             Debug.Assert(releaseAccessDependency.DependsOn(m_LastHandleAcquired), $"Dependency Chain Broken: The {nameof(JobHandle)} passed into {nameof(ReleaseAsync)} is not part of the chain from the {nameof(JobHandle)} that was given in the last call to {nameof(AcquireAsync)}. Check to ensure your ordering of {nameof(AcquireAsync)} and {nameof(ReleaseAsync)} match.");

--- a/Scripts/Runtime/Jobs/ConsolidateToNativeArrayJob.cs
+++ b/Scripts/Runtime/Jobs/ConsolidateToNativeArrayJob.cs
@@ -1,0 +1,46 @@
+using Anvil.Unity.DOTS.Data;
+using Unity.Burst;
+using Unity.Collections;
+using Unity.Jobs;
+
+namespace Anvil.Unity.DOTS.Jobs
+{
+    [BurstCompile]
+    public struct ConsolidateToNativeArrayJob<T> : IJob
+        where T : struct
+    {
+        [ReadOnly] private readonly UnsafeTypedStream<T>.Reader m_Reader;
+        private DeferredNativeArray<T> m_DeferredNativeArray;
+
+        public ConsolidateToNativeArrayJob(UnsafeTypedStream<T>.Reader reader,
+                                           DeferredNativeArray<T> deferredNativeArray)
+        {
+            m_Reader = reader;
+            m_DeferredNativeArray = deferredNativeArray;
+        }
+
+        public void Execute()
+        {
+            int newLength = m_Reader.Count();
+
+            if (newLength == 0)
+            {
+                return;
+            }
+
+            NativeArray<T> array = m_DeferredNativeArray.DeferredCreate(newLength);
+
+            int arrayIndex = 0;
+            for (int laneIndex = 0; laneIndex < m_Reader.LaneCount; ++laneIndex)
+            {
+                UnsafeTypedStream<T>.LaneReader laneReader = m_Reader.AsLaneReader(laneIndex);
+                int elementCount = laneReader.Count;
+                for (int elementIndex = 0; elementIndex < elementCount; ++elementIndex)
+                {
+                    array[arrayIndex] = laneReader.Read();
+                    arrayIndex++;
+                }
+            }
+        }
+    }
+}

--- a/Scripts/Runtime/Jobs/ConsolidateToNativeArrayJob.cs
+++ b/Scripts/Runtime/Jobs/ConsolidateToNativeArrayJob.cs
@@ -5,6 +5,13 @@ using Unity.Jobs;
 
 namespace Anvil.Unity.DOTS.Jobs
 {
+    /// <summary>
+    /// Helper job to turn a <see cref="UnsafeTypedStream{T}"/> into a <see cref="NativeArray{T}"/>
+    /// via a <see cref="DeferredNativeArray{T}"/>.
+    /// Useful for load balancing from multiple threads writing variable amounts to each lane in the
+    /// <see cref="UnsafeTypedStream{T}"/>.
+    /// </summary>
+    /// <typeparam name="T">The type contained in the collection</typeparam>
     [BurstCompile]
     public struct ConsolidateToNativeArrayJob<T> : IJob
         where T : struct

--- a/Scripts/Runtime/Jobs/ConsolidateToNativeArrayJob.cs.meta
+++ b/Scripts/Runtime/Jobs/ConsolidateToNativeArrayJob.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: b5747329ea7e4c24bd4ef4b542990f55
+timeCreated: 1653071833

--- a/Scripts/Runtime/Jobs/Util/ParallelCollectionUtil.cs
+++ b/Scripts/Runtime/Jobs/Util/ParallelCollectionUtil.cs
@@ -111,6 +111,14 @@ namespace Anvil.Unity.DOTS.Jobs
             return math.min(nativeThreadIndex - 1, JOB_WORKER_MAXIMUM_COUNT.Data);
         }
         
+        /// <summary>
+        /// Returns the index to use when operating on the main thread 
+        /// </summary>
+        /// <remarks>
+        /// This function assumes that the collection being used was sized appropriately via
+        /// <see cref="ParallelAccessUtil.CollectionSizeForMaxThreads"/>.
+        /// </remarks>
+        /// <returns>The collection index to use</returns>
         public static int CollectionIndexForMainThread()
         {
             int mainThreadIndex = JOB_WORKER_MAXIMUM_COUNT.Data;

--- a/Scripts/Runtime/Jobs/Util/ParallelCollectionUtil.cs
+++ b/Scripts/Runtime/Jobs/Util/ParallelCollectionUtil.cs
@@ -110,6 +110,13 @@ namespace Anvil.Unity.DOTS.Jobs
             Debug.Assert(nativeThreadIndex > 0 && nativeThreadIndex <= JobsUtility.MaxJobThreadCount);
             return math.min(nativeThreadIndex - 1, JOB_WORKER_MAXIMUM_COUNT.Data);
         }
+        
+        public static int CollectionIndexForMainThread()
+        {
+            int mainThreadIndex = JOB_WORKER_MAXIMUM_COUNT.Data;
+            DetectMultipleXThreads(mainThreadIndex);
+            return mainThreadIndex;
+        }
 
         [Conditional("ENABLE_UNITY_COLLECTIONS_CHECKS")]
         [BurstDiscard]


### PR DESCRIPTION
Adding a Clear function the `UnsafeTypedStream` 
Plus a few bug fixes

### What is the current behaviour?

- Currently you have to dispose and create a new `UnsafeTypedStream` anytime you want to reuse a variable each frame. 
- `UnsafeTypedStream` uses the same allocator for the structure itself and the content.
- Safety checks in `AccessController` didn't go far enough in the stack frame to get the right calling function.

### What is the new behaviour?

- Now there is a `Clear` function which either clears immediately on the calling thread or can be scheduled in a job to clear the data but keep the structure intact allowing it to be reused.
- `UnsafeTypedStream` can optionally have different types of memory allocation. One for the structure itself and one for the content. 
    - This allows for a `UnsafeTypedStream` to be created using `Persistent` memory but then for all the content to be `TempJob` memory which results in much faster allocations.
- Safety checks in `AccessController` now go far enough in the stack frame to get the right calling function.


### What issues does this resolve?
- None

### What PRs does this depend on?
 - None

### Does this introduce a breaking change?
 - [ ] Yes
 - [x] No

### Tag-Alongs

- Added a `CollectionIndexForMainThread`  function to `ParallelAccessUtil` 
- Added a `ConsolidateToNativeArrayJob` to turn `UnsafeTypedStream<T>` into `NativeArray<T>` via a `DeferredNativeArray`
