### PR TITLE
Add root namespace to assembly definitions

### DIFF
--- a/Scripts/Editor/anvil-unity-dots-editor.asmdef
+++ b/Scripts/Editor/anvil-unity-dots-editor.asmdef
@@ -1,5 +1,6 @@
 {
     "name": "anvil-unity-dots-editor",
+    "rootNamespace": "Anvil.Unity.DOTS.Editor",
     "references": [
         "anvil-csharp-core",
         "anvil-unity-core-editor",

--- a/Scripts/Runtime/anvil-unity-dots-runtime.asmdef
+++ b/Scripts/Runtime/anvil-unity-dots-runtime.asmdef
@@ -1,5 +1,6 @@
 {
     "name": "anvil-unity-dots-runtime",
+    "rootNamespace": "Anvil.Unity.DOTS",
     "references": [
         "anvil-csharp-core",
         "anvil-unity-core-runtime",


### PR DESCRIPTION
Add root namespace to assembly definitions

### What is the current behaviour?
IDEs do not suggest correct name spaces because their root namespace value isn't being set in their CSProj files.

### What is the new behaviour?
IDEs do suggest the correct name spaces in anvil-unity-core.

Since Unity generates the CSProj files for each Assembly Definition the root namespace needs to be specified on the assembly definition.

### What issues does this resolve?
 - None

### What PRs does this depend on?
 - None

### Does this introduce a breaking change?
 - [ ] Yes <!-- If so, what are the migration considerations? -->
 - [x] No
