### PR TITLE
Script Define Toggle

### DIFF
--- a/Scripts/Editor/Compiler.meta
+++ b/Scripts/Editor/Compiler.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 1b5a1e6e299948089f6a3bcdc69b2aa0
+timeCreated: 1668008042

--- a/Scripts/Editor/Compiler/ScriptDefinesToggle.cs
+++ b/Scripts/Editor/Compiler/ScriptDefinesToggle.cs
@@ -1,0 +1,86 @@
+using System.Collections.Generic;
+using System.Linq;
+using UnityEditor;
+using UnityEditor.Build;
+
+namespace Anvil.Unity.DOTS.Editor.Compiler
+{
+    /// <summary>
+    /// Provides a quick and easy way to enable/disable commonly used Scripting Defines for
+    /// development and debugging. 
+    /// </summary>
+    [InitializeOnLoad]
+    public static class ScriptDefinesToggle
+    {
+        private const string MENU_PATH_BASE = "Anvil/Script Defines";
+        private const string DEFINE_ANVIL_DEBUG_SAFETY_EXPENSIVE = "ANVIL_DEBUG_SAFETY_EXPENSIVE";
+        private const string MENU_PATH_ANVIL_DEBUG_SAFETY_EXPENSIVE = MENU_PATH_BASE + "/" + DEFINE_ANVIL_DEBUG_SAFETY_EXPENSIVE;
+        private const string DEFINE_ANVIL_DEBUG_LOGGING_EXPENSIVE = "ANVIL_DEBUG_LOGGING_EXPENSIVE";
+        private const string MENU_PATH_ANVIL_DEBUG_LOGGING_EXPENSIVE= MENU_PATH_BASE + "/" + DEFINE_ANVIL_DEBUG_LOGGING_EXPENSIVE;
+
+        private static readonly HashSet<string> ACTIVE_DEFINES = new HashSet<string>();
+        private static readonly NamedBuildTarget NAMED_BUILD_TARGET;
+
+        static ScriptDefinesToggle()
+        {
+            BuildTarget buildTarget = EditorUserBuildSettings.activeBuildTarget;
+            BuildTargetGroup buildTargetGroup = BuildPipeline.GetBuildTargetGroup(buildTarget);
+            NAMED_BUILD_TARGET = NamedBuildTarget.FromBuildTargetGroup(buildTargetGroup);
+            
+            ACTIVE_DEFINES.Clear();
+            PlayerSettings.GetScriptingDefineSymbols(NAMED_BUILD_TARGET, out string[] defines);
+            foreach (string define in defines)
+            {
+                ACTIVE_DEFINES.Add(define);
+            }
+        }
+        
+        [MenuItem(MENU_PATH_ANVIL_DEBUG_SAFETY_EXPENSIVE, true)]
+        private static bool ToggleAnvilDebugSafetyExpensive_Validator()
+        {
+            return Toggle_Validator(DEFINE_ANVIL_DEBUG_SAFETY_EXPENSIVE, 
+                                    MENU_PATH_ANVIL_DEBUG_SAFETY_EXPENSIVE);
+        }
+        
+        [MenuItem(MENU_PATH_ANVIL_DEBUG_SAFETY_EXPENSIVE)]
+        private static void ToggleAnvilDebugSafetyExpensive()
+        {
+            Toggle(DEFINE_ANVIL_DEBUG_SAFETY_EXPENSIVE);
+        }
+        
+        [MenuItem(MENU_PATH_ANVIL_DEBUG_LOGGING_EXPENSIVE, true)]
+        private static bool ToggleAnvilDebugLoggingExpensive_Validator()
+        {
+            return Toggle_Validator(DEFINE_ANVIL_DEBUG_LOGGING_EXPENSIVE, 
+                                    MENU_PATH_ANVIL_DEBUG_LOGGING_EXPENSIVE);
+        }
+        
+        [MenuItem(MENU_PATH_ANVIL_DEBUG_LOGGING_EXPENSIVE)]
+        private static void ToggleAnvilDebugLoggingExpensive()
+        {
+            Toggle(DEFINE_ANVIL_DEBUG_LOGGING_EXPENSIVE);
+        }
+
+        
+        private static bool Toggle_Validator(string define, string menuPath)
+        {
+            bool isEnabled = ACTIVE_DEFINES.Contains(define);
+            Menu.SetChecked(menuPath, isEnabled);
+            return true;
+        }
+
+        private static void Toggle(string define)
+        {
+            if (ACTIVE_DEFINES.Contains(define))
+            {
+                ACTIVE_DEFINES.Remove(define);
+            }
+            else
+            {
+                ACTIVE_DEFINES.Add(define);
+            }
+            
+            PlayerSettings.SetScriptingDefineSymbols(NAMED_BUILD_TARGET, ACTIVE_DEFINES.ToArray());
+        }
+    }
+}

--- a/Scripts/Editor/Compiler/ScriptDefinesToggle.cs.meta
+++ b/Scripts/Editor/Compiler/ScriptDefinesToggle.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 76dcd1aec586432a9f0c0823956f9d89
+timeCreated: 1668008055

--- a/Scripts/Editor/anvil-unity-dots-editor.asmdef
+++ b/Scripts/Editor/anvil-unity-dots-editor.asmdef
@@ -11,7 +11,9 @@
         "Unity.Jobs",
         "Unity.Mathematics"
     ],
-    "includePlatforms": [],
+    "includePlatforms": [
+        "Editor"
+    ],
     "excludePlatforms": [],
     "allowUnsafeCode": true,
     "overrideReferences": false,


### PR DESCRIPTION
Added a simple menu for toggling on/off Script Defines

### What is the current behaviour?

You would have to manually toggle them on/off in Player Settings and remember what they were called.

### What is the new behaviour?

You can use a menu `Anvil > Script Defines > ANVIL_DEBUG_ETC`

### What issues does this resolve?
- Resolves #106 

### What PRs does this depend on?
 - None

### Does this introduce a breaking change?
 - [ ] Yes
 - [x] No

## Discussion

In the Issue #106 I raised a couple of questions. In building this I think I've answered them but let's make sure we're on the same page.

1. I think the defines should exist throughout Anvil. CSharp, Unity Core and Unity Dots. To that end I think this PR should be deleted and this Toggle be part of Unity Core. If there are specific Unity Dots flags it can add via the same API.


2. I looked into ENABLE_UNITY_COLLECTIONS_CHECKS and it's something that is ALWAYS on in the Editor and ALWAYS off in the Player. You can only toggle it on/off for Burst code in the Editor. 

I think we should do a find replace on all our code (new issue) to remove any references to ENABLE_UNITY_COLLECTIONS_CHECKS and replace with ANVIL_DEBUG_SAFETY