### PR TITLE
Cancellation Optimization

### DIFF
--- a/Scripts/Runtime/Entities/TaskSystem/AbstractTaskSystem.cs
+++ b/Scripts/Runtime/Entities/TaskSystem/AbstractTaskSystem.cs
@@ -35,6 +35,8 @@ namespace Anvil.Unity.DOTS.Entities.Tasks
         internal List<AbstractTaskDriver> TaskDrivers { get; }
 
         internal TaskData TaskData { get; }
+        
+        internal bool HasCancellableData { get; }
 
 
         protected AbstractTaskSystem()
@@ -46,6 +48,7 @@ namespace Anvil.Unity.DOTS.Entities.Tasks
             Context = m_TaskDriverContextProvider.GetNextID();
 
             TaskData = new TaskData(null, this);
+            HasCancellableData = TaskData.CancellableDataStreams.Count > 0;
         }
 
         protected override void OnCreate()

--- a/Scripts/Runtime/Entities/TaskSystem/Cancelling/AbstractCancelFlow.cs
+++ b/Scripts/Runtime/Entities/TaskSystem/Cancelling/AbstractCancelFlow.cs
@@ -78,7 +78,7 @@ namespace Anvil.Unity.DOTS.Entities.Tasks
 
             CheckCancelProgressJob checkCancelProgressJob = new CheckCancelProgressJob(parentProgressLookup,
                                                                                        progressLookup,
-                                                                                       TaskData.CancelCompleteDataStream.Pending,
+                                                                                       TaskData.CancelCompleteDataStream.Pending.AsWriter(),
                                                                                        Parent?.TaskDriverContext ?? 0
 #if DEBUG
                                                                                       ,
@@ -113,7 +113,7 @@ namespace Anvil.Unity.DOTS.Entities.Tasks
 
             private UnsafeParallelHashMap<EntityProxyInstanceID, bool> m_ParentProgressLookup;
             private UnsafeParallelHashMap<EntityProxyInstanceID, bool> m_ProgressLookup;
-            [ReadOnly] private UnsafeTypedStream<EntityProxyInstanceID> m_CompleteWriter;
+            [ReadOnly] private readonly UnsafeTypedStream<EntityProxyInstanceID>.Writer m_CompleteWriter;
             [ReadOnly] private readonly byte m_Context;
 
             private UnsafeTypedStream<EntityProxyInstanceID>.LaneWriter m_CompleteLaneWriter;
@@ -128,7 +128,7 @@ namespace Anvil.Unity.DOTS.Entities.Tasks
 
             public CheckCancelProgressJob(UnsafeParallelHashMap<EntityProxyInstanceID, bool> parentProgressLookup,
                                           UnsafeParallelHashMap<EntityProxyInstanceID, bool> progressLookup,
-                                          UnsafeTypedStream<EntityProxyInstanceID> completeWriter,
+                                          UnsafeTypedStream<EntityProxyInstanceID>.Writer completeWriter,
                                           byte context
 #if DEBUG
                                          ,

--- a/Scripts/Runtime/Entities/TaskSystem/Cancelling/AbstractCancelFlow.cs
+++ b/Scripts/Runtime/Entities/TaskSystem/Cancelling/AbstractCancelFlow.cs
@@ -193,7 +193,11 @@ namespace Anvil.Unity.DOTS.Entities.Tasks
                     ref bool isParentProcessing = ref entry.Value;
                     EntityProxyInstanceID id = new EntityProxyInstanceID(parentID.Entity, m_Context);
 
-                    bool isStillProcessing = m_ProgressLookup[id];
+                    if (!m_ProgressLookup.TryGetValue(id, out bool isStillProcessing))
+                    {
+                        continue;
+                    }
+                    
                     HandleProgress(isStillProcessing, ref id);
                     if (isParentProcessing)
                     {

--- a/Scripts/Runtime/Entities/TaskSystem/Cancelling/AbstractCancelFlow.cs
+++ b/Scripts/Runtime/Entities/TaskSystem/Cancelling/AbstractCancelFlow.cs
@@ -192,12 +192,8 @@ namespace Anvil.Unity.DOTS.Entities.Tasks
                     EntityProxyInstanceID parentID = entry.Key;
                     ref bool isParentProcessing = ref entry.Value;
                     EntityProxyInstanceID id = new EntityProxyInstanceID(parentID.Entity, m_Context);
-
-                    if (!m_ProgressLookup.TryGetValue(id, out bool isStillProcessing))
-                    {
-                        continue;
-                    }
                     
+                    bool isStillProcessing = m_ProgressLookup[id];
                     HandleProgress(isStillProcessing, ref id);
                     if (isParentProcessing)
                     {

--- a/Scripts/Runtime/Entities/TaskSystem/Cancelling/SystemCancelFlow.cs
+++ b/Scripts/Runtime/Entities/TaskSystem/Cancelling/SystemCancelFlow.cs
@@ -11,11 +11,9 @@ namespace Anvil.Unity.DOTS.Entities.Tasks
             m_TaskSystem = taskSystem;
         }
 
-        internal void BuildRelationshipData(List<AbstractCancelFlow> cancelFlows,
-                                            List<CancelRequestDataStream> cancelRequests,
+        internal void BuildRelationshipData(List<CancelRequestDataStream> cancelRequests,
                                             List<byte> contexts)
         {
-            cancelFlows.Add(this);
             //Add ourself
             cancelRequests.Add(TaskData.CancelRequestDataStream);
             //Add the previous context which will represent the TaskDriver that writes to us

--- a/Scripts/Runtime/Entities/TaskSystem/Cancelling/TaskDriverCancelFlow.cs
+++ b/Scripts/Runtime/Entities/TaskSystem/Cancelling/TaskDriverCancelFlow.cs
@@ -75,8 +75,7 @@ namespace Anvil.Unity.DOTS.Entities.Tasks
         public void BuildRequestData()
         {
             List<byte> cancelContexts = new List<byte>();
-            List<AbstractCancelFlow> cancelFlows = new List<AbstractCancelFlow>();
-            BuildRequestData(cancelFlows, m_CancelRequestDataStreams, cancelContexts);
+            BuildRequestData(m_CancelRequestDataStreams, cancelContexts);
 
             m_RequestWriters = new NativeArray<UnsafeTypedStream<EntityProxyInstanceID>.Writer>(m_CancelRequestDataStreams.Count, Allocator.Persistent);
             m_RequestContexts = new NativeArray<byte>(m_CancelRequestDataStreams.Count, Allocator.Persistent);
@@ -90,24 +89,22 @@ namespace Anvil.Unity.DOTS.Entities.Tasks
             m_CancelRequestAcquisitionJobHandles = new NativeArray<JobHandle>(m_CancelRequestDataStreams.Count, Allocator.Persistent);
         }
 
-        private void BuildRequestData(List<AbstractCancelFlow> cancelFlows,
-                                      List<CancelRequestDataStream> cancelRequests,
+        private void BuildRequestData(List<CancelRequestDataStream> cancelRequests,
                                       List<byte> contexts)
         {
-            cancelFlows.Add(this);
             //Add ourself
             cancelRequests.Add(TaskData.CancelRequestDataStream);
             //Add our TaskDriver's context
             contexts.Add(TaskDriverContext);
-
+            
             //For all subtask drivers, recursively add
             foreach (AbstractTaskDriver taskDriver in m_TaskDriver.SubTaskDrivers)
             {
-                taskDriver.CancelFlow.BuildRequestData(cancelFlows, cancelRequests, contexts);
+                taskDriver.CancelFlow.BuildRequestData(cancelRequests, contexts);
             }
 
             //Add our governing system
-            m_SystemCancelFlow.BuildRelationshipData(cancelFlows, cancelRequests, contexts);
+            m_SystemCancelFlow.BuildRelationshipData(cancelRequests, contexts);
         }
 
         public void BuildScheduling()

--- a/Scripts/Runtime/Entities/TaskSystem/Cancelling/TaskDriverCancelFlow.cs
+++ b/Scripts/Runtime/Entities/TaskSystem/Cancelling/TaskDriverCancelFlow.cs
@@ -132,11 +132,17 @@ namespace Anvil.Unity.DOTS.Entities.Tasks
             List<AbstractCancelFlow> cancelFlows = GetOrCreateAtDepth(depth);
             List<AbstractCancelFlow> cancelFlowsOneDeeper = GetOrCreateAtDepth(depth + 1);
 
-            //Add our own Cancel Flow
-            cancelFlows.Add(taskDriver.CancelFlow);
-            //Add the System's Cancel Flow to the next depth
-            cancelFlowsOneDeeper.Add(taskDriver.CancelFlow.m_SystemCancelFlow);
-
+            //Add our own Cancel Flow if we have cancellable data
+            if (taskDriver.HasCancellableData)
+            {
+                cancelFlows.Add(taskDriver.CancelFlow);
+            }
+            //Add the System's Cancel Flow to the next depth if it has cancellable data
+            if (taskDriver.TaskSystem.HasCancellableData)
+            {
+                cancelFlowsOneDeeper.Add(taskDriver.CancelFlow.m_SystemCancelFlow);
+            }
+            
             //Drill down into the children
             foreach (AbstractTaskDriver subTaskDriver in taskDriver.SubTaskDrivers)
             {

--- a/Scripts/Runtime/Entities/TaskSystem/TaskData/DataStream/Cancelling/CancelRequestDataStream.cs
+++ b/Scripts/Runtime/Entities/TaskSystem/TaskData/DataStream/Cancelling/CancelRequestDataStream.cs
@@ -19,17 +19,20 @@ namespace Anvil.Unity.DOTS.Entities.Tasks
     internal class CancelRequestDataStream : AbstractLookupDataStream<EntityProxyInstanceID>
     {
         private readonly AccessControlledValue<UnsafeParallelHashMap<EntityProxyInstanceID, bool>> m_CancelProgressLookup;
+        private readonly CancelCompleteDataStream m_CancelCompleteDataStream;
 
-        public bool HasCancellableData
+        private bool HasCancellableData
         {
             get => OwningTaskDriver?.HasCancellableData ?? OwningTaskSystem.HasCancellableData;
         }
 
         public CancelRequestDataStream(AccessControlledValue<UnsafeParallelHashMap<EntityProxyInstanceID, bool>> cancelProgressLookup,
+                                       CancelCompleteDataStream cancelCompleteDataStream,
                                        AbstractTaskDriver taskDriver,
                                        AbstractTaskSystem taskSystem) : base(taskDriver, taskSystem)
         {
             m_CancelProgressLookup = cancelProgressLookup;
+            m_CancelCompleteDataStream = cancelCompleteDataStream;
         }
 
         //*************************************************************************************************************
@@ -45,27 +48,59 @@ namespace Anvil.Unity.DOTS.Entities.Tasks
 
         protected sealed override JobHandle ConsolidateForFrame(JobHandle dependsOn)
         {
+            return HasCancellableData
+                ? ConsolidateWithCancellableData(dependsOn)
+                : ConsolidateWithoutCancellableData(dependsOn);
+        }
+
+        private JobHandle ConsolidateWithCancellableData(JobHandle dependsOn)
+        {
             dependsOn = JobHandle.CombineDependencies(dependsOn,
                                                       AccessController.AcquireAsync(AccessType.ExclusiveWrite),
                                                       m_CancelProgressLookup.AcquireAsync(AccessType.ExclusiveWrite, out UnsafeParallelHashMap<EntityProxyInstanceID, bool> progressLookup));
 
-            ConsolidateCancelRequestsJob consolidateCancelRequestsJob = new ConsolidateCancelRequestsJob(Pending,
-                                                                                                         Lookup,
-                                                                                                         progressLookup,
-                                                                                                         HasCancellableData
+            ConsolidateCancelRequestsWithCancellableDataJob job = new ConsolidateCancelRequestsWithCancellableDataJob(Pending,
+                                                                                                                      Lookup,
+                                                                                                                      progressLookup
 #if DEBUG
-                                                                                                        ,
-                                                                                                         Debug_ProfilingInfo.ProfilingDetails
+                                                                                                                     ,
+                                                                                                                      Debug_ProfilingInfo.ProfilingDetails
 #endif
 #if ANVIL_DEBUG_LOGGING_EXPENSIVE
-                                                                                                        ,
-                                                                                                         Debug_DebugString
+                                                                                                                     ,
+                                                                                                                      Debug_DebugString
 #endif
-                                                                                                        );
+                                                                                                                     );
 
-            dependsOn = consolidateCancelRequestsJob.Schedule(dependsOn);
+            dependsOn = job.Schedule(dependsOn);
 
             m_CancelProgressLookup.ReleaseAsync(dependsOn);
+            AccessController.ReleaseAsync(dependsOn);
+            return dependsOn;
+        }
+
+        private JobHandle ConsolidateWithoutCancellableData(JobHandle dependsOn)
+        {
+            dependsOn = JobHandle.CombineDependencies(dependsOn,
+                                                      AccessController.AcquireAsync(AccessType.ExclusiveWrite),
+                                                      m_CancelCompleteDataStream.AccessController.AcquireAsync(AccessType.SharedWrite));
+
+            ConsolidateCancelRequestsWithoutCancellableDataJob job = new ConsolidateCancelRequestsWithoutCancellableDataJob(Pending,
+                                                                                                                            Lookup,
+                                                                                                                            m_CancelCompleteDataStream.Pending.AsWriter()
+#if DEBUG
+                                                                                                                           ,
+                                                                                                                            Debug_ProfilingInfo.ProfilingDetails
+#endif
+#if ANVIL_DEBUG_LOGGING_EXPENSIVE
+                                                                                                                           ,
+                                                                                                                            Debug_DebugString
+#endif
+                                                                                                                           );
+
+            dependsOn = job.Schedule(dependsOn);
+
+            m_CancelCompleteDataStream.AccessController.ReleaseAsync(dependsOn);
             AccessController.ReleaseAsync(dependsOn);
             return dependsOn;
         }
@@ -75,12 +110,11 @@ namespace Anvil.Unity.DOTS.Entities.Tasks
         //*************************************************************************************************************
 
         [BurstCompile]
-        private struct ConsolidateCancelRequestsJob : IJob
+        private struct ConsolidateCancelRequestsWithCancellableDataJob : IJob
         {
             [ReadOnly] private UnsafeTypedStream<EntityProxyInstanceID> m_Pending;
             private UnsafeParallelHashMap<EntityProxyInstanceID, bool> m_Lookup;
             private UnsafeParallelHashMap<EntityProxyInstanceID, bool> m_ProgressLookup;
-            [ReadOnly] private readonly bool m_HasCancellableData;
 
 
 #if DEBUG
@@ -91,24 +125,22 @@ namespace Anvil.Unity.DOTS.Entities.Tasks
 #endif
 
 
-            public ConsolidateCancelRequestsJob(UnsafeTypedStream<EntityProxyInstanceID> pending,
-                                                UnsafeParallelHashMap<EntityProxyInstanceID, bool> lookup,
-                                                UnsafeParallelHashMap<EntityProxyInstanceID, bool> progressLookup,
-                                                bool hasCancellableData
+            public ConsolidateCancelRequestsWithCancellableDataJob(UnsafeTypedStream<EntityProxyInstanceID> pending,
+                                                                   UnsafeParallelHashMap<EntityProxyInstanceID, bool> lookup,
+                                                                   UnsafeParallelHashMap<EntityProxyInstanceID, bool> progressLookup
 #if DEBUG
-                                               ,
-                                                DataStreamProfilingDetails profilingDetails
+                                                                  ,
+                                                                   DataStreamProfilingDetails profilingDetails
 #endif
 #if ANVIL_DEBUG_LOGGING_EXPENSIVE
-                                               ,
-                                                FixedString128Bytes debugString
+                                                                  ,
+                                                                   FixedString128Bytes debugString
 #endif
             )
             {
                 m_Pending = pending;
                 m_Lookup = lookup;
                 m_ProgressLookup = progressLookup;
-                m_HasCancellableData = hasCancellableData;
 #if DEBUG
                 m_ProfilingDetails = profilingDetails;
 #endif
@@ -127,11 +159,11 @@ namespace Anvil.Unity.DOTS.Entities.Tasks
                 m_Lookup.Clear();
                 foreach (EntityProxyInstanceID proxyInstanceID in m_Pending)
                 {
-                    Debug_EnsureNoDuplicates(proxyInstanceID);
+                    Debug_EnsureNoDuplicates(proxyInstanceID, ref m_Lookup);
                     m_Lookup.TryAdd(proxyInstanceID, true);
                     //We have something that wants to cancel, so we assume that it will get processed this frame.
                     //If nothing processes it, it will auto-complete the next frame. 
-                    m_ProgressLookup.TryAdd(proxyInstanceID, m_HasCancellableData);
+                    m_ProgressLookup.TryAdd(proxyInstanceID, true);
 #if DEBUG
                     lookupCount++;
 #endif
@@ -152,18 +184,107 @@ namespace Anvil.Unity.DOTS.Entities.Tasks
                 m_ProfilingDetails.ProfilerMarker.End();
 #endif
             }
+        }
 
-            //*************************************************************************************************************
-            // SAFETY
-            //*************************************************************************************************************
+        [BurstCompile]
+        private struct ConsolidateCancelRequestsWithoutCancellableDataJob : IJob
+        {
+            private const int UNSET_THREAD_INDEX = -1;
 
-            [Conditional("ANVIL_DEBUG_SAFETY_EXPENSIVE")]
-            private void Debug_EnsureNoDuplicates(EntityProxyInstanceID id)
+            [NativeSetThreadIndex] [ReadOnly] private readonly int m_NativeThreadIndex;
+
+            [ReadOnly] private UnsafeTypedStream<EntityProxyInstanceID> m_Pending;
+            private UnsafeParallelHashMap<EntityProxyInstanceID, bool> m_Lookup;
+            [ReadOnly] private readonly UnsafeTypedStream<EntityProxyInstanceID>.Writer m_CompleteWriter;
+
+            private UnsafeTypedStream<EntityProxyInstanceID>.LaneWriter m_CompleteLaneWriter;
+
+
+#if DEBUG
+            private DataStreamProfilingDetails m_ProfilingDetails;
+#endif
+#if ANVIL_DEBUG_LOGGING_EXPENSIVE
+            private readonly FixedString128Bytes m_DebugString;
+#endif
+
+
+            public ConsolidateCancelRequestsWithoutCancellableDataJob(UnsafeTypedStream<EntityProxyInstanceID> pending,
+                                                                      UnsafeParallelHashMap<EntityProxyInstanceID, bool> lookup,
+                                                                      UnsafeTypedStream<EntityProxyInstanceID>.Writer completeWriter
+#if DEBUG
+                                                                     ,
+                                                                      DataStreamProfilingDetails profilingDetails
+#endif
+#if ANVIL_DEBUG_LOGGING_EXPENSIVE
+                                                                     ,
+                                                                      FixedString128Bytes debugString
+#endif
+            ) : this()
             {
-                if (m_Lookup.ContainsKey(id))
+                m_Pending = pending;
+                m_Lookup = lookup;
+                m_CompleteWriter = completeWriter;
+#if DEBUG
+                m_ProfilingDetails = profilingDetails;
+#endif
+#if ANVIL_DEBUG_LOGGING_EXPENSIVE
+                m_DebugString = debugString;
+#endif
+
+                m_NativeThreadIndex = UNSET_THREAD_INDEX;
+            }
+
+            public void Execute()
+            {
+#if DEBUG
+                m_ProfilingDetails.ProfilerMarker.Begin();
+                int lookupCount = 0;
+#endif
+                int laneIndex = ParallelAccessUtil.CollectionIndexForThread(m_NativeThreadIndex);
+                m_CompleteLaneWriter = m_CompleteWriter.AsLaneWriter(laneIndex);
+
+                m_Lookup.Clear();
+                foreach (EntityProxyInstanceID proxyInstanceID in m_Pending)
                 {
-                    throw new InvalidOperationException($"Trying to add id of {id} but the same id already exists in the lookup! This should never happen! Investigate.");
+                    Debug_EnsureNoDuplicates(proxyInstanceID, ref m_Lookup);
+                    m_Lookup.TryAdd(proxyInstanceID, true);
+#if ANVIL_DEBUG_LOGGING_EXPENSIVE
+                    Debug.Log($"No cancel flow needed for {proxyInstanceID.ToFixedString()} on {m_DebugString} - Completing Early");
+#endif
+                    m_CompleteLaneWriter.Write(proxyInstanceID);
+#if DEBUG
+                    lookupCount++;
+#endif
                 }
+
+                m_Pending.Clear();
+
+#if ANVIL_DEBUG_LOGGING_EXPENSIVE
+                if (!m_Lookup.IsEmpty)
+                {
+                    Debug.Log($"{m_DebugString} - Count {m_Lookup.Count()}");
+                }
+#endif
+#if DEBUG
+                m_ProfilingDetails.PendingCapacity = m_Pending.Capacity();
+                m_ProfilingDetails.LiveInstances = lookupCount;
+                m_ProfilingDetails.LiveCapacity = m_Lookup.Capacity;
+                m_ProfilingDetails.ProfilerMarker.End();
+#endif
+            }
+        }
+
+
+        //*************************************************************************************************************
+        // SAFETY
+        //*************************************************************************************************************
+
+        [Conditional("ANVIL_DEBUG_SAFETY_EXPENSIVE")]
+        private static void Debug_EnsureNoDuplicates(EntityProxyInstanceID id, ref UnsafeParallelHashMap<EntityProxyInstanceID, bool> lookup)
+        {
+            if (lookup.ContainsKey(id))
+            {
+                throw new InvalidOperationException($"Trying to add id of {id} but the same id already exists in the lookup! This should never happen! Investigate.");
             }
         }
     }

--- a/Scripts/Runtime/Entities/TaskSystem/TaskData/TaskData.cs
+++ b/Scripts/Runtime/Entities/TaskSystem/TaskData/TaskData.cs
@@ -32,9 +32,14 @@ namespace Anvil.Unity.DOTS.Entities.Tasks
             CancellableDataStreams = new List<AbstractDataStream>();
             CancelResultDataStreams = new List<AbstractDataStream>();
             CancelProgressLookup = new AccessControlledValue<UnsafeParallelHashMap<EntityProxyInstanceID, bool>>(new UnsafeParallelHashMap<EntityProxyInstanceID, bool>(ChunkUtil.MaxElementsPerChunk<EntityProxyInstanceID>(),
-                                                                                                                                                                          Allocator.Persistent));
-            CancelRequestDataStream = new CancelRequestDataStream(CancelProgressLookup, TaskDriver, TaskSystem);
+                                     
+                                                                                                                                                                        Allocator.Persistent));
             CancelCompleteDataStream = new CancelCompleteDataStream(TaskDriver, TaskSystem);
+            CancelRequestDataStream = new CancelRequestDataStream(CancelProgressLookup, 
+                                                                  CancelCompleteDataStream, 
+                                                                  TaskDriver, 
+                                                                  TaskSystem);
+            
             
             DataStreamFactory.CreateDataStreams(this);
         }


### PR DESCRIPTION
As mentioned in #107, we can optimize the cancel flow. 

### What is the current behaviour?

Currently, when a Top Level TaskDriver is cancelled, we allow each SubTaskDriver and System to have the opportunity to run one frame and let us know if we should keep processing the cancel request or not get anything back and we assume we're done and complete the cancellation. 

See the following log:
```
[RandoCancelTaskDriver] - Rando Cancel - Timer Complete, Cancelling WanderTaskDriver
~~ Frame N+1 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
CancelRequestDataStream, Driver: FollowPathTaskDriver|2, System: FollowPathTaskSystem - Count 1
CancelRequestDataStream, System: FollowPathTaskSystem - Count 1
CancelRequestDataStream, System: PathfindTaskSystem - Count 1
CancelRequestDataStream, Driver: WanderTaskDriver|2, System: WanderTaskSystem - Count 1
CancelRequestDataStream, System: WanderTaskSystem - Count 1
CancelRequestDataStream, Driver: PathfindTaskDriver|2, System: PathfindTaskSystem - Count 1
CancelRequestDataStream, System: MoveToTaskSystem - Count 1
CancelRequestDataStream, System: TimerTaskSystem - Count 1
CancelRequestDataStream, Driver: MoveToTaskDriver|2, System: MoveToTaskSystem - Count 1
CancelRequestDataStream, Driver: TimerTaskDriver|2, System: TimerTaskSystem - Count 1
Still processing for Entity(1:1) - Context: 2 on SystemCancelFlow, System: MoveToTaskSystem - Holding open
Still processing for Entity(1:1) - Context: 2 on SystemCancelFlow, System: PathfindTaskSystem - Holding open
Still processing for Entity(1:1) - Context: 2 on SystemCancelFlow, System: TimerTaskSystem - Holding open
Still processing for Entity(1:1) - Context: 2 on SystemCancelFlow, System: FollowPathTaskSystem - Holding open
Still processing for Entity(1:1) - Context: 2 on TaskDriverCancelFlow, Driver: MoveToTaskDriver|2, System: MoveToTaskSystem - Holding open
Still processing for Entity(1:1) - Context: 2 on SystemCancelFlow, System: WanderTaskSystem - Holding open
Still processing for Entity(1:1) - Context: 2 on TaskDriverCancelFlow, Driver: TimerTaskDriver|2, System: TimerTaskSystem - Holding open
Still processing for Entity(1:1) - Context: 2 on TaskDriverCancelFlow, Driver: PathfindTaskDriver|2, System: PathfindTaskSystem - Holding open
Still processing for Entity(1:1) - Context: 2 on TaskDriverCancelFlow, Driver: FollowPathTaskDriver|2, System: FollowPathTaskSystem - Holding open
Still processing for Entity(1:1) - Context: 2 on TaskDriverCancelFlow, Driver: WanderTaskDriver|2, System: WanderTaskSystem - Holding open
Cancelling Instance with ID Entity(1:1) - Context: 2 for DataStream<MoveToComplete>, Driver: MoveToTaskDriver|2, System: MoveToTaskSystem
~~ Frame N+2 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
No longer processing for Entity(1:1) - Context: 2 on SystemCancelFlow, System: MoveToTaskSystem - Completing
No longer processing for Entity(1:1) - Context: 2 on SystemCancelFlow, System: FollowPathTaskSystem - Completing
No longer processing for Entity(1:1) - Context: 2 on SystemCancelFlow, System: PathfindTaskSystem - Completing
No longer processing for Entity(1:1) - Context: 2 on TaskDriverCancelFlow, Driver: MoveToTaskDriver|2, System: MoveToTaskSystem - Completing
No longer processing for Entity(1:1) - Context: 2 on SystemCancelFlow, System: TimerTaskSystem - Completing
No longer processing for Entity(1:1) - Context: 2 on SystemCancelFlow, System: WanderTaskSystem - Completing
No longer processing for Entity(1:1) - Context: 2 on TaskDriverCancelFlow, Driver: TimerTaskDriver|2, System: TimerTaskSystem - Completing
No longer processing for Entity(1:1) - Context: 2 on TaskDriverCancelFlow, Driver: PathfindTaskDriver|2, System: PathfindTaskSystem - Completing
No longer processing for Entity(1:1) - Context: 2 on TaskDriverCancelFlow, Driver: FollowPathTaskDriver|2, System: FollowPathTaskSystem - Completing
No longer processing for Entity(1:1) - Context: 2 on TaskDriverCancelFlow, Driver: WanderTaskDriver|2, System: WanderTaskSystem - Completing
CancelCompleteDataStream, Driver: TimerTaskDriver|2, System: TimerTaskSystem - Count 1
CancelCompleteDataStream, Driver: WanderTaskDriver|2, System: WanderTaskSystem - Count 1
CancelCompleteDataStream, System: TimerTaskSystem - Count 1
CancelCompleteDataStream, System: MoveToTaskSystem - Count 1
CancelCompleteDataStream, Driver: FollowPathTaskDriver|2, System: FollowPathTaskSystem - Count 1
CancelCompleteDataStream, System: WanderTaskSystem - Count 1
CancelCompleteDataStream, System: FollowPathTaskSystem - Count 1
CancelCompleteDataStream, Driver: MoveToTaskDriver|2, System: MoveToTaskSystem - Count 1
CancelCompleteDataStream, System: PathfindTaskSystem - Count 1
CancelCompleteDataStream, Driver: PathfindTaskDriver|2, System: PathfindTaskSystem - Count 1
InitPathfinding Wander was Cancelled, adding new WanderStart and new RandoCancel. Also moving to top right.
```

1. We request a cancel on frame N. 
2. **Frame N+1**
3. We then consolidate the cancel requests for all sub task drivers and their systems which also writes to the CancelProgress and tells it to keep it open for one frame.
4. All DataStreams are consolidated with the cancel information which results in removing the active instance of data.
5. **Frame N+2**
6. All CancelProgress entries are complete so we can remove them and write to our CancelComplete.
7. All CancelCompletes are consolidated so that jobs can be scheduled on them.
8. `InitPathfinding` picks up on this cancel complete and does its work.


### What is the new behaviour?

We can take advantage of knowing whether data can be cancelled or not. If it's not going to run any custom logic for cancelling, then we can skip the CancelProgress steps and go right to completion.

This results is far less jobs being run and allows for overall flow to happen quicker (possibly same frame).

```
[RandoCancelTaskDriver] - Rando Cancel - Timer Complete, Cancelling WanderTaskDriver
~~ Frame N+1 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
CancelRequestDataStream, Driver: FollowPathTaskDriver|2, System: FollowPathTaskSystem - Count 1
No cancel flow needed for Entity(1:1) - Context: 2 on CancelRequestDataStream, System: FollowPathTaskSystem - Completing Early
CancelRequestDataStream, System: MoveToTaskSystem - Count 1
No cancel flow needed for Entity(1:1) - Context: 2 on CancelRequestDataStream, System: PathfindTaskSystem - Completing Early
CancelRequestDataStream, Driver: WanderTaskDriver|2, System: WanderTaskSystem - Count 1
No cancel flow needed for Entity(1:1) - Context: 2 on CancelRequestDataStream, System: TimerTaskSystem - Completing Early
CancelRequestDataStream, Driver: MoveToTaskDriver|2, System: MoveToTaskSystem - Count 1
No cancel flow needed for Entity(1:1) - Context: 2 on CancelRequestDataStream, Driver: PathfindTaskDriver|2, System: PathfindTaskSystem - Completing Early
No cancel flow needed for Entity(1:1) - Context: 2 on CancelRequestDataStream, System: WanderTaskSystem - Completing Early
No cancel flow needed for Entity(1:1) - Context: 2 on CancelRequestDataStream, Driver: TimerTaskDriver|2, System: TimerTaskSystem - Completing Early
CancelRequestDataStream, System: TimerTaskSystem - Count 1
CancelRequestDataStream, System: FollowPathTaskSystem - Count 1
CancelRequestDataStream, Driver: PathfindTaskDriver|2, System: PathfindTaskSystem - Count 1
CancelRequestDataStream, System: PathfindTaskSystem - Count 1
CancelRequestDataStream, System: WanderTaskSystem - Count 1
CancelRequestDataStream, Driver: TimerTaskDriver|2, System: TimerTaskSystem - Count 1
Still processing for Entity(1:1) - Context: 2 on SystemCancelFlow, System: MoveToTaskSystem - Holding open
Still processing for Entity(1:1) - Context: 2 on TaskDriverCancelFlow, Driver: MoveToTaskDriver|2, System: MoveToTaskSystem - Holding open
Still processing for Entity(1:1) - Context: 2 on TaskDriverCancelFlow, Driver: FollowPathTaskDriver|2, System: FollowPathTaskSystem - Holding open
Still processing for Entity(1:1) - Context: 2 on TaskDriverCancelFlow, Driver: WanderTaskDriver|2, System: WanderTaskSystem - Holding open
Cancelling Instance with ID Entity(1:1) - Context: 2 for DataStream<TimerInstance>, System: TimerTaskSystem
CancelCompleteDataStream, System: TimerTaskSystem - Count 1
CancelCompleteDataStream, System: FollowPathTaskSystem - Count 1
CancelCompleteDataStream, System: PathfindTaskSystem - Count 1
CancelCompleteDataStream, Driver: TimerTaskDriver|2, System: TimerTaskSystem - Count 1
CancelCompleteDataStream, Driver: PathfindTaskDriver|2, System: PathfindTaskSystem - Count 1
CancelCompleteDataStream, System: WanderTaskSystem - Count 1
~~ Frame N+2 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
No longer processing for Entity(1:1) - Context: 2 on SystemCancelFlow, System: MoveToTaskSystem - Completing
No longer processing for Entity(1:1) - Context: 2 on TaskDriverCancelFlow, Driver: MoveToTaskDriver|2, System: MoveToTaskSystem - Completing
No longer processing for Entity(1:1) - Context: 2 on TaskDriverCancelFlow, Driver: FollowPathTaskDriver|2, System: FollowPathTaskSystem - Completing
No longer processing for Entity(1:1) - Context: 2 on TaskDriverCancelFlow, Driver: WanderTaskDriver|2, System: WanderTaskSystem - Completing
CancelCompleteDataStream, Driver: WanderTaskDriver|2, System: WanderTaskSystem - Count 1
CancelCompleteDataStream, Driver: FollowPathTaskDriver|2, System: FollowPathTaskSystem - Count 1
CancelCompleteDataStream, System: MoveToTaskSystem - Count 1
CancelCompleteDataStream, Driver: MoveToTaskDriver|2, System: MoveToTaskSystem - Count 1
InitPathfinding Wander was Cancelled, adding new WanderStart and new RandoCancel. Also moving to top right.
```

1. We request a cancel on frame N. 
2. **Frame N+1**
3. We then consolidate the cancel requests for all sub task drivers and their systems same as before.
    a. If the data or it's direct children have cancel logic to run, they write to CancelProgress like before.
    b. If not though, we skip and write directly to CancelComplete
4. All DataStreams are consolidated with the cancel information which results in removing the active instance of data.
5. All CancelCompletes are consolidated with the early completes due to no cancel logic being necessary.
6. **Frame N+2**
7. The remaining CancelProgress entries are complete so we can remove them and write to our CancelComplete.
8. All remaining CancelCompletes are consolidated so that jobs can be scheduled on them.
9. `InitPathfinding` picks up on this cancel complete and does its work.

### What issues does this resolve?
- Resolves #107 

### What PRs does this depend on?
 - #108 

### Does this introduce a breaking change?
 - [ ] Yes
 - [x] No - Behind the scenes optimization.
