### PR TITLE
Component Referencable - Managed instances in ECS Component Data

### DIFF
--- a/Scripts/Runtime/Entities/ManagedReference.meta
+++ b/Scripts/Runtime/Entities/ManagedReference.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: b7f14298a54c40b6be60ce1b1d6dbc18
+timeCreated: 1657225192

--- a/Scripts/Runtime/Entities/ManagedReference/AbstractComponentReferencable.cs
+++ b/Scripts/Runtime/Entities/ManagedReference/AbstractComponentReferencable.cs
@@ -2,6 +2,10 @@ using Anvil.CSharp.Core;
 
 namespace Anvil.Unity.DOTS.Data
 {
+    /// <summary>
+    /// A convenient implementation of <see cref="IComponentReferencable"/> that automatically registers and
+    /// unregisters itself with <see cref="ManagedReferenceStore"/>.
+    /// </summary>
     public abstract class AbstractComponentReferencable : AbstractAnvilBase, IComponentReferencable
     {
         protected AbstractComponentReferencable()

--- a/Scripts/Runtime/Entities/ManagedReference/AbstractComponentReferencable.cs
+++ b/Scripts/Runtime/Entities/ManagedReference/AbstractComponentReferencable.cs
@@ -1,0 +1,19 @@
+using Anvil.CSharp.Core;
+
+namespace Anvil.Unity.DOTS.Data
+{
+    public abstract class AbstractComponentReferencable : AbstractAnvilBase, IComponentReferencable
+    {
+        protected AbstractComponentReferencable()
+        {
+            ManagedReferenceStore.RegisterReference(this);
+        }
+
+        protected override void DisposeSelf()
+        {
+            ManagedReferenceStore.UnregisterReference(this);
+
+            base.DisposeSelf();
+        }
+    }
+}

--- a/Scripts/Runtime/Entities/ManagedReference/AbstractComponentReferencable.cs
+++ b/Scripts/Runtime/Entities/ManagedReference/AbstractComponentReferencable.cs
@@ -1,6 +1,6 @@
 using Anvil.CSharp.Core;
 
-namespace Anvil.Unity.DOTS.Data
+namespace Anvil.Unity.DOTS.Entities
 {
     /// <summary>
     /// A convenient implementation of <see cref="IComponentReferencable"/> that automatically registers and

--- a/Scripts/Runtime/Entities/ManagedReference/AbstractComponentReferencable.cs.meta
+++ b/Scripts/Runtime/Entities/ManagedReference/AbstractComponentReferencable.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: d8c4c3a5ff3d46689d202e35f10acc36
+timeCreated: 1657225476

--- a/Scripts/Runtime/Entities/ManagedReference/IComponentReferencable.cs
+++ b/Scripts/Runtime/Entities/ManagedReference/IComponentReferencable.cs
@@ -1,4 +1,4 @@
-namespace Anvil.Unity.DOTS.Data
+namespace Anvil.Unity.DOTS.Entities
 {
     /// <summary>
     /// Identifies that a managed instance is registered to <see cref="ManagedReferenceStore"/> and can be represented

--- a/Scripts/Runtime/Entities/ManagedReference/IComponentReferencable.cs
+++ b/Scripts/Runtime/Entities/ManagedReference/IComponentReferencable.cs
@@ -1,0 +1,4 @@
+namespace Anvil.Unity.DOTS.Data
+{
+    public interface IComponentReferencable { }
+}

--- a/Scripts/Runtime/Entities/ManagedReference/IComponentReferencable.cs
+++ b/Scripts/Runtime/Entities/ManagedReference/IComponentReferencable.cs
@@ -1,4 +1,11 @@
 namespace Anvil.Unity.DOTS.Data
 {
+    /// <summary>
+    /// Identifies that a managed instance is registered to <see cref="ManagedReferenceStore"/> and can be represented
+    /// with a <see cref="ManagedReference{T}"/> using <see cref="IComponentReferencableExtension.AsComponentDataReference"/>.
+    /// </summary>
+    /// <remarks>
+    /// Either subclass <see cref="AbstractComponentReferencable"/> or reference its implementation for correct usage.
+    /// </remarks>
     public interface IComponentReferencable { }
 }

--- a/Scripts/Runtime/Entities/ManagedReference/IComponentReferencable.cs.meta
+++ b/Scripts/Runtime/Entities/ManagedReference/IComponentReferencable.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 0179157fcb10425ba67b1a6f2ba937a2
+timeCreated: 1657226936

--- a/Scripts/Runtime/Entities/ManagedReference/IComponentReferencableExtension.cs
+++ b/Scripts/Runtime/Entities/ManagedReference/IComponentReferencableExtension.cs
@@ -1,4 +1,4 @@
-namespace Anvil.Unity.DOTS.Data
+namespace Anvil.Unity.DOTS.Entities
 {
     /// <summary>
     /// A collection of methods to use with <see cref="IComponentReferencable"/> instances.

--- a/Scripts/Runtime/Entities/ManagedReference/IComponentReferencableExtension.cs
+++ b/Scripts/Runtime/Entities/ManagedReference/IComponentReferencableExtension.cs
@@ -1,0 +1,10 @@
+namespace Anvil.Unity.DOTS.Data
+{
+    public static class IComponentReferencableExtension
+    {
+        public static ManagedReference<T> AsComponentDataReference<T>(this T instance) where T : class, IComponentReferencable
+        {
+            return new ManagedReference<T>(instance);
+        }
+    }
+}

--- a/Scripts/Runtime/Entities/ManagedReference/IComponentReferencableExtension.cs
+++ b/Scripts/Runtime/Entities/ManagedReference/IComponentReferencableExtension.cs
@@ -1,7 +1,19 @@
 namespace Anvil.Unity.DOTS.Data
 {
+    /// <summary>
+    /// A collection of methods to use with <see cref="IComponentReferencable"/> instances.
+    /// </summary>
     public static class IComponentReferencableExtension
     {
+        /// <summary>
+        /// Creates a <see cref="ManagedReference{T}"/> from an <see cref="IComponentReferencable"/> instance.
+        /// Used to reference a managed instance in ECS.
+        /// </summary>
+        /// <param name="instance">The instance to reference.</param>
+        /// <typeparam name="T">The type of the instance.</typeparam>
+        /// <returns>
+        /// A <see cref="ManagedReference{T}"/> that references the <see cref="instance"/> provided.
+        /// </returns>
         public static ManagedReference<T> AsComponentDataReference<T>(this T instance) where T : class, IComponentReferencable
         {
             return new ManagedReference<T>(instance);

--- a/Scripts/Runtime/Entities/ManagedReference/IComponentReferencableExtension.cs.meta
+++ b/Scripts/Runtime/Entities/ManagedReference/IComponentReferencableExtension.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: aafe41ebeb3f4b178fff3a0bbb5736c6
+timeCreated: 1657225493

--- a/Scripts/Runtime/Entities/ManagedReference/ManagedReference.cs
+++ b/Scripts/Runtime/Entities/ManagedReference/ManagedReference.cs
@@ -1,4 +1,5 @@
 using Unity.Entities;
+using UnityEngine;
 
 namespace Anvil.Unity.DOTS.Entities
 {
@@ -9,7 +10,7 @@ namespace Anvil.Unity.DOTS.Entities
     /// <typeparam name="T">The type of the managed instance that is referenced.</typeparam>
     public readonly struct ManagedReference<T> : IComponentData where T : class, IComponentReferencable
     {
-        private readonly int m_ManagedContextHash;
+        private readonly uint m_ManagedReferenceID;
 
         /// <summary>
         /// Creates a new managed reference from an <see cref="IComponentReferencable"/> instance.
@@ -17,7 +18,11 @@ namespace Anvil.Unity.DOTS.Entities
         /// <param name="instance">The instance to hold reference too.</param>
         public ManagedReference(T instance)
         {
-            m_ManagedContextHash = ManagedReferenceStore.GetHash(instance);
+            m_ManagedReferenceID = ManagedReferenceStore.GetID(instance);
+
+            // Shouldn't ever happen but we want to know since there are equality checks that depend on the default
+            // instance being unique to any properly initialized instance.
+            Debug.Assert(!Equals(default(ManagedReference<T>)));
         }
 
         /// <summary>
@@ -26,7 +31,7 @@ namespace Anvil.Unity.DOTS.Entities
         /// <returns>The managed instance that this structure represents.</returns>
         public T Resolve()
         {
-            return ManagedReferenceStore.Get<T>(m_ManagedContextHash);
+            return ManagedReferenceStore.Get<T>(m_ManagedReferenceID);
         }
     }
 }

--- a/Scripts/Runtime/Entities/ManagedReference/ManagedReference.cs
+++ b/Scripts/Runtime/Entities/ManagedReference/ManagedReference.cs
@@ -2,15 +2,28 @@ using Unity.Entities;
 
 namespace Anvil.Unity.DOTS.Data
 {
+    /// <summary>
+    /// Holds reference to a managed instance that is registered with <see cref="ManagedReferenceStore"/> in a valid
+    /// <see cref="IComponentData"/> structure.
+    /// </summary>
+    /// <typeparam name="T">The type of the managed instance that is referenced.</typeparam>
     public readonly struct ManagedReference<T> : IComponentData where T : class, IComponentReferencable
     {
         private readonly int ManagedContextHash;
 
+        /// <summary>
+        /// Creates a new managed reference from an <see cref="IComponentReferencable"/> instance.
+        /// </summary>
+        /// <param name="instance">The instance to hold reference too.</param>
         public ManagedReference(T instance)
         {
             ManagedContextHash = ManagedReferenceStore.GetHash(instance);
         }
 
+        /// <summary>
+        /// Retrieve the managed instance from the <see cref="ManagedReference{T}"/>.
+        /// </summary>
+        /// <returns>The managed instance that this structure represents.</returns>
         public T Resolve()
         {
             return ManagedReferenceStore.Get<T>(ManagedContextHash);

--- a/Scripts/Runtime/Entities/ManagedReference/ManagedReference.cs
+++ b/Scripts/Runtime/Entities/ManagedReference/ManagedReference.cs
@@ -9,7 +9,7 @@ namespace Anvil.Unity.DOTS.Data
     /// <typeparam name="T">The type of the managed instance that is referenced.</typeparam>
     public readonly struct ManagedReference<T> : IComponentData where T : class, IComponentReferencable
     {
-        private readonly int ManagedContextHash;
+        private readonly int m_ManagedContextHash;
 
         /// <summary>
         /// Creates a new managed reference from an <see cref="IComponentReferencable"/> instance.
@@ -17,7 +17,7 @@ namespace Anvil.Unity.DOTS.Data
         /// <param name="instance">The instance to hold reference too.</param>
         public ManagedReference(T instance)
         {
-            ManagedContextHash = ManagedReferenceStore.GetHash(instance);
+            m_ManagedContextHash = ManagedReferenceStore.GetHash(instance);
         }
 
         /// <summary>
@@ -26,7 +26,7 @@ namespace Anvil.Unity.DOTS.Data
         /// <returns>The managed instance that this structure represents.</returns>
         public T Resolve()
         {
-            return ManagedReferenceStore.Get<T>(ManagedContextHash);
+            return ManagedReferenceStore.Get<T>(m_ManagedContextHash);
         }
     }
 }

--- a/Scripts/Runtime/Entities/ManagedReference/ManagedReference.cs
+++ b/Scripts/Runtime/Entities/ManagedReference/ManagedReference.cs
@@ -1,6 +1,6 @@
 using Unity.Entities;
 
-namespace Anvil.Unity.DOTS.Data
+namespace Anvil.Unity.DOTS.Entities
 {
     /// <summary>
     /// Holds reference to a managed instance that is registered with <see cref="ManagedReferenceStore"/> in a valid

--- a/Scripts/Runtime/Entities/ManagedReference/ManagedReference.cs
+++ b/Scripts/Runtime/Entities/ManagedReference/ManagedReference.cs
@@ -1,0 +1,19 @@
+using Unity.Entities;
+
+namespace Anvil.Unity.DOTS.Data
+{
+    public readonly struct ManagedReference<T> : IComponentData where T : class, IComponentReferencable
+    {
+        private readonly int ManagedContextHash;
+
+        public ManagedReference(T instance)
+        {
+            ManagedContextHash = ManagedReferenceStore.GetHash(instance);
+        }
+
+        public T Resolve()
+        {
+            return ManagedReferenceStore.Get<T>(ManagedContextHash);
+        }
+    }
+}

--- a/Scripts/Runtime/Entities/ManagedReference/ManagedReference.cs.meta
+++ b/Scripts/Runtime/Entities/ManagedReference/ManagedReference.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: d862b55df63a4943b54abfe1ca8db7b0
+timeCreated: 1657225462

--- a/Scripts/Runtime/Entities/ManagedReference/ManagedReferenceExtension.cs
+++ b/Scripts/Runtime/Entities/ManagedReference/ManagedReferenceExtension.cs
@@ -17,8 +17,20 @@ namespace Anvil.Unity.DOTS.Entities
         /// <param name="entityManager">The <see cref="EntityManager"/> for the <see cref="Entity"/>.</param>
         /// <param name="entity">The <see cref="Entity"/> to add the reference too.</param>
         /// <param name="instance">The instance to reference.</param>
+        /// <typeparam name="T">The type of the managed instance.</typeparam>
+        public static void AddManagedRefTo<T>(this EntityManager entityManager, Entity entity, T instance) where T : class, IComponentReferencable
+        {
+            entityManager.AddComponentData(entity, instance.AsComponentDataReference());
+        }
+
+        /// <summary>
+        /// Sets an <see cref="IComponentReferencable"/> instance reference on a provided <see cref="Entity"/>
+        /// </summary>
+        /// <param name="entityManager">The <see cref="EntityManager"/> for the <see cref="Entity"/>.</param>
+        /// <param name="entity">The <see cref="Entity"/> to set the reference on.</param>
+        /// <param name="instance">The instance to reference.</param>
         /// <param name="preventOverwrite">
-        /// (Default: true) When true the method will throw an exception if a <see cref="ManagedReference{T}"/> of the
+        /// (Default: false) When true the method will throw an exception if a <see cref="ManagedReference{T}"/> of the
         /// same type already exists on the entity.
         /// </param>
         /// <typeparam name="T">The type of the managed instance.</typeparam>
@@ -26,14 +38,14 @@ namespace Anvil.Unity.DOTS.Entities
         /// Thrown when <see cref="preventOverwrite"/> is true and a <see cref="ManagedReference{T}"/> of the same type
         /// already exists on the <see cref="Entity"/>.
         /// </exception>
-        public static void AddManagedRefTo<T>(this EntityManager entityManager, Entity entity, T instance, bool preventOverwrite = true) where T : class, IComponentReferencable
+        public static void SetManagedRefTo<T>(this EntityManager entityManager, Entity entity, T instance, bool preventOverwrite = false) where T : class, IComponentReferencable
         {
-            if(preventOverwrite && entityManager.HasComponent<ManagedReference<T>>(entity))
+            if(preventOverwrite && !entityManager.GetComponentData<ManagedReference<T>>(entity).Equals(default(ManagedReference<T>)))
             {
                 throw new InvalidOperationException($"Managed ref for {nameof(T)} already exists in {nameof(World)}:{entityManager.World.Name} on {nameof(Entity)}:{entity}. Set {nameof(preventOverwrite)} to false to allow overwriting.");
             }
 
-            entityManager.AddComponentData(entity, instance.AsComponentDataReference());
+            entityManager.SetComponentData(entity, instance.AsComponentDataReference());
         }
 
         /// <summary>

--- a/Scripts/Runtime/Entities/ManagedReference/ManagedReferenceExtension.cs
+++ b/Scripts/Runtime/Entities/ManagedReference/ManagedReferenceExtension.cs
@@ -31,5 +31,20 @@ namespace Anvil.Unity.DOTS.Entities
             ManagedReference<T> refComponent = entityManager.GetComponentData<ManagedReference<T>>(entity);
             Debug.Assert(refComponent.Resolve() == instance);
         }
+
+        public static void RequireManagedSingletonForUpdate<T>(this ComponentSystemBase system) where T : class, IComponentReferencable
+        {
+            system.RequireSingletonForUpdate<ManagedReference<T>>();
+        }
+
+        public static T GetManagedSingleton<T>(this ComponentSystemBase system) where T : class, IComponentReferencable
+        {
+            return system.GetSingleton<ManagedReference<T>>().Resolve();
+        }
+
+        public static bool HasManagedSingleton<T>(this ComponentSystemBase system) where T : class, IComponentReferencable
+        {
+            return system.HasSingleton<ManagedReference<T>>();
+        }
     }
 }

--- a/Scripts/Runtime/Entities/ManagedReference/ManagedReferenceExtension.cs
+++ b/Scripts/Runtime/Entities/ManagedReference/ManagedReferenceExtension.cs
@@ -6,8 +6,26 @@ using Debug = UnityEngine.Debug;
 
 namespace Anvil.Unity.DOTS.Entities
 {
+    /// <summary>
+    /// Extension methods that make interacting with <see cref="ManagedReference{T}"/> easier.
+    /// </summary>
     public static class ManagedReferenceExtension
     {
+        /// <summary>
+        /// Adds an <see cref="IComponentReferencable"/> instance reference to a provided <see cref="Entity"/>
+        /// </summary>
+        /// <param name="entityManager">The <see cref="EntityManager"/> for the <see cref="Entity"/>.</param>
+        /// <param name="entity">The <see cref="Entity"/> to add the reference too.</param>
+        /// <param name="instance">The instance to reference.</param>
+        /// <param name="preventOverwrite">
+        /// (Default: true) When true the method will throw an exception if a <see cref="ManagedReference{T}"/> of the
+        /// same type already exists on the entity.
+        /// </param>
+        /// <typeparam name="T">The type of the managed instance.</typeparam>
+        /// <exception cref="InvalidOperationException">
+        /// Thrown when <see cref="preventOverwrite"/> is true and a <see cref="ManagedReference{T}"/> of the same type
+        /// already exists on the <see cref="Entity"/>.
+        /// </exception>
         public static void AddManagedRefTo<T>(this EntityManager entityManager, Entity entity, T instance, bool preventOverwrite = true) where T : class, IComponentReferencable
         {
             if(preventOverwrite && entityManager.HasComponent<ManagedReference<T>>(entity))
@@ -18,6 +36,17 @@ namespace Anvil.Unity.DOTS.Entities
             entityManager.AddComponentData(entity, instance.AsComponentDataReference());
         }
 
+        /// <summary>
+        /// Removes an <see cref="IComponentReferencable"/> instance reference from a provided <see cref="Entity"/>
+        /// </summary>
+        /// <param name="entityManager">The <see cref="EntityManager"/> for the <see cref="Entity"/>.</param>
+        /// <param name="entity">The <see cref="Entity"/> to remove the reference from.</param>
+        /// <param name="instance">
+        /// The instance to remove.
+        /// Only used when DEBUG is enabled to verify the intended instance is the one being removed from the entity
+        /// since this method will remove any instance of the type <see cref="T"/> from the <see cref="Entity"/>.
+        /// </param>
+        /// <typeparam name="T">The type of the managed instance.</typeparam>
         public static void RemoveManagedRefFrom<T>(this EntityManager entityManager, Entity entity, T instance) where T : class, IComponentReferencable
         {
             DEBUG_AssertInstanceMatchesRef(entityManager, entity, instance);
@@ -32,16 +61,39 @@ namespace Anvil.Unity.DOTS.Entities
             Debug.Assert(refComponent.Resolve() == instance);
         }
 
+        /// <summary>
+        /// Requires that a singleton <see cref="IComponentReferencable"/> instance reference exists for a
+        /// <see cref="ComponentSystemBase"/> to update.
+        /// This is the <see cref="IComponentReferencable"/> equivalent of
+        /// <see cref="ComponentSystemBase.RequireSingletonForUpdate"/>.
+        /// </summary>
+        /// <param name="system">The system to add the requirement too.</param>
+        /// <typeparam name="T">The type of the managed instance.</typeparam>
         public static void RequireManagedSingletonForUpdate<T>(this ComponentSystemBase system) where T : class, IComponentReferencable
         {
             system.RequireSingletonForUpdate<ManagedReference<T>>();
         }
 
+        /// <summary>
+        /// Gets the singleton managed instance.
+        /// This is the <see cref="IComponentReferencable"/> equivalent of
+        /// <see cref="ComponentSystemBase.GetSingleton{T}"/>
+        /// </summary>
+        /// <param name="system">The system to query though.</param>
+        /// <typeparam name="T">The type of the managed instance.</typeparam>
+        /// <returns>The managed instance.</returns>
         public static T GetManagedSingleton<T>(this ComponentSystemBase system) where T : class, IComponentReferencable
         {
             return system.GetSingleton<ManagedReference<T>>().Resolve();
         }
 
+        /// <summary>
+        /// Checks whether a singleton component of the specified managed type exists.
+        /// This is the <see cref="IComponentReferencable"/> equivalent of <see cref="ComponentSystemBase.HasSingleton{T}"/>
+        /// </summary>
+        /// <param name="system">The system to query though.</param>
+        /// <typeparam name="T">The type of the managed instance.</typeparam>
+        /// <returns>True if a singleton of the managed type exists.</returns>
         public static bool HasManagedSingleton<T>(this ComponentSystemBase system) where T : class, IComponentReferencable
         {
             return system.HasSingleton<ManagedReference<T>>();

--- a/Scripts/Runtime/Entities/ManagedReference/ManagedReferenceExtension.cs
+++ b/Scripts/Runtime/Entities/ManagedReference/ManagedReferenceExtension.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Diagnostics;
+using Anvil.Unity.DOTS.Data;
+using Unity.Entities;
+using Debug = UnityEngine.Debug;
+
+namespace Anvil.Unity.DOTS.Entities
+{
+    public static class ManagedReferenceExtension
+    {
+        public static void AddManagedRefTo<T>(this EntityManager entityManager, Entity entity, T instance, bool preventOverwrite = true) where T : class, IComponentReferencable
+        {
+            if(preventOverwrite && entityManager.HasComponent<ManagedReference<T>>(entity))
+            {
+                throw new InvalidOperationException($"Managed ref for {nameof(T)} already exists in {nameof(World)}:{entityManager.World.Name} on {nameof(Entity)}:{entity}. Set {nameof(preventOverwrite)} to false to allow overwriting.");
+            }
+
+            entityManager.AddComponentData(entity, instance.AsComponentDataReference());
+        }
+
+        public static void RemoveManagedRefFrom<T>(this EntityManager entityManager, Entity entity, T instance) where T : class, IComponentReferencable
+        {
+            DEBUG_AssertInstanceMatchesRef(entityManager, entity, instance);
+            entityManager.RemoveComponent<ManagedReference<T>>(entity);
+        }
+
+        // Ensure that the instance that's been provided matches the one defined in the component ref on the entity
+        [Conditional("DEBUG")]
+        private static void DEBUG_AssertInstanceMatchesRef<T>(EntityManager entityManager, Entity entity, T instance) where T : class, IComponentReferencable
+        {
+            ManagedReference<T> refComponent = entityManager.GetComponentData<ManagedReference<T>>(entity);
+            Debug.Assert(refComponent.Resolve() == instance);
+        }
+    }
+}

--- a/Scripts/Runtime/Entities/ManagedReference/ManagedReferenceExtension.cs
+++ b/Scripts/Runtime/Entities/ManagedReference/ManagedReferenceExtension.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Diagnostics;
-using Anvil.Unity.DOTS.Data;
 using Unity.Entities;
 using Debug = UnityEngine.Debug;
 

--- a/Scripts/Runtime/Entities/ManagedReference/ManagedReferenceExtension.cs.meta
+++ b/Scripts/Runtime/Entities/ManagedReference/ManagedReferenceExtension.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 7b428109701b4db7a22babb14440cbf4
+timeCreated: 1657572096

--- a/Scripts/Runtime/Entities/ManagedReference/ManagedReferenceStore.cs
+++ b/Scripts/Runtime/Entities/ManagedReference/ManagedReferenceStore.cs
@@ -9,13 +9,13 @@ namespace Anvil.Unity.DOTS.Data
     /// </summary>
     public static class ManagedReferenceStore
     {
-        private static readonly Dictionary<int, IComponentReferencable> m_instances = new Dictionary<int, IComponentReferencable>();
+        private static readonly Dictionary<int, IComponentReferencable> m_Instances = new Dictionary<int, IComponentReferencable>();
 
 #if UNITY_EDITOR
         [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.SubsystemRegistration)]
         private static void Init()
         {
-            m_instances.Clear();
+            m_Instances.Clear();
         }
 #endif
 
@@ -27,7 +27,7 @@ namespace Anvil.Unity.DOTS.Data
         public static void RegisterReference(IComponentReferencable instance)
         {
             Debug.Assert(instance.GetType().IsClass, $"Implementations of {nameof(IComponentReferencable)} must be classes");
-            m_instances.Add(instance.GetHashCode(), instance);
+            m_Instances.Add(instance.GetHashCode(), instance);
         }
 
         /// <summary>
@@ -38,7 +38,7 @@ namespace Anvil.Unity.DOTS.Data
         /// <returns>True if the instance is successfully found and removed.</returns>
         public static bool UnregisterReference(IComponentReferencable instance)
         {
-            return m_instances.Remove(instance.GetHashCode());
+            return m_Instances.Remove(instance.GetHashCode());
         }
 
         /// <summary>
@@ -49,7 +49,7 @@ namespace Anvil.Unity.DOTS.Data
         internal static int GetHash(IComponentReferencable instance)
         {
             int hashCode = instance.GetHashCode();
-            Debug.Assert(m_instances.ContainsKey(hashCode),
+            Debug.Assert(m_Instances.ContainsKey(hashCode),
                 $"Instance is not yet registered with {nameof(ManagedReferenceStore)}. Make sure it is registering on creation and unregistering on disposal before using.");
 
             return hashCode;
@@ -66,7 +66,7 @@ namespace Anvil.Unity.DOTS.Data
         /// <returns>The managed instance.</returns>
         public static T Get<T>(int managedReferenceHash) where T : class, IComponentReferencable
         {
-            return (T)m_instances[managedReferenceHash];
+            return (T)m_Instances[managedReferenceHash];
         }
     }
 }

--- a/Scripts/Runtime/Entities/ManagedReference/ManagedReferenceStore.cs
+++ b/Scripts/Runtime/Entities/ManagedReference/ManagedReferenceStore.cs
@@ -1,21 +1,29 @@
 using System.Collections.Generic;
+using Anvil.CSharp.Data;
+using Anvil.CSharp.Logging;
 using UnityEngine;
+using Logger = Anvil.CSharp.Logging.Logger;
 
 namespace Anvil.Unity.DOTS.Entities
 {
     /// <summary>
-    /// A static store of all <see cref="IComponentReferencable"/> instances. Used to get instances by hash.
+    /// A static store of all <see cref="IComponentReferencable"/> instances. Used to get instances by ID.
     /// Used by <see cref="ManagedReference{T}"/>.
     /// </summary>
     public static class ManagedReferenceStore
     {
-        private static readonly Dictionary<int, IComponentReferencable> m_Instances = new Dictionary<int, IComponentReferencable>();
+        private static readonly Logger s_Logger = Log.GetStaticLogger(typeof(ManagedReferenceStore));
+        private static readonly Dictionary<uint, IComponentReferencable> s_IDToInstance = new Dictionary<uint, IComponentReferencable>();
+        private static readonly Dictionary<IComponentReferencable, uint> s_InstanceToID = new Dictionary<IComponentReferencable, uint>();
+        private static IDProvider s_IDProvider;
 
 #if UNITY_EDITOR
         [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.SubsystemRegistration)]
         private static void Init()
         {
-            m_Instances.Clear();
+            s_IDProvider = new IDProvider(uint.MaxValue - 1_000_000);
+            s_IDToInstance.Clear();
+            s_InstanceToID.Clear();
         }
 #endif
 
@@ -27,7 +35,14 @@ namespace Anvil.Unity.DOTS.Entities
         public static void RegisterReference(IComponentReferencable instance)
         {
             Debug.Assert(instance.GetType().IsClass, $"Implementations of {nameof(IComponentReferencable)} must be classes");
-            m_Instances.Add(instance.GetHashCode(), instance);
+
+            uint id = s_IDProvider.GetNextID();
+            if(!s_InstanceToID.TryAdd(instance, id))
+            {
+                s_Logger.Warning($"Instance already registered, ignoring. instance: {instance}");
+                return;
+            }
+            s_IDToInstance.Add(id, instance);
         }
 
         /// <summary>
@@ -38,35 +53,43 @@ namespace Anvil.Unity.DOTS.Entities
         /// <returns>True if the instance is successfully found and removed.</returns>
         public static bool UnregisterReference(IComponentReferencable instance)
         {
-            return m_Instances.Remove(instance.GetHashCode());
+            if (!s_InstanceToID.TryGetValue(instance, out uint id))
+            {
+                Debug.Assert(!s_IDToInstance.ContainsValue(instance));
+                return false;
+            }
+
+            Debug.Assert(s_IDToInstance.ContainsKey(id));
+            s_InstanceToID.Remove(instance);
+            s_IDToInstance.Remove(id);
+            return true;
         }
 
         /// <summary>
-        /// Gets the hash of an <see cref="IComponentReferencable"/> instance.
+        /// Gets the ID of an <see cref="IComponentReferencable"/> instance.
         /// </summary>
-        /// <param name="instance">The instance to get the hash of.</param>
-        /// <returns>The hash of the instance.</returns>
-        internal static int GetHash(IComponentReferencable instance)
+        /// <param name="instance">The instance to get the ID of.</param>
+        /// <returns>The ID of the instance.</returns>
+        internal static uint GetID(IComponentReferencable instance)
         {
-            int hashCode = instance.GetHashCode();
-            Debug.Assert(m_Instances.ContainsKey(hashCode),
+            Debug.Assert(s_InstanceToID.ContainsKey(instance),
                 $"Instance is not yet registered with {nameof(ManagedReferenceStore)}. Make sure it is registering on creation and unregistering on disposal before using.");
 
-            return hashCode;
+            return s_InstanceToID[instance];
         }
 
         /// <summary>
-        /// Get a managed instance by its hash.
+        /// Get a managed instance by its ID.
         /// </summary>
-        /// <param name="managedReferenceHash">
-        /// The hash of the managed instance.
+        /// <param name="id">
+        /// The ID of the managed instance.
         /// Usually provided by a <see cref="ManagedReference{T}"/>.
         /// </param>
         /// <typeparam name="T">The type of the managed instance.</typeparam>
         /// <returns>The managed instance.</returns>
-        public static T Get<T>(int managedReferenceHash) where T : class, IComponentReferencable
+        internal static T Get<T>(uint id) where T : class, IComponentReferencable
         {
-            return (T)m_Instances[managedReferenceHash];
+            return (T)s_IDToInstance[id];
         }
     }
 }

--- a/Scripts/Runtime/Entities/ManagedReference/ManagedReferenceStore.cs
+++ b/Scripts/Runtime/Entities/ManagedReference/ManagedReferenceStore.cs
@@ -1,0 +1,43 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace Anvil.Unity.DOTS.Data
+{
+    public static class ManagedReferenceStore
+    {
+        private static readonly Dictionary<int, IComponentReferencable> m_instances = new Dictionary<int, IComponentReferencable>();
+
+#if UNITY_EDITOR
+        [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.SubsystemRegistration)]
+        private static void Init()
+        {
+            m_instances.Clear();
+        }
+#endif
+
+        public static void RegisterReference(IComponentReferencable instance)
+        {
+            Debug.Assert(instance.GetType().IsClass, $"Implementations of {nameof(IComponentReferencable)} must be classes");
+            m_instances.Add(instance.GetHashCode(), instance);
+        }
+
+        public static bool UnregisterReference(IComponentReferencable instance)
+        {
+            return m_instances.Remove(instance.GetHashCode());
+        }
+
+        internal static int GetHash(IComponentReferencable instance)
+        {
+            int hashCode = instance.GetHashCode();
+            Debug.Assert(m_instances.ContainsKey(hashCode),
+                $"Instance is not yet registered with {nameof(ManagedReferenceStore)}. Make sure it is registering on creation and unregistering on disposal before using.");
+
+            return hashCode;
+        }
+
+        public static T Get<T>(int managedReferenceHash) where T : class, IComponentReferencable
+        {
+            return (T)m_instances[managedReferenceHash];
+        }
+    }
+}

--- a/Scripts/Runtime/Entities/ManagedReference/ManagedReferenceStore.cs
+++ b/Scripts/Runtime/Entities/ManagedReference/ManagedReferenceStore.cs
@@ -1,7 +1,7 @@
 using System.Collections.Generic;
 using UnityEngine;
 
-namespace Anvil.Unity.DOTS.Data
+namespace Anvil.Unity.DOTS.Entities
 {
     /// <summary>
     /// A static store of all <see cref="IComponentReferencable"/> instances. Used to get instances by hash.

--- a/Scripts/Runtime/Entities/ManagedReference/ManagedReferenceStore.cs
+++ b/Scripts/Runtime/Entities/ManagedReference/ManagedReferenceStore.cs
@@ -3,6 +3,10 @@ using UnityEngine;
 
 namespace Anvil.Unity.DOTS.Data
 {
+    /// <summary>
+    /// A static store of all <see cref="IComponentReferencable"/> instances. Used to get instances by hash.
+    /// Used by <see cref="ManagedReference{T}"/>.
+    /// </summary>
     public static class ManagedReferenceStore
     {
         private static readonly Dictionary<int, IComponentReferencable> m_instances = new Dictionary<int, IComponentReferencable>();
@@ -15,17 +19,33 @@ namespace Anvil.Unity.DOTS.Data
         }
 #endif
 
+        /// <summary>
+        /// Registers a managed instance so it can be resolved by a <see cref="ManagedReference{T}"/>.
+        /// This is usually called when the instance is created.
+        /// </summary>
+        /// <param name="instance">The instance to register.</param>
         public static void RegisterReference(IComponentReferencable instance)
         {
             Debug.Assert(instance.GetType().IsClass, $"Implementations of {nameof(IComponentReferencable)} must be classes");
             m_instances.Add(instance.GetHashCode(), instance);
         }
 
+        /// <summary>
+        /// Unregisters a managed instance.
+        /// This is usually called when the instance is destroyed.
+        /// </summary>
+        /// <param name="instance">The instance to unregister.</param>
+        /// <returns>True if the instance is successfully found and removed.</returns>
         public static bool UnregisterReference(IComponentReferencable instance)
         {
             return m_instances.Remove(instance.GetHashCode());
         }
 
+        /// <summary>
+        /// Gets the hash of an <see cref="IComponentReferencable"/> instance.
+        /// </summary>
+        /// <param name="instance">The instance to get the hash of.</param>
+        /// <returns>The hash of the instance.</returns>
         internal static int GetHash(IComponentReferencable instance)
         {
             int hashCode = instance.GetHashCode();
@@ -35,6 +55,15 @@ namespace Anvil.Unity.DOTS.Data
             return hashCode;
         }
 
+        /// <summary>
+        /// Get a managed instance by its hash.
+        /// </summary>
+        /// <param name="managedReferenceHash">
+        /// The hash of the managed instance.
+        /// Usually provided by a <see cref="ManagedReference{T}"/>.
+        /// </param>
+        /// <typeparam name="T">The type of the managed instance.</typeparam>
+        /// <returns>The managed instance.</returns>
         public static T Get<T>(int managedReferenceHash) where T : class, IComponentReferencable
         {
             return (T)m_instances[managedReferenceHash];

--- a/Scripts/Runtime/Entities/ManagedReference/ManagedReferenceStore.cs.meta
+++ b/Scripts/Runtime/Entities/ManagedReference/ManagedReferenceStore.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 5cff888de97940689da5f01f4bdb5c32
+timeCreated: 1657225123


### PR DESCRIPTION
This PR adds the ability to store a managed reference in an `IComponentData` container. Effectively allowing you to attach managed instances to entities.

### What is the current behaviour?
There is no convenient way to reference a managed instance in `IComponentData`. This is particularly painful when trying to interface between traditional OO code and ECS.

Existing approaches are:
 - Store managed references on a system (Ex: `AbstractDataSystem`) and have all systems query the system.
    - Can't easily associate instance with a particular entity
    - Instance doesn't travel with entities between worlds
    - Can't be referenced in jobs or burst compiled code.

 - Use Managed IComponentData
    - Not performant
    - Can't be referenced in jobs or burst compiled code.

 - Create a managed wrapper around an unsafe type
    - Pain to create and manage
    - Not useful for 3rd party instances that aren't written in this way.

### What is the new behaviour?
The Component Referencable feature allows developers to easily attach managed instance references to entities. The main pieces are:
 - `IComponentReferencable`/`AbstractComponentReferencable - Types that implement or subclass can be referenced by hashcode using a `ManagedReference<T>` instance 
 - `ManagedReferenceStore` - Maintains a map between hashcode and managed instance
 - `ManagedReference<T>` - Holds the hashcode of a managed instance it represents. This instance is `IComponentData` compatible and can be resolved into the managed instance it represents on the main thread.

##### Example usage
The most common current usage is to map a world scoped singleton to a managed instance.

**A managed instance:**
```csharp
public class MyWorldSingleton : AbstractComponentReferencable
{
   //.... any managed fields, properties, etc...
   // Just a normal IDisposable class
}
```


**Adding the instance**
```csharp
   // In some managed context
   EntityManager entityManager = myWorld.EntityManager;
   Entity entity = entityManager.CreateEntity();
   entityManager.AddManagedRefTo(entity, new MyWorldSingleton())
```


**A consuming system:**
```csharp
public partial class MySystem : SystemBase
{
   protected override void OnCreate()
   {
      base.OnCreate();

      this.RequireManagedSingletonForUpdate<MyWorldSingleton>();
   }

   protected override void OnUpdate()
   {
      MyWorldSingleton myWorldSingleton = this.GetManagedSingleton<MyWorldSingleton>();

      // Or if it's not a singleton...
      ManagedReference<MyWorldSingleton> myWorldSingletonRef = EntityManager.GetComponentData<ManagedReference<MyWorldSingleton>>(someEntity);
      MyWorldSingleton myWorldSingleton = myWorldSingletonRef.Resolve();
   }
}
```

However this feature could be used to:
 - Maintain a link between an OO version of a game actor and the ECS version.
 - Provide access to managed configuration data in a world.
 - Easily implement 

##### Benefits
 - `ManagedReference<T>` can be compared against other `ManagedReference<T>` in threaded and burst compiled code
    - Managed instance access can only done from main thread in non-burst code.
 - Can be associated with an Entity like any other `IComponentData`

### What issues does this resolve?
 - None

### What PRs does this depend on?
 - https://github.com/decline-cookies/anvil-csharp-core/pull/97

### Does this introduce a breaking change?
 - [ ] Yes <!-- If so, what are the migration considerations? -->
 - [x] No
