### PR TITLE
SubTaskDriver Registration

### DIFF
--- a/Scripts/Runtime/Entities/TaskSystem/AbstractTaskDriver.cs
+++ b/Scripts/Runtime/Entities/TaskSystem/AbstractTaskDriver.cs
@@ -78,6 +78,8 @@ namespace Anvil.Unity.DOTS.Entities.Tasks
             
             TaskStreamFactory.CreateTaskStreams(this, TaskStreams);
             CancelRequestsDataStream = new CancelRequestsDataStream();
+
+            TaskDriverFactory.CreateSubTaskDrivers(this, m_SubTaskDrivers, world);
             
             m_TaskFlowGraph = world.GetOrCreateSystem<TaskFlowSystem>().TaskFlowGraph;
             m_TaskFlowGraph.RegisterTaskDriver(this);

--- a/Scripts/Runtime/Entities/TaskSystem/TaskDriverFactory.cs
+++ b/Scripts/Runtime/Entities/TaskSystem/TaskDriverFactory.cs
@@ -1,0 +1,84 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Reflection;
+using Unity.Entities;
+using UnityEngine;
+
+namespace Anvil.Unity.DOTS.Entities.Tasks
+{
+    internal static class TaskDriverFactory
+    {
+        private static readonly Type ABSTRACT_TASK_DRIVER_TYPE = typeof(AbstractTaskDriver);
+        private static readonly MethodInfo PROTOTYPE_METHOD = typeof(TaskDriverFactory).GetMethod(nameof(CreateTaskDriver), BindingFlags.Static | BindingFlags.NonPublic);
+        private static readonly Dictionary<Type, MethodInfo> TYPED_GENERIC_METHODS = new Dictionary<Type, MethodInfo>();
+
+        [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.SubsystemRegistration)]
+        private static void Init()
+        {
+            //TODO: #70 - Double check this works as expected in a build. https://github.com/decline-cookies/anvil-unity-dots/pull/58/files#r974334409
+            TYPED_GENERIC_METHODS.Clear();
+        }
+        
+        public static void CreateSubTaskDrivers(AbstractTaskDriver taskDriver, List<AbstractTaskDriver> subTaskDrivers, World world)
+        {
+            Type type = taskDriver.GetType();
+            FieldInfo[] taskDriverFields = type.GetFields(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+            foreach (FieldInfo field in taskDriverFields)
+            {
+                if (!ABSTRACT_TASK_DRIVER_TYPE.IsAssignableFrom(field.FieldType))
+                {
+                    continue;
+                }
+                
+                Debug_CheckFieldIsReadOnly(field);
+
+                AbstractTaskDriver subTaskDriver = Create(field.FieldType, world);
+                subTaskDrivers.Add(subTaskDriver);
+
+                Debug_EnsureFieldNotSet(field, taskDriver);
+                
+                field.SetValue(taskDriver, subTaskDriver);
+            }
+        }
+
+        private static AbstractTaskDriver Create(Type taskDriverType, World world)
+        {
+            if (!TYPED_GENERIC_METHODS.TryGetValue(taskDriverType, out MethodInfo typedGenericMethod))
+            {
+                typedGenericMethod = PROTOTYPE_METHOD.MakeGenericMethod(taskDriverType);
+                TYPED_GENERIC_METHODS.Add(taskDriverType, typedGenericMethod);
+            }
+
+            return (AbstractTaskDriver)typedGenericMethod.Invoke(null, new object[]{world});
+        }
+
+        private static TTaskDriver CreateTaskDriver<TTaskDriver>(World world)
+            where TTaskDriver : AbstractTaskDriver
+        {
+            return (TTaskDriver)Activator.CreateInstance(typeof(TTaskDriver), world);
+        }
+        
+        //*************************************************************************************************************
+        // SAFETY
+        //*************************************************************************************************************
+        
+        [Conditional("ENABLE_UNITY_COLLECTIONS_CHECKS")]
+        private static void Debug_CheckFieldIsReadOnly(FieldInfo fieldInfo)
+        {
+            if (!fieldInfo.IsInitOnly)
+            {
+                throw new InvalidOperationException($"Field with name {fieldInfo.Name} on {fieldInfo.ReflectedType} is not marked as \"readonly\", please ensure that it is.");
+            }
+        }
+        
+        [Conditional("ENABLE_UNITY_COLLECTIONS_CHECKS")]
+        private static void Debug_EnsureFieldNotSet(FieldInfo fieldInfo, object instance)
+        {
+            if (fieldInfo.GetValue(instance) != null)
+            {
+                throw new InvalidOperationException($"Field with name {fieldInfo.Name} on {fieldInfo.ReflectedType} is already set! Did you call {nameof(CreateSubTaskDrivers)} more than once?");
+            }
+        }
+    }
+}

--- a/Scripts/Runtime/Entities/TaskSystem/TaskDriverFactory.cs.meta
+++ b/Scripts/Runtime/Entities/TaskSystem/TaskDriverFactory.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 6419289ffa01474b99eaf553936a1729
+timeCreated: 1665602994


### PR DESCRIPTION
Small one to finish up support for SubTaskDrivers. 

### What is the current behaviour?

- You could create a sub task driver but it wasn't hooked into the system so cancelling wouldn't propagate and disposal was manual.

### What is the new behaviour?

- Using similar reflection to building `TaskStreams` we now will build all sub task drivers for you and ensure they are registered to their parent and properly disposed.
- They will also properly get the cancellation propagation now.

```csharp
public class WanderTaskDriver : AbstractTaskDriver<WanderTaskSystem>
    {
        //NOTE: We don't have to actually create these. Or dispose them. Happens automatically.
        private readonly TimerTaskDriver m_TimerTaskDriver;
        private readonly MoveToTaskDriver m_MoveToTaskDriver;
        
        [SuppressMessage("ReSharper", "PossibleNullReferenceException")]
        public WanderTaskDriver(World world) : base(world)
        {
            ConfigureJobTriggeredBy(TaskSystem.WanderInstances,
                                    StartWanderJob.Schedule,
                                    BatchStrategy.MaximizeChunk)
               .RequireTaskStreamForWrite(m_TimerTaskDriver.TaskSystem.Timers);

            ConfigureJobTriggeredBy(m_TimerTaskDriver.TimerCompletedDataStream,
                                    MoveJob.Schedule,
                                    BatchStrategy.MaximizeChunk)
               .RequireTaskStreamForWrite(m_MoveToTaskDriver.TaskSystem.MoveToInstances);

            ConfigureJobTriggeredBy(m_MoveToTaskDriver.MoveToCompleteDataStream,
                                    RestartWanderJob.Schedule,
                                    BatchStrategy.MaximizeChunk)
               .RequireTaskStreamForWrite(m_TimerTaskDriver.TaskSystem.Timers);
        }
```

### What issues does this resolve?
- Resolves #74

### What PRs does this depend on?
 - #87 

### Does this introduce a breaking change?
 - [x] Yes - You don't need to create them manually anymore. 
 - [ ] No
