### PR TITLE
Better logging with GetReadableName extension for Types

### DIFF
--- a/Scripts/Runtime/Entities/TaskSystem/AbstractTaskDriver.cs
+++ b/Scripts/Runtime/Entities/TaskSystem/AbstractTaskDriver.cs
@@ -1,5 +1,6 @@
 using Anvil.CSharp.Collections;
 using Anvil.CSharp.Core;
+using Anvil.CSharp.Reflection;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -100,8 +101,7 @@ namespace Anvil.Unity.DOTS.Entities.Tasks
 
         public override string ToString()
         {
-            //TODO: #112 (anvil-csharp-core) Extract to Anvil-CSharp Util method -Used in AbstractJobConfig as well
-            return GetType().Name;
+            return GetType().GetReadableName();
         }
 
         internal void Harden()

--- a/Scripts/Runtime/Entities/TaskSystem/AbstractTaskSystem.cs
+++ b/Scripts/Runtime/Entities/TaskSystem/AbstractTaskSystem.cs
@@ -1,5 +1,6 @@
 using Anvil.CSharp.Collections;
 using Anvil.CSharp.Data;
+using Anvil.CSharp.Reflection;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -98,8 +99,7 @@ namespace Anvil.Unity.DOTS.Entities.Tasks
 
         public override string ToString()
         {
-            //TODO: #112 (anvil-csharp-core) Extract to Anvil-CSharp Util method -Used in AbstractJobConfig as well
-            return GetType().Name;
+            return GetType().GetReadableName();
         }
 
         internal void Harden()
@@ -326,7 +326,7 @@ namespace Anvil.Unity.DOTS.Entities.Tasks
         {
             if (m_IsHardened)
             {
-                throw new InvalidOperationException($"Trying to register a {taskDriver} job but the create phase for systems is complete! Please ensure that all {taskDriver.GetType()}'s are created in {nameof(OnCreate)} or earlier.");
+                throw new InvalidOperationException($"Trying to register a {taskDriver} job but the create phase for systems is complete! Please ensure that all {taskDriver.GetType().GetReadableName()}'s are created in {nameof(OnCreate)} or earlier.");
             }
         }
 

--- a/Scripts/Runtime/Entities/TaskSystem/AbstractTaskSystem.cs
+++ b/Scripts/Runtime/Entities/TaskSystem/AbstractTaskSystem.cs
@@ -326,7 +326,7 @@ namespace Anvil.Unity.DOTS.Entities.Tasks
         {
             if (m_IsHardened)
             {
-                throw new InvalidOperationException($"Trying to register a {taskDriver} job but the create phase for systems is complete! Please ensure that all {taskDriver.GetType().GetReadableName()}'s are created in {nameof(OnCreate)} or earlier.");
+                throw new InvalidOperationException($"Trying to register a {taskDriver} job but the create phase for systems is complete! Please ensure that all {taskDriver}'s are created in {nameof(OnCreate)} or earlier.");
             }
         }
 

--- a/Scripts/Runtime/Entities/TaskSystem/Job/JobConfig/AbstractJobConfig.cs
+++ b/Scripts/Runtime/Entities/TaskSystem/Job/JobConfig/AbstractJobConfig.cs
@@ -1,5 +1,6 @@
 using Anvil.CSharp.Collections;
 using Anvil.CSharp.Core;
+using Anvil.CSharp.Reflection;
 using Anvil.Unity.DOTS.Jobs;
 using System;
 using System.Collections.Generic;
@@ -86,13 +87,6 @@ namespace Anvil.Unity.DOTS.Entities.Tasks
                                     AbstractTaskDriver taskDriver)
         {
             IsEnabled = true;
-            Type type = GetType();
-
-            //TODO: #112 (anvil-csharp-core) Extract to Anvil-CSharp Util method -Used in AbstractProxyDataStream as well
-            m_TypeString = type.IsGenericType
-                ? $"{type.Name[..^2]}<{type.GenericTypeArguments[0].Name}>"
-                : type.Name;
-
             TaskFlowGraph = taskFlowGraph;
             TaskSystem = taskSystem;
             TaskDriver = taskDriver;
@@ -121,7 +115,7 @@ namespace Anvil.Unity.DOTS.Entities.Tasks
 
         public override string ToString()
         {
-            return $"{m_TypeString} with schedule function name of {m_ScheduleInfo?.ScheduleJobFunctionInfo ?? "NOT YET SET"} on {TaskDebugUtil.GetLocationName(TaskSystem, TaskDriver)}";
+            return $"{GetType().GetReadableName()} with schedule function name of {m_ScheduleInfo?.ScheduleJobFunctionInfo ?? "NOT YET SET"} on {TaskDebugUtil.GetLocationName(TaskSystem, TaskDriver)}";
         }
 
         //*************************************************************************************************************

--- a/Scripts/Runtime/Entities/TaskSystem/TaskFlow/TaskFlowGraph.cs
+++ b/Scripts/Runtime/Entities/TaskSystem/TaskFlow/TaskFlowGraph.cs
@@ -328,7 +328,7 @@ namespace Anvil.Unity.DOTS.Entities.Tasks
             //             _                                  => throw new ArgumentOutOfRangeException($"Tried to generate issue string for {path} but no code path satisfies!")
             //         };
             //         
-            //         throw new InvalidOperationException($"{node.DataStream.GetType()} located on {node.ToLocationString()}, does not have any job for {path}. {issue}");
+            //         throw new InvalidOperationException($"{node.DataStream} located on {node.ToLocationString()}, does not have any job for {path}. {issue}");
             //     }
             // }
         }

--- a/Scripts/Runtime/Entities/TaskSystem/TaskStream/DataStream/AbstractDataStream.cs
+++ b/Scripts/Runtime/Entities/TaskSystem/TaskStream/DataStream/AbstractDataStream.cs
@@ -1,4 +1,5 @@
 using Anvil.CSharp.Core;
+using Anvil.CSharp.Reflection;
 using Anvil.Unity.DOTS.Jobs;
 using System;
 
@@ -10,17 +11,9 @@ namespace Anvil.Unity.DOTS.Entities.Tasks
 
         internal AccessController AccessController { get; }
 
-        private readonly string m_TypeString;
-
         protected AbstractDataStream()
         {
             Type = GetType();
-            
-            //TODO: #112 (anvil-csharp-core) Extract to Anvil-CSharp Util method -Used in AbstractJobConfig as well
-            m_TypeString = Type.IsGenericType
-                ? $"{Type.Name[..^2]}<{Type.GenericTypeArguments[0].Name}>"
-                : Type.Name;
-            
             AccessController = new AccessController();
         }
 
@@ -32,7 +25,7 @@ namespace Anvil.Unity.DOTS.Entities.Tasks
 
         public override string ToString()
         {
-            return m_TypeString;
+            return Type.GetReadableName();
         }
     }
 }

--- a/Scripts/Runtime/Entities/TaskSystem/TaskStream/TaskStream.cs
+++ b/Scripts/Runtime/Entities/TaskSystem/TaskStream/TaskStream.cs
@@ -1,3 +1,4 @@
+using Anvil.CSharp.Reflection;
 using System;
 using System.Diagnostics;
 
@@ -48,12 +49,7 @@ namespace Anvil.Unity.DOTS.Entities.Tasks
 
         public override string ToString()
         {
-            Type type = GetType();
-
-            //TODO: #112 (anvil-csharp-core) Extract to Anvil-CSharp Util method -Used in AbstractJobConfig as well
-            return type.IsGenericType
-                ? $"{type.Name[..^2]}<{type.GenericTypeArguments[0].Name}>"
-                : type.Name;
+            return GetType().GetReadableName();
         }
 
         internal sealed override AbstractEntityProxyDataStream GetDataStream()

--- a/Scripts/Runtime/Entities/TaskSystem/Util/TaskDebugUtil.cs
+++ b/Scripts/Runtime/Entities/TaskSystem/Util/TaskDebugUtil.cs
@@ -5,8 +5,8 @@ namespace Anvil.Unity.DOTS.Entities.Tasks
         public static string GetLocationName(AbstractTaskSystem taskSystem, AbstractTaskDriver taskDriver)
         {
             return (taskDriver == null)
-                ? $"{taskSystem.GetType().Name}"
-                : $"{taskDriver.GetType().Name} as part of the {taskSystem.GetType().Name} system";
+                ? $"{taskSystem}"
+                : $"{taskDriver} as part of the {taskSystem} system";
         }
     }
 }


### PR DESCRIPTION
Now that https://github.com/decline-cookies/anvil-csharp-core/pull/120 is merged in, we can use it for better logging.

### What is the current behaviour?

- Some manual manipulations of Type to get the right output string.

### What is the new behaviour?

- Just using the new `GetReadableName` extension

### What issues does this resolve?
- None

### What PRs does this depend on?
 - None

### Does this introduce a breaking change?
 - [ ] Yes
 - [x] No
