### PR TITLE
Added support for CDFE Access

### DIFF
--- a/Scripts/Runtime/Entities/Tasks/Jobs/JobConfig/AbstractJobConfig.cs
+++ b/Scripts/Runtime/Entities/Tasks/Jobs/JobConfig/AbstractJobConfig.cs
@@ -235,6 +235,7 @@ namespace Anvil.Unity.DOTS.Entities.Tasks
         // CONFIGURATION - REQUIRED DATA - ComponentDataFromEntity (CDFE)
         //*************************************************************************************************************
 
+        /// <inheritdoc cref="IJobConfigRequirements.RequireCDFEForRead{T}"/>
         public IJobConfigRequirements RequireCDFEForRead<T>()
             where T : struct, IComponentData
         {
@@ -244,7 +245,8 @@ namespace Anvil.Unity.DOTS.Entities.Tasks
 
             return this;
         }
-
+        
+        /// <inheritdoc cref="IJobConfigRequirements.RequireCDFEForUpdate{T}"/>
         public IJobConfigRequirements RequireCDFEForUpdate<T>()
             where T : struct, IComponentData
         {
@@ -386,7 +388,7 @@ namespace Anvil.Unity.DOTS.Entities.Tasks
             CDFEAccessWrapper<T> cdfeAccessWrapper = (CDFEAccessWrapper<T>)m_AccessWrappers[id];
             return cdfeAccessWrapper.CreateCDFEReader();
         }
-        
+
         internal CDFEUpdater<T> GetCDFEUpdater<T>()
             where T : struct, IComponentData
         {

--- a/Scripts/Runtime/Entities/Tasks/Jobs/JobConfig/AbstractJobConfig.cs
+++ b/Scripts/Runtime/Entities/Tasks/Jobs/JobConfig/AbstractJobConfig.cs
@@ -22,21 +22,25 @@ namespace Anvil.Unity.DOTS.Entities.Tasks
             /// Represents an Exclusive Write lock on the underlying data.
             /// </summary>
             Update,
+
             /// <summary>
             /// The data is being written to.
             /// Represents a Shared Write lock on the underlying data.
             /// </summary>
             Write,
+
             /// <summary>
             /// The data is being read from.
             /// Represents a Shared Read lock on the underlying data.
             /// </summary>
             Read,
+
             /// <summary>
             /// The special id data is being written to so specific instances can be cancelled.
             /// Represents a Shared Write lock on the underlying data.
             /// </summary>
             WritePendingCancel,
+
             /// <summary>
             /// The data is being Cancelled. It will either continue to be processed again the next frame or be
             /// resolved into a resolve target <see cref="TaskStream{TInstance}"/>
@@ -44,6 +48,7 @@ namespace Anvil.Unity.DOTS.Entities.Tasks
             /// Similar to <see cref="Update"/> but operates only on instances that have been cancelled.
             /// </summary>
             Cancelling,
+
             /// <summary>
             /// The data is being written to a resolve target <see cref="TaskStream{TInstance}"/>.
             /// Represents a Shared Write lock on the underlying data.
@@ -62,7 +67,7 @@ namespace Anvil.Unity.DOTS.Entities.Tasks
         private AbstractScheduleInfo m_ScheduleInfo;
         private bool m_ShouldDisableAfterNextRun;
         private bool m_IsHardened;
-        
+
         /// <inheritdoc cref="IJobConfig.IsEnabled"/>
         public bool IsEnabled
         {
@@ -124,7 +129,7 @@ namespace Anvil.Unity.DOTS.Entities.Tasks
         //*************************************************************************************************************
         // CONFIGURATION - COMMON
         //*************************************************************************************************************
-        
+
         /// <inheritdoc cref="IJobConfig.RunOnce"/>
         public IJobConfig RunOnce()
         {
@@ -142,14 +147,14 @@ namespace Anvil.Unity.DOTS.Entities.Tasks
         //*************************************************************************************************************
         // CONFIGURATION - REQUIRED DATA - DATA STREAM
         //*************************************************************************************************************
-        
+
         /// <inheritdoc cref="IJobConfigRequirements.RequireTaskStreamForWrite{TInstance}"/>
         public IJobConfigRequirements RequireTaskStreamForWrite<TInstance>(TaskStream<TInstance> taskStream)
             where TInstance : unmanaged, IEntityProxyInstance
         {
             return RequireDataStreamForWrite(taskStream.DataStream, Usage.Write);
         }
-        
+
         /// <inheritdoc cref="IJobConfigRequirements.RequireTaskStreamForRead{TInstance}"/>
         public IJobConfigRequirements RequireTaskStreamForRead<TInstance>(TaskStream<TInstance> taskStream)
             where TInstance : unmanaged, IEntityProxyInstance
@@ -159,7 +164,7 @@ namespace Anvil.Unity.DOTS.Entities.Tasks
 
             return this;
         }
-        
+
         /// <inheritdoc cref="IJobConfigRequirements.RequireTaskDriverForRequestCancel"/>
         public IJobConfigRequirements RequireTaskDriverForRequestCancel(AbstractTaskDriver taskDriver)
         {
@@ -180,7 +185,7 @@ namespace Anvil.Unity.DOTS.Entities.Tasks
         //*************************************************************************************************************
         // CONFIGURATION - REQUIRED DATA - NATIVE ARRAY
         //*************************************************************************************************************
-        
+
         /// <inheritdoc cref="IJobConfigRequirements.RequireNativeArrayForRead{T}"/>
         public IJobConfigRequirements RequireNativeArrayForRead<T>(NativeArray<T> array)
             where T : struct
@@ -193,13 +198,13 @@ namespace Anvil.Unity.DOTS.Entities.Tasks
         //*************************************************************************************************************
         // CONFIGURATION - REQUIRED DATA - ENTITY QUERY
         //*************************************************************************************************************
-        
+
         /// <inheritdoc cref="IJobConfigRequirements.RequireEntityNativeArrayFromQueryForRead"/>
         public IJobConfigRequirements RequireEntityNativeArrayFromQueryForRead(EntityQuery entityQuery)
         {
             return RequireEntityNativeArrayFromQueryForRead(new EntityQueryNativeArray(entityQuery));
         }
-        
+
         /// <inheritdoc cref="IJobConfigRequirements.RequireIComponentDataNativeArrayFromQueryForRead{T}"/>
         public IJobConfigRequirements RequireIComponentDataNativeArrayFromQueryForRead<T>(EntityQuery entityQuery)
             where T : struct, IComponentData
@@ -227,6 +232,30 @@ namespace Anvil.Unity.DOTS.Entities.Tasks
         }
 
         //*************************************************************************************************************
+        // CONFIGURATION - REQUIRED DATA - ComponentDataFromEntity (CDFE)
+        //*************************************************************************************************************
+
+        public IJobConfigRequirements RequireCDFEForRead<T>()
+            where T : struct, IComponentData
+        {
+            CDFEAccessWrapper<T> wrapper = new CDFEAccessWrapper<T>(AccessType.SharedRead, TaskSystem);
+            AddAccessWrapper(new JobConfigDataID(typeof(CDFEAccessWrapper<T>.CDFEType), Usage.Read),
+                             wrapper);
+
+            return this;
+        }
+
+        public IJobConfigRequirements RequireCDFEForUpdate<T>()
+            where T : struct, IComponentData
+        {
+            CDFEAccessWrapper<T> wrapper = new CDFEAccessWrapper<T>(AccessType.SharedWrite, TaskSystem);
+            AddAccessWrapper(new JobConfigDataID(typeof(CDFEAccessWrapper<T>.CDFEType), Usage.Update),
+                             wrapper);
+
+            return this;
+        }
+
+        //*************************************************************************************************************
         // HARDEN
         //*************************************************************************************************************
 
@@ -234,10 +263,10 @@ namespace Anvil.Unity.DOTS.Entities.Tasks
         {
             //During Hardening we can optimize by pre-allocating native arrays for dependency combining and convert
             //dictionary iterations into lists. We also allow for sub classes to do their own optimizing if needed.
-            
+
             Debug_EnsureNotHardened();
             m_IsHardened = true;
-            
+
             foreach (AbstractAccessWrapper wrapper in m_AccessWrappers.Values)
             {
                 m_SchedulingAccessWrappers.Add(wrapper);
@@ -262,7 +291,7 @@ namespace Anvil.Unity.DOTS.Entities.Tasks
             //will read from or write to and combine them into one to actually schedule the job with Unity's job 
             //system. The resulting handle from that job is then fed back to each piece of data to allow Unity's
             //dependency system to know when it's safe to use the data again.
-            
+
             Debug_EnsureScheduleInfoExists();
 
             if (!IsEnabled)
@@ -349,6 +378,24 @@ namespace Anvil.Unity.DOTS.Entities.Tasks
             return entityQueryAccessWrapper.NativeArray;
         }
 
+        internal CDFEReader<T> GetCDFEReader<T>()
+            where T : struct, IComponentData
+        {
+            JobConfigDataID id = new JobConfigDataID(typeof(CDFEAccessWrapper<T>.CDFEType), Usage.Read);
+            Debug_EnsureWrapperExists(id);
+            CDFEAccessWrapper<T> cdfeAccessWrapper = (CDFEAccessWrapper<T>)m_AccessWrappers[id];
+            return cdfeAccessWrapper.CreateCDFEReader();
+        }
+        
+        internal CDFEUpdater<T> GetCDFEUpdater<T>()
+            where T : struct, IComponentData
+        {
+            JobConfigDataID id = new JobConfigDataID(typeof(CDFEAccessWrapper<T>.CDFEType), Usage.Update);
+            Debug_EnsureWrapperExists(id);
+            CDFEAccessWrapper<T> cdfeAccessWrapper = (CDFEAccessWrapper<T>)m_AccessWrappers[id];
+            return cdfeAccessWrapper.CreateCDFEUpdater();
+        }
+
         //*************************************************************************************************************
         // SAFETY
         //*************************************************************************************************************
@@ -361,7 +408,7 @@ namespace Anvil.Unity.DOTS.Entities.Tasks
                 throw new InvalidOperationException($"{this} is not hardened yet!");
             }
         }
-        
+
         [Conditional("ENABLE_UNITY_COLLECTIONS_CHECKS")]
         private void Debug_EnsureNotHardened()
         {

--- a/Scripts/Runtime/Entities/Tasks/Jobs/JobConfig/Interfaces/IJobConfigRequirements.cs
+++ b/Scripts/Runtime/Entities/Tasks/Jobs/JobConfig/Interfaces/IJobConfigRequirements.cs
@@ -86,10 +86,21 @@ namespace Anvil.Unity.DOTS.Entities.Tasks
         /// <param name="taskDriver">The <see cref="AbstractTaskDriver"/> to allow for cancelling</param>
         /// <returns>Reference to itself to continue chaining configuration methods</returns>
         public IJobConfigRequirements RequireTaskDriverForRequestCancel(AbstractTaskDriver taskDriver);
-
+        
+        /// <summary>
+        /// Specifies a <see cref="ComponentDataFromEntity{T}"/> to be read from in a shared-read context.
+        /// </summary>
+        /// <typeparam name="T">The type of <see cref="IComponentData"/> in the CDFE</typeparam>
+        /// <returns>Reference to itself to continue chaining configuration methods</returns>
         public IJobConfigRequirements RequireCDFEForRead<T>()
             where T : struct, IComponentData;
 
+        /// <summary>
+        /// Specifies a <see cref="ComponentDataFromEntity{T}"/> to be read from in a shared-write context.
+        /// Note that it can also be read at the same time.
+        /// </summary>
+        /// <typeparam name="T">The type of <see cref="IComponentData"/> in the CDFE</typeparam>
+        /// <returns>Reference to itself to continue chaining configuration methods</returns>
         public IJobConfigRequirements RequireCDFEForUpdate<T>()
             where T : struct, IComponentData;
     }

--- a/Scripts/Runtime/Entities/Tasks/Jobs/JobConfig/Interfaces/IJobConfigRequirements.cs
+++ b/Scripts/Runtime/Entities/Tasks/Jobs/JobConfig/Interfaces/IJobConfigRequirements.cs
@@ -86,5 +86,11 @@ namespace Anvil.Unity.DOTS.Entities.Tasks
         /// <param name="taskDriver">The <see cref="AbstractTaskDriver"/> to allow for cancelling</param>
         /// <returns>Reference to itself to continue chaining configuration methods</returns>
         public IJobConfigRequirements RequireTaskDriverForRequestCancel(AbstractTaskDriver taskDriver);
+
+        public IJobConfigRequirements RequireCDFEForRead<T>()
+            where T : struct, IComponentData;
+
+        public IJobConfigRequirements RequireCDFEForUpdate<T>()
+            where T : struct, IComponentData;
     }
 }

--- a/Scripts/Runtime/Entities/Tasks/Jobs/JobData/AbstractJobData.cs
+++ b/Scripts/Runtime/Entities/Tasks/Jobs/JobData/AbstractJobData.cs
@@ -118,5 +118,21 @@ namespace Anvil.Unity.DOTS.Entities.Tasks
         {
             return m_JobConfig.GetIComponentDataNativeArrayFromQuery<T>(AbstractJobConfig.Usage.Read);
         }
+        
+        //*************************************************************************************************************
+        // CDFE
+        //*************************************************************************************************************
+
+        public CDFEReader<T> GetCDFEReader<T>()
+            where T : struct, IComponentData
+        {
+            return m_JobConfig.GetCDFEReader<T>();
+        }
+
+        public CDFEUpdater<T> GetCDFEUpdater<T>()
+            where T : struct, IComponentData
+        {
+            return m_JobConfig.GetCDFEUpdater<T>();
+        }
     }
 }

--- a/Scripts/Runtime/Entities/Tasks/Jobs/JobData/AbstractJobData.cs
+++ b/Scripts/Runtime/Entities/Tasks/Jobs/JobData/AbstractJobData.cs
@@ -122,13 +122,23 @@ namespace Anvil.Unity.DOTS.Entities.Tasks
         //*************************************************************************************************************
         // CDFE
         //*************************************************************************************************************
-
+        
+        /// <summary>
+        /// Gets a <see cref="ComponentDataFromEntity{T}"/> to read from in a job.
+        /// </summary>
+        /// <typeparam name="T">The type of <see cref="IComponentData"/> in the CDFE</typeparam>
+        /// <returns>The <see cref="GetCDFEReader{T}"/></returns>
         public CDFEReader<T> GetCDFEReader<T>()
             where T : struct, IComponentData
         {
             return m_JobConfig.GetCDFEReader<T>();
         }
-
+    
+        /// <summary>
+        /// Gets a <see cref="ComponentDataFromEntity{T}"/> to read from and write to in a job.
+        /// </summary>
+        /// <typeparam name="T">The type of <see cref="IComponentData"/> in the CDFE</typeparam>
+        /// <returns>The <see cref="GetCDFEUpdater{T}"/></returns>
         public CDFEUpdater<T> GetCDFEUpdater<T>()
             where T : struct, IComponentData
         {

--- a/Scripts/Runtime/Entities/Tasks/Jobs/Wrapper/CDFEAccessWrapper.cs
+++ b/Scripts/Runtime/Entities/Tasks/Jobs/Wrapper/CDFEAccessWrapper.cs
@@ -1,0 +1,42 @@
+using Anvil.Unity.DOTS.Jobs;
+using Unity.Entities;
+using Unity.Jobs;
+
+namespace Anvil.Unity.DOTS.Entities.Tasks
+{
+    internal class CDFEAccessWrapper<T> : AbstractAccessWrapper
+        where T : struct, IComponentData
+    {
+        private readonly SystemBase m_System;
+        
+        internal class CDFEType
+        {
+        }
+
+        public CDFEAccessWrapper(AccessType accessType, SystemBase system) : base(accessType)
+        {
+            m_System = system;
+        }
+
+        public CDFEReader<T> CreateCDFEReader()
+        {
+            return new CDFEReader<T>(m_System);
+        }
+
+        public CDFEUpdater<T> CreateCDFEUpdater()
+        {
+            return new CDFEUpdater<T>(m_System);
+        }
+
+        public override JobHandle Acquire()
+        {
+            //Do nothing, Unity's System will handle dependencies for us
+            return default;
+        }
+
+        public override void Release(JobHandle releaseAccessDependency)
+        {
+            //Do nothing - Unity's System will handle dependencies for us
+        }
+    }
+}

--- a/Scripts/Runtime/Entities/Tasks/Jobs/Wrapper/CDFEAccessWrapper.cs.meta
+++ b/Scripts/Runtime/Entities/Tasks/Jobs/Wrapper/CDFEAccessWrapper.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: bd02917b10134bdbab2353d664642b06
+timeCreated: 1665064800

--- a/Scripts/Runtime/Entities/Tasks/TaskStream/JobDataInteraction/CDFEReader.cs
+++ b/Scripts/Runtime/Entities/Tasks/TaskStream/JobDataInteraction/CDFEReader.cs
@@ -3,8 +3,13 @@ using Unity.Entities;
 
 namespace Anvil.Unity.DOTS.Entities.Tasks
 {
+    /// <summary>
+    /// Represents a read only reference to a <see cref="ComponentDataFromEntity{T}"/>
+    /// To be used in jobs that only allows for reading of this data.
+    /// </summary>
+    /// <typeparam name="T">The type of <see cref="IComponentData"/> to read</typeparam>
     [BurstCompatible]
-    public struct CDFEReader<T>
+    public readonly struct CDFEReader<T>
         where T : struct, IComponentData
     {
         [ReadOnly] private readonly ComponentDataFromEntity<T> m_CDFE;
@@ -13,7 +18,11 @@ namespace Anvil.Unity.DOTS.Entities.Tasks
         {
             m_CDFE = system.GetComponentDataFromEntity<T>(true);
         }
-
+        
+        /// <summary>
+        /// Gets the <typeparamref name="T"/> that corresponds to the passed <see cref="Entity"/>
+        /// </summary>
+        /// <param name="entity">The <see cref="Entity"/> to lookup the data</param>
         public T this[Entity entity]
         {
             get => m_CDFE[entity];

--- a/Scripts/Runtime/Entities/Tasks/TaskStream/JobDataInteraction/CDFEReader.cs
+++ b/Scripts/Runtime/Entities/Tasks/TaskStream/JobDataInteraction/CDFEReader.cs
@@ -1,0 +1,22 @@
+using Unity.Collections;
+using Unity.Entities;
+
+namespace Anvil.Unity.DOTS.Entities.Tasks
+{
+    [BurstCompatible]
+    public struct CDFEReader<T>
+        where T : struct, IComponentData
+    {
+        [ReadOnly] private readonly ComponentDataFromEntity<T> m_CDFE;
+
+        internal CDFEReader(SystemBase system)
+        {
+            m_CDFE = system.GetComponentDataFromEntity<T>(true);
+        }
+
+        public T this[Entity entity]
+        {
+            get => m_CDFE[entity];
+        }
+    }
+}

--- a/Scripts/Runtime/Entities/Tasks/TaskStream/JobDataInteraction/CDFEReader.cs.meta
+++ b/Scripts/Runtime/Entities/Tasks/TaskStream/JobDataInteraction/CDFEReader.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: bd8fd28a9c6547ecb653ad4a50e40f58
+timeCreated: 1665064415

--- a/Scripts/Runtime/Entities/Tasks/TaskStream/JobDataInteraction/CDFEUpdater.cs
+++ b/Scripts/Runtime/Entities/Tasks/TaskStream/JobDataInteraction/CDFEUpdater.cs
@@ -3,6 +3,12 @@ using Unity.Entities;
 
 namespace Anvil.Unity.DOTS.Entities.Tasks
 {
+    /// <summary>
+    /// Represents a <see cref="ComponentDataFromEntity{T}"/> that can be read from and written to in
+    /// parallel. It sets the <see cref="NativeDisableParallelForRestrictionAttribute"/> on the CDFE.
+    /// To be used in jobs that allow for updating a specific instance in the CDFE.
+    /// </summary>
+    /// <typeparam name="T">The type of <see cref="IComponentData"/> to update.</typeparam>
     [BurstCompatible]
     public struct CDFEUpdater<T>
         where T : struct, IComponentData
@@ -13,7 +19,11 @@ namespace Anvil.Unity.DOTS.Entities.Tasks
         {
             m_CDFE = system.GetComponentDataFromEntity<T>(false);
         }
-
+        
+        /// <summary>
+        /// Gets/Sets the <typeparamref name="T"/> that corresponds to the passed <see cref="Entity"/>
+        /// </summary>
+        /// <param name="entity">The <see cref="Entity"/> to lookup the data</param>
         public T this[Entity entity]
         {
             get => m_CDFE[entity];

--- a/Scripts/Runtime/Entities/Tasks/TaskStream/JobDataInteraction/CDFEUpdater.cs
+++ b/Scripts/Runtime/Entities/Tasks/TaskStream/JobDataInteraction/CDFEUpdater.cs
@@ -1,0 +1,23 @@
+using Unity.Collections;
+using Unity.Entities;
+
+namespace Anvil.Unity.DOTS.Entities.Tasks
+{
+    [BurstCompatible]
+    public struct CDFEUpdater<T>
+        where T : struct, IComponentData
+    {
+        [NativeDisableParallelForRestriction] private ComponentDataFromEntity<T> m_CDFE;
+
+        internal CDFEUpdater(SystemBase system)
+        {
+            m_CDFE = system.GetComponentDataFromEntity<T>(false);
+        }
+
+        public T this[Entity entity]
+        {
+            get => m_CDFE[entity];
+            set => m_CDFE[entity] = value;
+        }
+    }
+}

--- a/Scripts/Runtime/Entities/Tasks/TaskStream/JobDataInteraction/CDFEUpdater.cs.meta
+++ b/Scripts/Runtime/Entities/Tasks/TaskStream/JobDataInteraction/CDFEUpdater.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: c50809844d604e2a85f3cc735dc2b59f
+timeCreated: 1665064567

--- a/Scripts/Runtime/Entities/Tasks/Util/ResolveTargetUtil.cs
+++ b/Scripts/Runtime/Entities/Tasks/Util/ResolveTargetUtil.cs
@@ -78,7 +78,7 @@ namespace Anvil.Unity.DOTS.Entities.Tasks
         {
             if (id == IDProvider.UNSET_ID)
             {
-                throw new InvalidOperationException($"Trying to get id for {default(TResolveTargetType)} but it was never registered!");
+                throw new InvalidOperationException($"Trying to get id for {default(TResolveTargetType)} but it was never registered! Did you call {nameof(IResolvableJobConfigRequirements.RequireResolveTarget)} for your job?");
             }
         }
     }


### PR DESCRIPTION
With the Task System, we supported 
- `TaskStreams`
- `NativeArray`
- `EntityQuery`

As ways to require and access data in jobs. 

Now we also support `ComponentDataFromEntity` or CDFE's as a first class citizen.

I ran into this while taking the new TaskSystem for a spin to quickly build up a MoveTo TaskSystem/Driver.

### What is the current behaviour?

Previously if you wanted to use a CDFE you could do so by using a reference to your system and calling:

```csharp
            [ReadOnly] private readonly float m_DeltaTime;
            [ReadOnly] private readonly ComponentDataFromEntity<PathFollowSpeed> m_SpeedsByEntity;
            [NativeDisableParallelForRestriction] private ComponentDataFromEntity<Translation> m_TranslationByEntity;
            
            private MoveToJob(UpdateJobData<MoveToInstance> jobData)
            {
                m_DeltaTime = jobData.Time.DeltaTime;
                m_SpeedsByEntity = jobData.System.GetComponentDataFromEntity<PathFollowSpeed>(true);
                m_TranslationByEntity = jobData.System.GetComponentDataFromEntity<Translation>();
            }
```

Note the need to remember to add the `NativeDisableParallelForRestriction` on the CDFE we want to update and the need to remember to pass in the `readonly = true` optional param for the CDFE we need to read. 

There are also no safety checks that you required access to these when configuring your job. While that doesn't really matter for actual execution, it would be nice for the Task Flow and communicating what data your job is going to touch without having the read the actual job.

### What is the new behaviour?

I added two helper structs similar to `DataStreamWriter` called `CDFEReader` and `CDFEUpdater` along with their various JobConfig and JobData APIs. 

Scheduling a job now communicates that you intend to use them:

```csharp
            ConfigureJobToUpdate(MoveToInstances,
                                 MoveToJob.Schedule,
                                 BatchStrategy.MaximizeChunk)
               .RequireResolveTarget<MoveToComplete>()
               .RequireCDFEForRead<PathFollowSpeed>()
               .RequireCDFEForUpdate<Translation>();
```

And the actual job is more simple and easy to write:

```csharp
            [ReadOnly] private readonly float m_DeltaTime;
            [ReadOnly] private readonly CDFEReader<PathFollowSpeed> m_SpeedsByEntity;
            private CDFEUpdater<Translation> m_TranslationsByEntity;

            private MoveToJob(UpdateJobData<MoveToInstance> jobData)
            {
                m_DeltaTime = jobData.Time.DeltaTime;
                m_SpeedsByEntity = jobData.GetCDFEReader<PathFollowSpeed>();
                m_TranslationsByEntity = jobData.GetCDFEUpdater<Translation>();
            }
```

You don't need to remember the rules for proper access or the optimization bits for read-only, the helper structs do that for you behind the scenes.


### What issues does this resolve?
- None

### What PRs does this depend on?
 - #80 

### Does this introduce a breaking change?
 - [ ] Yes
 - [x] No - New functionality

### Tag-Alongs
- More descriptive error messaging.
