### PR TITLE
Entities 0.51-preview.32 API updates

### DIFF
--- a/Scripts/Runtime/Data/VirtualData/VirtualData.cs
+++ b/Scripts/Runtime/Data/VirtualData/VirtualData.cs
@@ -68,7 +68,7 @@ namespace Anvil.Unity.DOTS.Data
 
         private UnsafeTypedStream<TInstance> m_Pending;
         private DeferredNativeArray<TInstance> m_IterationTarget;
-        private UnsafeHashMap<TKey, TInstance> m_Lookup;
+        private UnsafeParallelHashMap<TKey, TInstance> m_Lookup;
 
         AccessController IVirtualData.AccessController
         {
@@ -85,7 +85,7 @@ namespace Anvil.Unity.DOTS.Data
             m_IterationTarget = new DeferredNativeArray<TInstance>(Allocator.Persistent,
                                                                    Allocator.TempJob);
 
-            m_Lookup = new UnsafeHashMap<TKey, TInstance>(MAX_ELEMENTS_PER_CHUNK, Allocator.Persistent);
+            m_Lookup = new UnsafeParallelHashMap<TKey, TInstance>(MAX_ELEMENTS_PER_CHUNK, Allocator.Persistent);
         }
 
         protected override void DisposeSelf()
@@ -233,11 +233,11 @@ namespace Anvil.Unity.DOTS.Data
         {
             private UnsafeTypedStream<TInstance> m_Pending;
             private DeferredNativeArray<TInstance> m_Iteration;
-            private UnsafeHashMap<TKey, TInstance> m_Lookup;
+            private UnsafeParallelHashMap<TKey, TInstance> m_Lookup;
 
             public ConsolidateLookupJob(UnsafeTypedStream<TInstance> pending,
                                         DeferredNativeArray<TInstance> iteration,
-                                        UnsafeHashMap<TKey, TInstance> lookup)
+                                        UnsafeParallelHashMap<TKey, TInstance> lookup)
             {
                 m_Pending = pending;
                 m_Iteration = iteration;


### PR DESCRIPTION
This PR covers updates to the API that were made to be compatible with Entities 0.51-preview.32

### What is the current behaviour?
The library does not compile

### What is the new behaviour?
The library compiles

### What issues does this resolve?
None

### What PRs does this depend on?
 - None

### Does this introduce a breaking change?
 - [x] Yes - Update your project to Entities 0.51-preview.32
 - [ ] No
