### PR TITLE
Adding the ability to clear a DeferredNativeArray

### DIFF
--- a/Scripts/Runtime/Data/Collections/DeferredNativeArray.cs
+++ b/Scripts/Runtime/Data/Collections/DeferredNativeArray.cs
@@ -79,13 +79,20 @@ namespace Anvil.Unity.DOTS.Data
             [NativeDisableUnsafePtrRestriction] public void* Buffer;
             public int Length;
             public Allocator DeferredAllocator;
+            
 #if ENABLE_UNITY_COLLECTIONS_CHECKS
-            public bool CanAllocate;
+            private bool m_CanAllocate;
 #endif
             [Conditional("ENABLE_UNITY_COLLECTIONS_CHECKS")]
             public void AssertCanAllocate()
             {
-                Debug.Assert(CanAllocate);
+                Debug.Assert(m_CanAllocate);
+            }
+
+            [Conditional("ENABLE_UNITY_COLLECTIONS_CHECKS")]
+            public void SetCanAllocate(bool value)
+            {
+                m_CanAllocate = value;
             }
         }
 
@@ -135,7 +142,7 @@ namespace Anvil.Unity.DOTS.Data
             array.m_BufferInfo->Length = 0;
             array.m_BufferInfo->Buffer = null;
             array.m_BufferInfo->DeferredAllocator = deferredAllocator;
-            array.m_BufferInfo->CanAllocate = true;
+            array.m_BufferInfo->SetCanAllocate(true);
 
             array.m_Allocator = allocator;
 
@@ -256,7 +263,7 @@ namespace Anvil.Unity.DOTS.Data
         public unsafe void Clear()
         {
             ClearBufferInfo(m_BufferInfo);
-            m_BufferInfo->CanAllocate = true;
+            m_BufferInfo->SetCanAllocate(true);
         }
 
         /// <summary>
@@ -296,7 +303,7 @@ namespace Anvil.Unity.DOTS.Data
 
             ClearJob clearJob = new ClearJob(m_BufferInfo);
             JobHandle jobHandle = clearJob.Schedule(inputDeps);
-            m_BufferInfo->CanAllocate = true;
+            m_BufferInfo->SetCanAllocate(true);
             return jobHandle;
         }
 
@@ -327,7 +334,7 @@ namespace Anvil.Unity.DOTS.Data
             //Update the buffer info
             m_BufferInfo->Length = newLength;
             m_BufferInfo->Buffer = newMemory;
-            m_BufferInfo->CanAllocate = false;
+            m_BufferInfo->SetCanAllocate(false);
 
             //Return an actual NativeArray so it's familiar to use and we don't have to reimplement the same api and functionality
             NativeArray<T> array = NativeArrayUnsafeUtility.ConvertExistingDataToNativeArray<T>(m_BufferInfo->Buffer, newLength, m_BufferInfo->DeferredAllocator);

--- a/Scripts/Runtime/Data/Collections/DeferredNativeArray.cs
+++ b/Scripts/Runtime/Data/Collections/DeferredNativeArray.cs
@@ -138,11 +138,23 @@ namespace Anvil.Unity.DOTS.Data
         /// <summary>
         /// Creates a new instance of <see cref="DeferredNativeArray{T}"/>
         /// </summary>
-        /// <param name="allocator">The <see cref="Allocator"/> to use for memory allocation.</param>
+        /// <param name="allocator">
+        /// The <see cref="Allocator"/> to use for memory allocation of the collection and
+        /// the deferred data.
+        /// </param>
         public DeferredNativeArray(Allocator allocator) : this(allocator, allocator)
         {
         }
-
+        
+        /// <summary>
+        /// Creates a new instance of <see cref="DeferredNativeArray{T}"/>
+        /// </summary>
+        /// <param name="allocator">
+        /// The <see cref="Allocator"/> to use for memory allocation of the collection only.
+        /// </param>
+        /// <param name="deferredAllocator">
+        /// The <see cref="Allocator"/> to use for memory allocation of the deferred data.
+        /// </param>
         public DeferredNativeArray(Allocator allocator, Allocator deferredAllocator)
         {
             Allocate(allocator, deferredAllocator, out this);


### PR DESCRIPTION
### What is the current behaviour?

Currently a `DeferredNativeArray` must be `Disposed` and recreated if you want to use it again similar to the other built in Unity native collections.

### What is the new behaviour?

There's often a pattern of having a persistent collection existing in the system and the temp job allocating the data in a job per frame similar to the `UnsafeTypedStream`.

This allows for keeping a collection around and just clearing the data each frame instead of having to dispose and recreate.

`DeferredNativeArray` now supports this pattern.

### What issues does this resolve?
- None

### What PRs does this depend on?
 - None

### Does this introduce a breaking change?
 - [ ] Yes 
 - [x] No

### Tag-Alongs

- Fixed a bug where the debugger info would throw an error when inspecting in the debugger.
- Fixed a bug where a scheduled `Dispose` would clear the pointer of an inflight iteration resulting in a runtime error in the job. Now properly clearing the pointer where we should be.
