### PR TITLE
Adding Virtual Data

### DIFF
--- a/Scripts/Runtime/Data/VirtualData.meta
+++ b/Scripts/Runtime/Data/VirtualData.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 9bcb361fd2f95408c9df0cb1a8703bb4
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/Runtime/Data/VirtualData/IVirtualData.cs
+++ b/Scripts/Runtime/Data/VirtualData/IVirtualData.cs
@@ -1,0 +1,26 @@
+using Anvil.CSharp.Core;
+using Anvil.Unity.DOTS.Jobs;
+using Unity.Jobs;
+
+namespace Anvil.Unity.DOTS.Data
+{
+    /// <summary>
+    /// Interface for dealing with <see cref="VirtualData{TKey,TInstance}"/> in a generic way without having
+    /// to know the types.
+    /// </summary>
+    public interface IVirtualData : IAnvilDisposable
+    {
+        internal void AddResultDestination(IVirtualData resultData);
+        internal void RemoveResultDestination(IVirtualData resultData);
+        
+        internal JobHandle ConsolidateForFrame(JobHandle dependsOn);
+
+        internal JobHandle AcquireForUpdate();
+        internal void ReleaseForUpdate(JobHandle releaseAccessDependency);
+
+        internal AccessController AccessController
+        {
+            get;
+        }
+    }
+}

--- a/Scripts/Runtime/Data/VirtualData/IVirtualData.cs.meta
+++ b/Scripts/Runtime/Data/VirtualData/IVirtualData.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2a1378c21044d42ed82cd421aff4b175
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/Runtime/Data/VirtualData/InstanceData.meta
+++ b/Scripts/Runtime/Data/VirtualData/InstanceData.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 414150f61b18b466bb6c9eb44232c64b
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/Runtime/Data/VirtualData/InstanceData/ILookupData.cs
+++ b/Scripts/Runtime/Data/VirtualData/InstanceData/ILookupData.cs
@@ -1,0 +1,21 @@
+using System;
+
+namespace Anvil.Unity.DOTS.Data
+{
+    /// <summary>
+    /// Data to be used in <see cref="VirtualData{TKey,TInstance}"/>
+    /// that can be looked up with a <typeparamref name="TKey"/>
+    /// </summary>
+    /// <typeparam name="TKey">The type of key to use for lookup.</typeparam>
+    public interface ILookupData<out TKey>
+        where TKey : struct, IEquatable<TKey>
+    {
+        /// <summary>
+        /// The lookup key for this struct
+        /// </summary>
+        public TKey Key
+        {
+            get;
+        }
+    }
+}

--- a/Scripts/Runtime/Data/VirtualData/InstanceData/ILookupData.cs.meta
+++ b/Scripts/Runtime/Data/VirtualData/InstanceData/ILookupData.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e5f3e14ea41364e1f9fd123ea0f6b1af
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/Runtime/Data/VirtualData/InstanceData/IVirtualDataInstance.cs
+++ b/Scripts/Runtime/Data/VirtualData/InstanceData/IVirtualDataInstance.cs
@@ -1,0 +1,19 @@
+namespace Anvil.Unity.DOTS.Data
+{
+    /// <summary>
+    /// Data to be used in <see cref="VirtualData{TKey,TInstance}"/>
+    /// that can write out a result when it has completed updating.
+    /// </summary>
+    /// <typeparam name="TResult">The type of result to write</typeparam>
+    public interface IVirtualDataInstance<TResult>
+        where TResult : struct
+    {
+        /// <summary>
+        /// The location to write the result
+        /// </summary>
+        public VDJobResultsDestination<TResult> ResultsDestination
+        {
+            get;
+        }
+    }
+}

--- a/Scripts/Runtime/Data/VirtualData/InstanceData/IVirtualDataInstance.cs.meta
+++ b/Scripts/Runtime/Data/VirtualData/InstanceData/IVirtualDataInstance.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: efc8b9ac3090e46278636cfa3881bf3b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/Runtime/Data/VirtualData/Jobs.meta
+++ b/Scripts/Runtime/Data/VirtualData/Jobs.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 9a5c6450e320a420f9c283a7d023bca9
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/Runtime/Data/VirtualData/Jobs/VDJobReader.cs
+++ b/Scripts/Runtime/Data/VirtualData/Jobs/VDJobReader.cs
@@ -1,0 +1,30 @@
+using Unity.Collections;
+
+namespace Anvil.Unity.DOTS.Data
+{
+    /// <summary>
+    /// A struct to be used in jobs that only allows for reading.
+    /// Commonly used to read and trigger something else.
+    /// </summary>
+    /// <typeparam name="TInstance">They type of data to read</typeparam>
+    [BurstCompatible]
+    public readonly struct VDJobReader<TInstance>
+        where TInstance : struct
+    {
+        [ReadOnly] private readonly NativeArray<TInstance> m_Iteration;
+
+        internal VDJobReader(NativeArray<TInstance> iteration)
+        {
+            m_Iteration = iteration;
+        }
+        
+        /// <summary>
+        /// Gets the <typeparamref name="TInstance"/> at the specified index.
+        /// </summary>
+        /// <param name="index">The index into the backing array</param>
+        public TInstance this[int index]
+        {
+            get => m_Iteration[index];
+        }
+    }
+}

--- a/Scripts/Runtime/Data/VirtualData/Jobs/VDJobReader.cs.meta
+++ b/Scripts/Runtime/Data/VirtualData/Jobs/VDJobReader.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e07de61cf6b6f4abbacc55ac556eae69
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/Runtime/Data/VirtualData/Jobs/VDJobResultsDestination.cs
+++ b/Scripts/Runtime/Data/VirtualData/Jobs/VDJobResultsDestination.cs
@@ -1,0 +1,26 @@
+using Unity.Collections;
+
+namespace Anvil.Unity.DOTS.Data
+{
+    /// <summary>
+    /// A struct to be used in jobs that acts as a placeholder for results to be written to
+    /// later on. Use with <see cref="IVirtualDataInstance{TResult}"/>
+    /// </summary>
+    /// <typeparam name="TResult">The type of result that can be written</typeparam>
+    [BurstCompatible]
+    public readonly struct VDJobResultsDestination<TResult>
+        where TResult : struct
+    {
+        //Implicit cast to a writer when we need to actually write.
+        //Otherwise this struct doesn't let you do anything with it until we can guarantee you
+        //have access.
+        public static implicit operator VDJobResultsWriter<TResult>(VDJobResultsDestination<TResult> destination) => new VDJobResultsWriter<TResult>(destination.m_ResultWriter);
+
+        [ReadOnly] private readonly UnsafeTypedStream<TResult>.Writer m_ResultWriter;
+
+        internal VDJobResultsDestination(UnsafeTypedStream<TResult>.Writer resultWriter)
+        {
+            m_ResultWriter = resultWriter;
+        }
+    }
+}

--- a/Scripts/Runtime/Data/VirtualData/Jobs/VDJobResultsDestination.cs.meta
+++ b/Scripts/Runtime/Data/VirtualData/Jobs/VDJobResultsDestination.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e2ed311d46b624ce1bd5d18977b4f78c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/Runtime/Data/VirtualData/Jobs/VDJobResultsWriter.cs
+++ b/Scripts/Runtime/Data/VirtualData/Jobs/VDJobResultsWriter.cs
@@ -1,0 +1,38 @@
+using Unity.Collections;
+
+namespace Anvil.Unity.DOTS.Data
+{
+    /// <summary>
+    /// A struct to be used in jobs that writes new results.
+    /// <seealso cref="IVirtualDataInstance{TResult}"/>
+    /// <seealso cref="VDJobResultsDestination{TResult}"/>
+    /// </summary>
+    /// <typeparam name="TResult">The type of result to write</typeparam>
+    [BurstCompatible]
+    public readonly struct VDJobResultsWriter<TResult>
+        where TResult : struct
+    {
+        [ReadOnly] private readonly UnsafeTypedStream<TResult>.Writer m_ResultWriter;
+
+        internal VDJobResultsWriter(UnsafeTypedStream<TResult>.Writer resultWriter)
+        {
+            m_ResultWriter = resultWriter;
+        }
+        
+        /// <summary>
+        /// Adds a new result to the <see cref="VirtualData{TKey,TInstance}"/> of results.
+        /// </summary>
+        /// <param name="result">The result to write</param>
+        /// <param name="laneIndex">The lane index to write to.</param>
+        public void Add(TResult result, int laneIndex)
+        {
+            Add(ref result, laneIndex);
+        }
+        
+        /// <inheritdoc cref="Add(TResult,int)"/>
+        public void Add(ref TResult result, int laneIndex)
+        {
+            m_ResultWriter.AsLaneWriter(laneIndex).Write(ref result);
+        }
+    }
+}

--- a/Scripts/Runtime/Data/VirtualData/Jobs/VDJobResultsWriter.cs.meta
+++ b/Scripts/Runtime/Data/VirtualData/Jobs/VDJobResultsWriter.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3efe24ec59bbb4afbaa835ba7d1af5e6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/Runtime/Data/VirtualData/Jobs/VDJobUpdater.cs
+++ b/Scripts/Runtime/Data/VirtualData/Jobs/VDJobUpdater.cs
@@ -1,0 +1,121 @@
+using Anvil.Unity.DOTS.Jobs;
+using System;
+using Unity.Collections;
+using UnityEngine;
+
+namespace Anvil.Unity.DOTS.Data
+{
+    /// <summary>
+    /// A struct to be used in jobs that is for updating the <see cref="VirtualData{TKey,TInstance}"/>
+    /// that this <see cref="VDJobUpdater{TKey,TInstance}"/> represents.
+    ///
+    /// Commonly used to iterate through all instances, perform some work and either
+    /// <see cref="Continue(TInstance)"/> if more work needs to be done next frame or
+    /// <see cref="Complete"/> if the work is done.
+    /// </summary>
+    /// <typeparam name="TKey">The type of key to use for lookup of the instance</typeparam>
+    /// <typeparam name="TInstance">The type of instance</typeparam>
+    [BurstCompatible]
+    public struct VDJobUpdater<TKey, TInstance>
+        where TKey : struct, IEquatable<TKey>
+        where TInstance : struct, ILookupData<TKey>
+    {
+        private const int DEFAULT_LANE_INDEX = -1;
+
+        [ReadOnly] private readonly UnsafeTypedStream<TInstance>.Writer m_ContinueWriter;
+        [ReadOnly] private readonly NativeArray<TInstance> m_Iteration;
+
+        private UnsafeTypedStream<TInstance>.LaneWriter m_ContinueLaneWriter;
+
+#if ENABLE_UNITY_COLLECTIONS_CHECKS
+        private enum UpdaterState
+        {
+            Uninitialized,
+            Ready,
+            Modifying
+        }
+
+        private UpdaterState m_State;
+#endif
+
+        public int LaneIndex
+        {
+            get;
+            private set;
+        }
+
+        internal VDJobUpdater(UnsafeTypedStream<TInstance>.Writer continueWriter,
+                              NativeArray<TInstance> iteration)
+        {
+            m_ContinueWriter = continueWriter;
+            m_Iteration = iteration;
+
+            m_ContinueLaneWriter = default;
+            LaneIndex = DEFAULT_LANE_INDEX;
+
+#if ENABLE_UNITY_COLLECTIONS_CHECKS
+            m_State = UpdaterState.Uninitialized;
+#endif
+        }
+        
+        /// <summary>
+        /// Initializes the struct based on the thread it's being used on.
+        /// This must be called before doing anything else with the struct.
+        /// </summary>
+        /// <param name="nativeThreadIndex">The native thread index</param>
+        public void InitForThread(int nativeThreadIndex)
+        {
+#if ENABLE_UNITY_COLLECTIONS_CHECKS
+            Debug.Assert(m_State == UpdaterState.Uninitialized);
+            m_State = UpdaterState.Ready;
+#endif
+
+            LaneIndex = ParallelAccessUtil.CollectionIndexForThread(nativeThreadIndex);
+            m_ContinueLaneWriter = m_ContinueWriter.AsLaneWriter(LaneIndex);
+        }
+        
+        /// <summary>
+        /// Gets a <typeparamref name="TInstance"/> at the specified index.
+        /// </summary>
+        /// <param name="index">The index to the backing array</param>
+        public TInstance this[int index]
+        {
+            get
+            {
+#if ENABLE_UNITY_COLLECTIONS_CHECKS
+                Debug.Assert(m_State == UpdaterState.Ready);
+                m_State = UpdaterState.Modifying;
+#endif
+
+                return m_Iteration[index];
+            }
+        }
+        
+        /// <summary>
+        /// Signals that this instance should be updated again next frame.
+        /// </summary>
+        /// <param name="instance">The instance to continue</param>
+        public void Continue(TInstance instance)
+        {
+            Continue(ref instance);
+        }
+        
+        /// <inheritdoc cref="Continue(TInstance)"/>
+        public void Continue(ref TInstance instance)
+        {
+#if ENABLE_UNITY_COLLECTIONS_CHECKS
+            Debug.Assert(m_State == UpdaterState.Modifying);
+            m_State = UpdaterState.Ready;
+#endif
+            m_ContinueLaneWriter.Write(ref instance);
+        }
+
+        internal void Complete()
+        {
+#if ENABLE_UNITY_COLLECTIONS_CHECKS
+            Debug.Assert(m_State == UpdaterState.Modifying);
+            m_State = UpdaterState.Ready;
+#endif
+        }
+    }
+}

--- a/Scripts/Runtime/Data/VirtualData/Jobs/VDJobUpdater.cs.meta
+++ b/Scripts/Runtime/Data/VirtualData/Jobs/VDJobUpdater.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d2a6156deaa56448aa4ad48e937536b5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/Runtime/Data/VirtualData/Jobs/VDJobWriter.cs
+++ b/Scripts/Runtime/Data/VirtualData/Jobs/VDJobWriter.cs
@@ -1,0 +1,84 @@
+using Anvil.Unity.DOTS.Jobs;
+using Unity.Collections;
+using UnityEngine;
+
+namespace Anvil.Unity.DOTS.Data
+{
+    /// <summary>
+    /// A struct to be used in jobs that is for writing new <typeparamref name="TInstance"/> to
+    /// <see cref="VirtualData{TKey,TInstance}"/>.
+    ///
+    /// Commonly used to add new instances. 
+    /// </summary>
+    /// <typeparam name="TInstance">The type of instance to add</typeparam>
+    [BurstCompatible]
+    public struct VDJobWriter<TInstance>
+        where TInstance : struct
+    {
+        private const int DEFAULT_LANE_INDEX = -1;
+
+        [ReadOnly] private readonly UnsafeTypedStream<TInstance>.Writer m_InstanceWriter;
+
+        private UnsafeTypedStream<TInstance>.LaneWriter m_InstanceLaneWriter;
+        private int m_LaneIndex;
+
+#if ENABLE_UNITY_COLLECTIONS_CHECKS
+        private enum WriterState
+        {
+            Uninitialized,
+            Ready
+        }
+
+        private WriterState m_State;
+#endif
+
+
+        internal VDJobWriter(UnsafeTypedStream<TInstance>.Writer instanceWriter) : this()
+        {
+            m_InstanceWriter = instanceWriter;
+
+            m_InstanceLaneWriter = default;
+            m_LaneIndex = DEFAULT_LANE_INDEX;
+
+#if ENABLE_UNITY_COLLECTIONS_CHECKS
+            m_State = WriterState.Uninitialized;
+#endif
+        }
+        
+        /// <summary>
+        /// Initializes the struct based on the thread it's being used on.
+        /// This must be called before doing anything else with the struct.
+        /// </summary>
+        /// <param name="nativeThreadIndex">The native thread index</param>
+        public void InitForThread(int nativeThreadIndex)
+        {
+#if ENABLE_UNITY_COLLECTIONS_CHECKS
+            Debug.Assert(m_State == WriterState.Uninitialized);
+            m_State = WriterState.Ready;
+#endif
+
+            m_LaneIndex = ParallelAccessUtil.CollectionIndexForThread(nativeThreadIndex);
+            m_InstanceLaneWriter = m_InstanceWriter.AsLaneWriter(m_LaneIndex);
+        }
+        
+        /// <summary>
+        /// Adds the instance to the <see cref="VirtualData{TKey,TInstance}"/>'s
+        /// underlying pending collection to be added the next time the virtual data is
+        /// consolidated.
+        /// </summary>
+        /// <param name="instance">The instance to add</param>
+        public void Add(TInstance instance)
+        {
+            Add(ref instance);
+        }
+        
+        /// <inheritdoc cref="Add(TInstance)"/>
+        public void Add(ref TInstance instance)
+        {
+#if ENABLE_UNITY_COLLECTIONS_CHECKS
+            Debug.Assert(m_State == WriterState.Ready);
+#endif
+            m_InstanceLaneWriter.Write(ref instance);
+        }
+    }
+}

--- a/Scripts/Runtime/Data/VirtualData/Jobs/VDJobWriter.cs.meta
+++ b/Scripts/Runtime/Data/VirtualData/Jobs/VDJobWriter.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e7745fefe49dc4aa0b32c29d8d94ea9c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/Runtime/Data/VirtualData/VirtualData.cs
+++ b/Scripts/Runtime/Data/VirtualData/VirtualData.cs
@@ -1,0 +1,296 @@
+using Anvil.CSharp.Core;
+using Anvil.Unity.DOTS.Entities;
+using Anvil.Unity.DOTS.Jobs;
+using System;
+using System.Collections.Generic;
+using Unity.Burst;
+using Unity.Collections;
+using Unity.Collections.LowLevel.Unsafe;
+using Unity.Jobs;
+
+namespace Anvil.Unity.DOTS.Data
+{
+    /// <summary>
+    /// This class represents wrapped collections of data and manages them for use in Jobs.
+    /// </summary>
+    /// <remarks>
+    /// In Unity's ECS, data is stored on <see cref="Entity"/>'s via <see cref="IComponentBase"/> structs.
+    /// Unity's <see cref="SystemBase"/>'s handle the dependencies on the different sorts of data that are needed
+    /// for a given update call depending on the <see cref="EntityQuery"/>s used and Jobs scheduled.
+    ///
+    /// There are often cases where the overhead of using Entities doesn't make sense. The data is not persistent
+    /// and should exist for a period of time and then cease to exist. While this can be accomplished by Adding
+    /// or Removing Components from an Entity or spawning/destroying new entities with those components, it results
+    /// in a structural change which gets resolved at a sync point and happens on the main thread.
+    ///
+    /// Instead, using <see cref="VirtualData{TKey,TInstance}"/> can alleviate these issues while working in a similar
+    /// manner. Additional benefits are:
+    /// 
+    /// - Allowing for Shared Write
+    /// - - Multiple different jobs can write to the Pending collection at the same time.
+    /// - Fast reading via iteration or lookup
+    /// - The ability for instances of the data to write a result to different result destinations.
+    /// - - This gives implicit grouping of the data while still allowing for processing the overall set of data
+    ///     as one large set.
+    /// - - Getting access to writing to the results is handled automatically.
+    /// </remarks>
+    /// <typeparam name="TKey">The type of key to use to lookup data. Usually <see cref="Entity"/></typeparam>
+    /// <typeparam name="TInstance">The type of data to store</typeparam>
+    public class VirtualData<TKey, TInstance> : AbstractAnvilBase,
+                                                IVirtualData
+        where TKey : struct, IEquatable<TKey>
+        where TInstance : struct, ILookupData<TKey>
+    {
+        /// <summary>
+        /// The number of elements of <typeparamref name="TInstance"/> that can fit into a chunk (16kb)
+        /// This is useful for deciding on batch sizes.
+        /// </summary>
+        public static readonly int MAX_ELEMENTS_PER_CHUNK = ChunkUtil.MaxElementsPerChunk<TInstance>();
+
+        internal static VirtualData<TKey, TInstance> Create(params IVirtualData[] sources)
+        {
+            VirtualData<TKey, TInstance> virtualData = new VirtualData<TKey, TInstance>();
+
+            foreach (IVirtualData source in sources)
+            {
+                virtualData.AddSource(source);
+                source.AddResultDestination(virtualData);
+            }
+
+            return virtualData;
+        }
+
+        private readonly HashSet<IVirtualData> m_Sources = new HashSet<IVirtualData>();
+        private readonly HashSet<IVirtualData> m_ResultDestinations = new HashSet<IVirtualData>();
+        private readonly AccessController m_AccessController;
+
+        private UnsafeTypedStream<TInstance> m_Pending;
+        private DeferredNativeArray<TInstance> m_Iteration;
+        private UnsafeHashMap<TKey, TInstance> m_Lookup;
+
+        /// <summary>
+        /// The underlying <see cref="IDeferredNativeArray"/> used for scheduling
+        /// <see cref="IAnvilJobForDefer"/> or <see cref="IAnvilJobBatchDefer"/> jobs.
+        /// </summary>
+        public DeferredNativeArray<TInstance> ArrayForScheduling
+        {
+            get => m_Iteration;
+        }
+
+        AccessController IVirtualData.AccessController
+        {
+            get => m_AccessController;
+        }
+
+        private VirtualData()
+        {
+            m_AccessController = new AccessController();
+            m_Pending = new UnsafeTypedStream<TInstance>(Allocator.Persistent,
+                                                         Allocator.TempJob);
+            m_Iteration = new DeferredNativeArray<TInstance>(Allocator.Persistent,
+                                                             Allocator.TempJob);
+
+            m_Lookup = new UnsafeHashMap<TKey, TInstance>(MAX_ELEMENTS_PER_CHUNK, Allocator.Persistent);
+        }
+
+        protected override void DisposeSelf()
+        {
+            m_Pending.Dispose();
+            m_Iteration.Dispose();
+            m_Lookup.Dispose();
+
+            RemoveFromSources();
+            m_ResultDestinations.Clear();
+            m_Sources.Clear();
+
+            m_AccessController.Dispose();
+
+            base.DisposeSelf();
+        }
+
+        //*************************************************************************************************************
+        // SERIALIZATION
+        //*************************************************************************************************************
+
+        //TODO: Add Serialization and Deserialization functions to hook into our serialization framework
+
+        //*************************************************************************************************************
+        // RELATIONSHIPS
+        //*************************************************************************************************************
+
+        void IVirtualData.AddResultDestination(IVirtualData resultData)
+        {
+            AddResultDestination(resultData);
+        }
+
+        private void AddResultDestination(IVirtualData resultData)
+        {
+            m_ResultDestinations.Add(resultData);
+        }
+
+        void IVirtualData.RemoveResultDestination(IVirtualData resultData)
+        {
+            RemoveResultDestination(resultData);
+        }
+
+        private void RemoveResultDestination(IVirtualData resultData)
+        {
+            m_ResultDestinations.Remove(resultData);
+        }
+
+        private void AddSource(IVirtualData sourceData)
+        {
+            m_Sources.Add(sourceData);
+        }
+
+        private void RemoveSource(IVirtualData sourceData)
+        {
+            m_Sources.Remove(sourceData);
+        }
+
+        private void RemoveFromSources()
+        {
+            foreach (IVirtualData sourceData in m_Sources)
+            {
+                sourceData.RemoveResultDestination(this);
+            }
+        }
+
+        //*************************************************************************************************************
+        // ACCESS
+        //*************************************************************************************************************
+
+        JobHandle IVirtualData.AcquireForUpdate()
+        {
+            return AcquireForUpdate();
+        }
+
+        private JobHandle AcquireForUpdate()
+        {
+            JobHandle exclusiveWrite = m_AccessController.AcquireAsync(AccessType.ExclusiveWrite);
+
+            if (m_ResultDestinations.Count == 0)
+            {
+                return exclusiveWrite;
+            }
+
+            //Get write access to all possible channels that we can write a response to.
+            //+1 to include the exclusive write
+            NativeArray<JobHandle> allDependencies = new NativeArray<JobHandle>(m_ResultDestinations.Count + 1, Allocator.Temp);
+            allDependencies[0] = exclusiveWrite;
+            int index = 1;
+            foreach (IVirtualData destinationData in m_ResultDestinations)
+            {
+                allDependencies[index] = destinationData.AccessController.AcquireAsync(AccessType.SharedWrite);
+                index++;
+            }
+
+            return JobHandle.CombineDependencies(allDependencies);
+        }
+
+        void IVirtualData.ReleaseForUpdate(JobHandle releaseAccessDependency)
+        {
+            ReleaseForUpdate(releaseAccessDependency);
+        }
+
+        private void ReleaseForUpdate(JobHandle releaseAccessDependency)
+        {
+            m_AccessController.ReleaseAsync(releaseAccessDependency);
+
+            if (m_ResultDestinations.Count == 0)
+            {
+                return;
+            }
+
+            foreach (IVirtualData destinationData in m_ResultDestinations)
+            {
+                destinationData.AccessController.ReleaseAsync(releaseAccessDependency);
+            }
+        }
+
+        //*************************************************************************************************************
+        // JOB STRUCTS
+        //*************************************************************************************************************
+
+        internal VDJobReader<TInstance> CreateVDJobReader()
+        {
+            return new VDJobReader<TInstance>(m_Iteration.AsDeferredJobArray());
+        }
+
+        internal VDJobResultsDestination<TInstance> CreateVDJobResultsDestination()
+        {
+            return new VDJobResultsDestination<TInstance>(m_Pending.AsWriter());
+        }
+
+        internal VDJobUpdater<TKey, TInstance> CreateVDJobUpdater()
+        {
+            return new VDJobUpdater<TKey, TInstance>(m_Pending.AsWriter(),
+                                                     m_Iteration.AsDeferredJobArray(),
+                                                     m_Lookup);
+        }
+
+        internal VDJobWriter<TInstance> CreateVDJobWriter()
+        {
+            return new VDJobWriter<TInstance>(m_Pending.AsWriter());
+        }
+
+        //*************************************************************************************************************
+        // CONSOLIDATION
+        //*************************************************************************************************************
+
+        JobHandle IVirtualData.ConsolidateForFrame(JobHandle dependsOn)
+        {
+            return ConsolidateForFrame(dependsOn);
+        }
+
+        private JobHandle ConsolidateForFrame(JobHandle dependsOn)
+        {
+            JobHandle exclusiveWriteHandle = m_AccessController.AcquireAsync(AccessType.ExclusiveWrite);
+            ConsolidateLookupJob consolidateLookupJob = new ConsolidateLookupJob(m_Pending,
+                                                                                 m_Iteration,
+                                                                                 m_Lookup);
+            JobHandle consolidateHandle = consolidateLookupJob.Schedule(JobHandle.CombineDependencies(dependsOn, exclusiveWriteHandle));
+
+            m_AccessController.ReleaseAsync(consolidateHandle);
+
+            return consolidateHandle;
+        }
+
+        //*************************************************************************************************************
+        // JOBS
+        //*************************************************************************************************************
+
+        [BurstCompile]
+        private struct ConsolidateLookupJob : IJob
+        {
+            private UnsafeTypedStream<TInstance> m_Pending;
+            private DeferredNativeArray<TInstance> m_Iteration;
+            private UnsafeHashMap<TKey, TInstance> m_Lookup;
+
+            public ConsolidateLookupJob(UnsafeTypedStream<TInstance> pending,
+                                        DeferredNativeArray<TInstance> iteration,
+                                        UnsafeHashMap<TKey, TInstance> lookup)
+            {
+                m_Pending = pending;
+                m_Iteration = iteration;
+                m_Lookup = lookup;
+            }
+
+            public void Execute()
+            {
+                m_Lookup.Clear();
+                m_Iteration.Clear();
+
+                NativeArray<TInstance> iterationArray = m_Iteration.DeferredCreate(m_Pending.Count());
+                m_Pending.CopyTo(ref iterationArray);
+                m_Pending.Clear();
+
+                for (int i = 0; i < iterationArray.Length; ++i)
+                {
+                    TInstance value = iterationArray[i];
+                    m_Lookup.TryAdd(value.Key, value);
+                }
+            }
+        }
+    }
+}

--- a/Scripts/Runtime/Data/VirtualData/VirtualData.cs.meta
+++ b/Scripts/Runtime/Data/VirtualData/VirtualData.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8b0acc028c4ce403b9a10766fffefe7c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/Runtime/Data/VirtualData/VirtualDataExtensions.cs
+++ b/Scripts/Runtime/Data/VirtualData/VirtualDataExtensions.cs
@@ -1,0 +1,72 @@
+using System;
+
+namespace Anvil.Unity.DOTS.Data
+{
+    /// <summary>
+    /// Helper methods when working with <see cref="VirtualData{TKey,TInstance}"/>
+    /// These make it more clear what is happening when operating on <see cref="VirtualData{TKey,TInstance}"/> instances
+    /// in a job.
+    /// </summary>
+    public static class VirtualDataExtensions
+    {
+        /// <summary>
+        /// Writes a result struct to the <see cref="VDJobResultsDestination{TResult}"/> on a
+        /// <see cref="IVirtualDataInstance{TResult}"/>
+        /// </summary>
+        /// <param name="instance">The instance to correspond the result to</param>
+        /// <param name="result">The result struct to write</param>
+        /// <param name="jobUpdater">The <see cref="VDJobUpdater{TKey,TInstance}"/> the instance was from.</param>
+        /// <typeparam name="TKey">The type of key for the instance.</typeparam>
+        /// <typeparam name="TInstance">The type of the instance struct.</typeparam>
+        /// <typeparam name="TResult">The type of the result struct</typeparam>
+        public static void Complete<TKey, TInstance, TResult>(this TInstance instance, ref TResult result, ref VDJobUpdater<TKey, TInstance> jobUpdater)
+            where TKey : struct, IEquatable<TKey>
+            where TInstance : struct, ILookupData<TKey>, IVirtualDataInstance<TResult>
+            where TResult : struct
+        {
+            VDJobResultsWriter<TResult> resultsWriter = instance.ResultsDestination;
+            resultsWriter.Add(ref result, jobUpdater.LaneIndex);
+            jobUpdater.Complete();
+        }
+        
+        /// <inheritdoc cref="Complete{TKey,TInstance,TResult}"/>
+        public static void Complete<TKey, TInstance, TResult>(this TInstance instance, TResult result, ref VDJobUpdater<TKey, TInstance> jobUpdater)
+            where TKey : struct, IEquatable<TKey>
+            where TInstance : struct, ILookupData<TKey>, IVirtualDataInstance<TResult>
+            where TResult : struct
+        {
+            Complete(instance, ref result, ref jobUpdater);
+        }
+
+        /// <summary>
+        /// Consistency helper function to correspond to <see cref="Complete{TKey,TInstance,TResult}(TInstance,ref TResult,ref Anvil.Unity.DOTS.Data.VDJobUpdater{TKey,TInstance})"/>
+        /// when there is no result to write.
+        /// Allows for the code to look the same in the jobs and checks safeties when ENABLE_UNITY_COLLECTIONS_CHECKS is enabled.
+        /// </summary>
+        /// <param name="instance">The instance to operate on</param>
+        /// <param name="jobUpdater">The <see cref="VDJobUpdater{TKey,TInstance}"/> the instance was from.</param>
+        /// <typeparam name="TKey">The type of key for the instance.</typeparam>
+        /// <typeparam name="TInstance">The type of the instance struct.</typeparam>
+        public static void Complete<TKey, TInstance>(this TInstance instance, ref VDJobUpdater<TKey, TInstance> jobUpdater)
+            where TKey : struct, IEquatable<TKey>
+            where TInstance : struct, ILookupData<TKey>
+        {
+            jobUpdater.Complete();
+        }
+        
+        /// <summary>
+        /// Companion to <see cref="Complete{TKey,TInstance,TResult}(TInstance,ref TResult,ref Anvil.Unity.DOTS.Data.VDJobUpdater{TKey,TInstance})"/>
+        /// where the instance is not ready to write it's result and should be updated again the next frame.
+        /// </summary>
+        /// <param name="instance">The instance to update again next frame</param>
+        /// <param name="jobUpdater">The <see cref="VDJobUpdater{TKey,TInstance}"/> the instance was from.</param>
+        /// <typeparam name="TKey">The type of key for the instance.</typeparam>
+        /// <typeparam name="TInstance">The type of the instance struct.</typeparam>
+        public static void ContinueOn<TKey, TInstance>(this TInstance instance, ref VDJobUpdater<TKey, TInstance> jobUpdater)
+            where TKey : struct, IEquatable<TKey>
+            where TInstance : struct, ILookupData<TKey>
+        {
+            jobUpdater.Continue(ref instance);
+        }
+    }
+}

--- a/Scripts/Runtime/Data/VirtualData/VirtualDataExtensions.cs.meta
+++ b/Scripts/Runtime/Data/VirtualData/VirtualDataExtensions.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9ddd32b31355f428cb02912b1dcc1d9a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Virtual Data is an abstract way to represent data that doesn't have a persistent lifetime relative to an Entity. It is a good way to represent state and flowing through tasks.

**NOTE** On it's own, this PR doesn't add much for the developer because a lot of it is locked down via `internal`. This is intentional as `VirtualData` will be created and controlled via the upcoming PRs for `TaskDrivers`. However in the interest of smaller PR's this is a good chunk to look at.

### What is the current behaviour?

This doesn't exist today, you would have to manage collections manually and manage access to those collections manually as well.

### What is the new behaviour?

Nice wrapped behaviour to take care of
- Shared Writing to add new data
- Consolidated fast NativeArray for iteration reading
- Writing results to different result locations for implicit grouping of data for a context while still having the overall type of data be generically updated. 
    - Ex. All `Timers` can be updated together but completed to different locations depending who spawned them.

### What issues does this resolve?
- None

### What PRs does this depend on?
 - #36 and #35

### Does this introduce a breaking change?
 - [ ] Yes
 - [x] No
