### PR TITLE
Deferred Native Array - Clear Optimization

### DIFF
--- a/Scripts/Runtime/Entities/TaskSystem/TaskStream/DataStream/EntityProxyDataStream.cs
+++ b/Scripts/Runtime/Entities/TaskSystem/TaskStream/DataStream/EntityProxyDataStream.cs
@@ -27,8 +27,7 @@ namespace Anvil.Unity.DOTS.Entities.Tasks
         internal EntityProxyDataStream() : base()
         {
             m_Pending = new UnsafeTypedStream<EntityProxyInstanceWrapper<TInstance>>(Allocator.Persistent);
-            m_IterationTarget = new DeferredNativeArray<EntityProxyInstanceWrapper<TInstance>>(Allocator.Persistent,
-                                                                                         Allocator.TempJob);
+            m_IterationTarget = new DeferredNativeArray<EntityProxyInstanceWrapper<TInstance>>(Allocator.Persistent);
         }
 
         protected override void DisposeSelf()
@@ -118,7 +117,7 @@ namespace Anvil.Unity.DOTS.Entities.Tasks
             {
                 m_Iteration.Clear();
 
-                NativeArray<EntityProxyInstanceWrapper<TInstance>> iterationArray = m_Iteration.DeferredCreate(m_Pending.Count());
+                NativeArray<EntityProxyInstanceWrapper<TInstance>> iterationArray = m_Iteration.DeferredCreate(m_Pending.Count(), NativeArrayOptions.UninitializedMemory);
                 m_Pending.CopyTo(ref iterationArray);
                 m_Pending.Clear();
             }


### PR DESCRIPTION
In a mistaken test, I tried to make 1 million entities walk across the screen instead of the usual 100,000.

When doing so, I noticed that the ConsolidateJob was taking 81ms! 

Upon profiling, I discovered that it was hitting a Large Allocation Fallback for free and allocate every frame. 

With some quick optimizations, I got the 81ms down to 18ms which is a pretty big improvement even though we likely won't ever get that high with number of elements. 

### What is the current behaviour?

- `EntityProxyDataStream` was freeing and allocating `TempJob` memory every frame for Consolidation. Which normally would be fine but becomes an issue at higher element counts.

### What is the new behaviour?

- `EntityProxyDataStream` now uses `Persistent` memory and only frees and re-allocates if we grow larger. We can reuse the same bucket for Consolidation. 

### What issues does this resolve?
 - None

### What PRs does this depend on?
 - None

### Does this introduce a breaking change?
 - [x] Yes - Just be aware that `Clear` doesn't free memory anymore. This is inline with what `Clear` does on pretty much every other data structure we created and Unity has.
 - [ ] No
