### PR TITLE
Hotfix cleanup

### DIFF
--- a/Scripts/Runtime/Entities/Util/WorldUtil.cs
+++ b/Scripts/Runtime/Entities/Util/WorldUtil.cs
@@ -193,10 +193,6 @@ namespace Anvil.Unity.DOTS.Entities
 #endif
                 SortAllGroupsInWorld(world);
             }
-            catch (Exception e)
-            {
-                throw e;
-            }
             finally
             {
                 Log.SuppressLogging = false;

--- a/Scripts/Runtime/Logging/BurstableLogger.cs
+++ b/Scripts/Runtime/Logging/BurstableLogger.cs
@@ -17,6 +17,11 @@ namespace Anvil.Unity.DOTS.Logging
     /// (usually <see cref="FixedString32Bytes" />)
     /// </typeparam>
     /// <remarks>
+    /// NOTE: Unlike <see cref="Logger"/> this logger is thread safe when burst compilation is enabled.
+    /// This is only possible because of the unique path that logs take through <see cref="UnityLogListener"/>
+    /// from a burst context.
+    /// TODO: #95
+    ///
     /// In the future, the goal of this type is to provide all the same information that
     /// <see cref="Log.Logger" /> provides. That is not possible with Burst today but should be
     /// possible in the future without making any changes at the consuming end. At the moment, the


### PR DESCRIPTION
Misc cleanup and documentation.

### What is the current behaviour?

### What is the new behaviour?
`BurstableLogger` - Thread safety documented
`WorldUtil` - Remove redundant catch + rethrow

### What issues does this resolve?
None

### What PRs does this depend on?
 - None

### Does this introduce a breaking change?
 - [ ] Yes <!-- If so, what are the migration considerations? -->
 - [x] No
