### PR TITLE
Test asmdef

### DIFF
--- a/Scripts/Editor/Tests.meta
+++ b/Scripts/Editor/Tests.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 1381cd73bacf84e1ab39a12ab7b10dd0
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/Editor/Tests/anvil-unity-dots-tests.asmdef
+++ b/Scripts/Editor/Tests/anvil-unity-dots-tests.asmdef
@@ -11,15 +11,21 @@
         "Unity.Entities",
         "Unity.Jobs",
         "Unity.Mathematics",
-        "Unity.Transforms"
+        "Unity.Transforms",
+        "UnityEditor.TestRunner",
+        "UnityEngine.TestRunner"
     ],
     "includePlatforms": [
         "Editor"
     ],
     "excludePlatforms": [],
     "allowUnsafeCode": true,
-    "overrideReferences": false,
-    "precompiledReferences": [],
+    "overrideReferences": true,
+    "precompiledReferences": [
+        "nunit.framework.dll",
+        "anvil-csharp-logging.dll",
+        "anvil-unity-logging.dll"
+    ],
     "autoReferenced": true,
     "defineConstraints": [],
     "versionDefines": [],

--- a/Scripts/Editor/Tests/anvil-unity-dots-tests.asmdef
+++ b/Scripts/Editor/Tests/anvil-unity-dots-tests.asmdef
@@ -1,0 +1,27 @@
+{
+    "name": "anvil-unity-dots-tests",
+    "rootNamespace": "Anvil.Unity.DOTS.Tests",
+    "references": [
+        "anvil-unity-dots-runtime",
+        "anvil-unity-dots-editor",
+        "anvil-unity-core-runtime",
+        "anvil-csharp-core",
+        "Unity.Burst",
+        "Unity.Collections",
+        "Unity.Entities",
+        "Unity.Jobs",
+        "Unity.Mathematics",
+        "Unity.Transforms"
+    ],
+    "includePlatforms": [
+        "Editor"
+    ],
+    "excludePlatforms": [],
+    "allowUnsafeCode": true,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/Scripts/Editor/Tests/anvil-unity-dots-tests.asmdef.meta
+++ b/Scripts/Editor/Tests/anvil-unity-dots-tests.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 1e6bd9c0abde143b5a5e219dd47c4581
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Add unit test directory and assembly definition in preparation for unit tests.

### What is the current behaviour?

Unit tests are not setup.

### What is the new behaviour?

Unit tests can be added to `Scripts/Editor/Tests/`

### What issues does this resolve?
- Resolves: #50

### What PRs does this depend on?
<!-- List PRs in other repos that need to be merged before this one -->
 - None

### Does this introduce a breaking change?
 - [ ] Yes <!-- If so, what are the migration considerations? -->
 - [x] No
