### PR TITLE
Fix Build Support

### DIFF
--- a/Scripts/Runtime/Entities/ManagedReference/ManagedReferenceStore.cs
+++ b/Scripts/Runtime/Entities/ManagedReference/ManagedReferenceStore.cs
@@ -12,12 +12,20 @@ namespace Anvil.Unity.DOTS.Entities
     /// </summary>
     public static class ManagedReferenceStore
     {
-        private static readonly Logger s_Logger = Log.GetStaticLogger(typeof(ManagedReferenceStore));
-        private static readonly Dictionary<uint, IComponentReferencable> s_IDToInstance = new Dictionary<uint, IComponentReferencable>();
-        private static readonly Dictionary<IComponentReferencable, uint> s_InstanceToID = new Dictionary<IComponentReferencable, uint>();
+        private static readonly Logger s_Logger;
+        private static readonly Dictionary<uint, IComponentReferencable> s_IDToInstance;
+        private static readonly Dictionary<IComponentReferencable, uint> s_InstanceToID;
         private static IDProvider s_IDProvider;
 
-#if UNITY_EDITOR
+        static ManagedReferenceStore()
+        {
+            s_Logger = Log.GetStaticLogger(typeof(ManagedReferenceStore));
+            s_IDToInstance = new Dictionary<uint, IComponentReferencable>();
+            s_InstanceToID = new Dictionary<IComponentReferencable, uint>();
+
+            Init();
+        }
+
         [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.SubsystemRegistration)]
         private static void Init()
         {
@@ -25,7 +33,6 @@ namespace Anvil.Unity.DOTS.Entities
             s_IDToInstance.Clear();
             s_InstanceToID.Clear();
         }
-#endif
 
         /// <summary>
         /// Registers a managed instance so it can be resolved by a <see cref="ManagedReference{T}"/>.

--- a/Scripts/Runtime/Entities/ManagedReference/ManagedReferenceStore.cs
+++ b/Scripts/Runtime/Entities/ManagedReference/ManagedReferenceStore.cs
@@ -22,11 +22,9 @@ namespace Anvil.Unity.DOTS.Entities
             s_Logger = Log.GetStaticLogger(typeof(ManagedReferenceStore));
             s_IDToInstance = new Dictionary<uint, IComponentReferencable>();
             s_InstanceToID = new Dictionary<IComponentReferencable, uint>();
-
-            Init();
         }
 
-        [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.SubsystemRegistration)]
+        [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.AfterAssembliesLoaded)]
         private static void Init()
         {
             s_IDProvider = new IDProvider(uint.MaxValue - 1_000_000);

--- a/Scripts/Runtime/Entities/Tasks/Data/AbstractTaskWorkConfig.cs
+++ b/Scripts/Runtime/Entities/Tasks/Data/AbstractTaskWorkConfig.cs
@@ -64,7 +64,7 @@ namespace Anvil.Unity.DOTS.Entities
             TaskWorkData.AddDataWrapper(dataWrapper);
             DataWrappers.Add(dataWrapper);
         }
-        
+
         protected void InternalRequireDataForAdd<TKey, TInstance>(VirtualData<TKey, TInstance> data, bool isAsync)
             where TKey : unmanaged, IEquatable<TKey>
             where TInstance : unmanaged, IKeyedData<TKey>
@@ -75,7 +75,7 @@ namespace Anvil.Unity.DOTS.Entities
             Debug_NotifyWorkDataOfUsage(wrapper.Type, isAsync ? DataUsage.AddAsync : DataUsage.Add);
 #endif
         }
-        
+
         protected void InternalRequireDataForIterate<TKey, TInstance>(VirtualData<TKey, TInstance> data, bool isAsync)
             where TKey : unmanaged, IEquatable<TKey>
             where TInstance : unmanaged, IKeyedData<TKey>
@@ -86,7 +86,7 @@ namespace Anvil.Unity.DOTS.Entities
             Debug_NotifyWorkDataOfUsage(wrapper.Type, isAsync ? DataUsage.IterateAsync : DataUsage.Iterate);
 #endif
         }
-        
+
         protected void InternalRequireDataForUpdate<TKey, TInstance>(VirtualData<TKey, TInstance> data, bool isAsync)
             where TKey : unmanaged, IEquatable<TKey>
             where TInstance : unmanaged, IKeyedData<TKey>
@@ -97,7 +97,7 @@ namespace Anvil.Unity.DOTS.Entities
             Debug_NotifyWorkDataOfUsage(wrapper.Type, isAsync ? DataUsage.UpdateAsync : DataUsage.Update);
 #endif
         }
-        
+
         protected void InternalRequireDataAsResultsDestination<TKey, TResult>(VirtualData<TKey, TResult> resultData, bool isAsync)
             where TKey : unmanaged, IEquatable<TKey>
             where TResult : unmanaged, IKeyedData<TKey>
@@ -116,14 +116,23 @@ namespace Anvil.Unity.DOTS.Entities
         [Conditional("ENABLE_UNITY_COLLECTIONS_CHECKS")]
         internal void Debug_SetConfigurationStateComplete()
         {
+// HACK: This shouldn't be required in addition to the `Conditional` attribute above but Unity's build system doesn't
+// seem to respect the attribute.
+#if ENABLE_UNITY_COLLECTIONS_CHECKS
             m_ConfigState = ConfigState.Executing;
+#endif
         }
 
+
+// HACK: This shouldn't be required in addition to the `Conditional` attribute above but Unity's build system doesn't
+// seem to respect the attribute.
 #if ENABLE_UNITY_COLLECTIONS_CHECKS
+        [Conditional("ENABLE_UNITY_COLLECTIONS_CHECKS")]
         private void Debug_NotifyWorkDataOfUsage(Type type, DataUsage usage)
         {
             TaskWorkData.Debug_NotifyWorkDataOfUsage(type, usage);
         }
 #endif
+
     }
 }

--- a/Scripts/Runtime/Jobs/Util/ParallelCollectionUtil.cs
+++ b/Scripts/Runtime/Jobs/Util/ParallelCollectionUtil.cs
@@ -90,12 +90,12 @@ namespace Anvil.Unity.DOTS.Jobs
         /// some value above <see cref="JobsUtility.JobWorkerMaximumCount"/>.
         /// 2. The scheduler may place your job on a profiler thread in the editor. In this case the native thread
         /// index will also be some value above <see cref="JobsUtility.JobWorkerMaximumCount"/>
-        /// It is unknown why this is. 
+        /// It is unknown why this is.
         ///
         /// Our goal is to have a tightly packed collection so in the example of an 8 core machine with
         /// <see cref="JobsUtility.JobWorkerMaximumCount"/> equal to 15, we would have the following mapping.
         ///
-        /// thread 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, X 
+        /// thread 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, X
         /// index  0, 1, 2, 3, 4, 5, 6, 7, 8, 9,  10, 11, 12, 13, 14, 15
         ///
         /// We have a tightly packed collection with index 0 through 15 for a total of 16 buckets.
@@ -111,9 +111,9 @@ namespace Anvil.Unity.DOTS.Jobs
             Debug.Assert(nativeThreadIndex > 0 && nativeThreadIndex <= JobsUtility.MaxJobThreadCount);
             return math.min(nativeThreadIndex - 1, JOB_WORKER_MAXIMUM_COUNT.Data);
         }
-        
+
         /// <summary>
-        /// Returns the index to use when operating on the main thread 
+        /// Returns the index to use when operating on the main thread
         /// </summary>
         /// <remarks>
         /// This function assumes that the collection being used was sized appropriately via
@@ -127,11 +127,16 @@ namespace Anvil.Unity.DOTS.Jobs
             return mainThreadIndex;
         }
 
-        [Conditional("ENABLE_UNITY_COLLECTIONS_CHECKS")]
+
         [BurstDiscard]
+        [Conditional("ENABLE_UNITY_COLLECTIONS_CHECKS")]
         private static void DetectMultipleXThreads(int nativeThreadIndex)
         {
+// HACK: This shouldn't be required in addition to the `Conditional` attribute above but Unity's build system doesn't
+// seem to respect the attribute.
+#if ENABLE_UNITY_COLLECTIONS_CHECKS
             ThreadHelper.DetectMultipleXThreads(nativeThreadIndex, CollectionSizeForMaxThreads);
+#endif
         }
 
     }


### PR DESCRIPTION
These changes allow projects using Anvil-DOTS to be exported to a build.

### What is the current behaviour?
Attempting to publish a build when Anvil-DOTS is referenced throws compiler errors.
 - Missing `#if ENABLE_UNITY_COLLECTIONS_CHECKS` guards around `DisposeSentinel` and `AtomicSafetyHandle` uses
 - Issues with the compiler correctly handling methods decorated with `[Conditional]` attributes referencing `#if` wrapped code (when they both reference the same `#define`).
 - Static logic that relies on `[RuntimeInitializeOnLoad]` code being executed fails.

### What is the new behaviour?
 - Add `#if ENABLE_UNITY_COLLECTIONS_CHECKS` guards around `SafetyHandlePtr`, `DisposeSentinel`, and `AtomicSafetyHandle` uses
 - Methods decorated with `[Conditional]` attributes have their logic referencing `#if` wrapped code now also have their logic `#if` wrapped.
    - This means that when this limitation is resolved by Unity we will automatically get the benefits of having the method removed. We can periodically go back and check if this limitation still exists and remove the new `#if` checks if it has been fixed.
 - Static logic that relies on `[RuntimeInitializeOnLoad]` now also has a static constructor that calls the same decorated `Init()` method.

### What issues does this resolve?
Ability to export a build that correctly functions.

### What PRs does this depend on?
 - None

### Does this introduce a breaking change?
 - [ ] Yes <!-- If so, what are the migration considerations? -->
 - [x] No
