### PR TITLE
AccessControlledValue Disposal - Acquire for Dispose first

### DIFF
--- a/Scripts/Runtime/Job/AccessControl/AccessControlledValue.cs
+++ b/Scripts/Runtime/Job/AccessControl/AccessControlledValue.cs
@@ -28,9 +28,12 @@ namespace Anvil.Unity.DOTS.Jobs
 
         protected override void DisposeSelf()
         {
-            m_AccessController.Acquire(AccessType.Disposal);
+            if (m_Value is IDisposable disposable)
+            {
+                m_AccessController.Acquire(AccessType.Disposal);
+                disposable.Dispose();
+            }
             m_AccessController.Dispose();
-            (m_Value as IDisposable)?.Dispose();
             base.DisposeSelf();
         }
 

--- a/Scripts/Runtime/Job/AccessControl/AccessControlledValue.cs
+++ b/Scripts/Runtime/Job/AccessControl/AccessControlledValue.cs
@@ -28,6 +28,7 @@ namespace Anvil.Unity.DOTS.Jobs
 
         protected override void DisposeSelf()
         {
+            m_AccessController.Acquire(AccessType.Disposal);
             m_AccessController.Dispose();
             (m_Value as IDisposable)?.Dispose();
             base.DisposeSelf();


### PR DESCRIPTION
Added automatic acquiring for disposal when disposing.

### What is the current behaviour?

You must (or really really should) manually acquire for Disposal first. 
Otherwise when disposing, the data may be in flight leading to a crash/exception being thrown.

```csharp
m_MyAccessControlledValue.Acquire(AccessType.Disposal);
m_MyAccessControlledValue.Dispose();
```

### What is the new behaviour?

The `Dispose` method automatically acquires for you so you don't forget.

### What issues does this resolve?
- Resolves #104 

### What PRs does this depend on?
 - None

### Does this introduce a breaking change?
 - [x] Yes - If you're already manually acquiring you'll need to change that so you're not acquiring twice. However at runtime it will squawk at you for acquiring twice making it quick and easy to fix.
 - [ ] No
