### PR TITLE
Add MathExtension

### DIFF
--- a/Scripts/Editor/Tests/Mathematics.meta
+++ b/Scripts/Editor/Tests/Mathematics.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b11a9042961d74aac9521319fe33a2a9
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/Editor/Tests/Mathematics/MathExtensionTests.cs
+++ b/Scripts/Editor/Tests/Mathematics/MathExtensionTests.cs
@@ -1,0 +1,27 @@
+using Anvil.Unity.Core;
+using NUnit.Framework;
+using UnityEngine;
+
+namespace Anvil.Unity.DOTS.Tests.Mathematics
+{
+    public static class MathExtensionTests
+    {
+        [Test]
+        public static void CreateFromPointsTest()
+        {
+            Rect rect = RectUtil.CreateFromPoints(new Vector2(1, 2), new Vector2(3, 4));
+
+            Assert.That(rect.min.x, Is.EqualTo(1));
+            Assert.That(rect.min.y, Is.EqualTo(2));
+            Assert.That(rect.max.x, Is.EqualTo(3));
+            Assert.That(rect.max.y, Is.EqualTo(4));
+
+            rect = RectUtil.CreateFromPoints(new Vector2(3, 4), new Vector2(1, 2));
+
+            Assert.That(rect.min.x, Is.EqualTo(1));
+            Assert.That(rect.min.y, Is.EqualTo(2));
+            Assert.That(rect.max.x, Is.EqualTo(3));
+            Assert.That(rect.max.y, Is.EqualTo(4));
+        }
+    }
+}

--- a/Scripts/Editor/Tests/Mathematics/MathExtensionTests.cs
+++ b/Scripts/Editor/Tests/Mathematics/MathExtensionTests.cs
@@ -1,27 +1,197 @@
 using Anvil.Unity.Core;
+using Anvil.Unity.DOTS.Mathematics;
 using NUnit.Framework;
-using UnityEngine;
+using Unity.Mathematics;
 
 namespace Anvil.Unity.DOTS.Tests.Mathematics
 {
     public static class MathExtensionTests
     {
-        [Test]
-        public static void CreateFromPointsTest()
+        private static int EqualityWithTolerance(float3 a, float3 b)
         {
-            Rect rect = RectUtil.CreateFromPoints(new Vector2(1, 2), new Vector2(3, 4));
+            return math.all(a.IsApproximately(b)) ? 0 : 1;
+        }
+        private static int EqualityWithTolerance(float3x3 a, float3x3 b)
+        {
+            return a.IsApproximately(b).Equals(new bool3x3(true)) ? 0 : 1;
+        }
 
-            Assert.That(rect.min.x, Is.EqualTo(1));
-            Assert.That(rect.min.y, Is.EqualTo(2));
-            Assert.That(rect.max.x, Is.EqualTo(3));
-            Assert.That(rect.max.y, Is.EqualTo(4));
+        /// <remarks>
+        /// Tests <see cref="DOTS.Mathematics.MathExtension.GetScale()"/> and
+        /// <see cref="DOTS.Mathematics.MathExtension.GetRotation"/> need to be used in tandem to produce valid results
+        /// so they share she same tests.
+        /// </remarks>
+        [Test]
+        public static void GetScaleAndGetRotationTest()
+        {
+            float4x4 transform_identity = float4x4.TRS(float3.zero, quaternion.identity, new float3(1f));
 
-            rect = RectUtil.CreateFromPoints(new Vector2(3, 4), new Vector2(1, 2));
+            float4x4 transform_translate = float4x4.TRS(new float3(7f), quaternion.identity, new float3(1f));
+            float4x4 transform_negativeTranslate = float4x4.TRS(new float3(-7f), quaternion.identity, new float3(1f));
 
-            Assert.That(rect.min.x, Is.EqualTo(1));
-            Assert.That(rect.min.y, Is.EqualTo(2));
-            Assert.That(rect.max.x, Is.EqualTo(3));
-            Assert.That(rect.max.y, Is.EqualTo(4));
+            quaternion transform_rotate_rotation = quaternion.Euler(math.radians(45f));
+            float4x4 transform_rotate = float4x4.TRS(float3.zero, transform_rotate_rotation, new float3(1f));
+            quaternion transform_Zrotate_rotation = quaternion.Euler(math.radians(0), math.radians(0), math.radians(45));
+            float4x4 transform_Zrotate = float4x4.TRS(
+                float3.zero,
+                transform_Zrotate_rotation,
+                new float3(1f)
+                );
+
+            float4x4 transform_scale = float4x4.TRS(float3.zero, quaternion.identity, new float3(7f));
+            float4x4 transform_negativeScale = float4x4.TRS(float3.zero, quaternion.identity, new float3(-7f));
+            float4x4 transform_Zscale = float4x4.TRS(float3.zero, quaternion.identity, new float3(1f, 1f, 7f));
+            float4x4 transform_negativeZscale = float4x4.TRS(float3.zero, quaternion.identity, new float3(1f, 1f, -7f));
+
+            float4x4 transform_scale_zero = float4x4.TRS(float3.zero, quaternion.identity, float3.zero);
+
+            quaternion transform_compound_rotate = quaternion.Euler(math.radians(0), math.radians(0), math.radians(45));
+            float4x4 transform_compound = float4x4.TRS(
+                new float3(7f),
+                transform_compound_rotate,
+                new float3(7f)
+            );
+            quaternion transform_negativeCompound_rotate = quaternion.Euler(math.radians(-45));
+            float4x4 transform_negativeCompound = float4x4.TRS(
+                new float3(-7f),
+                transform_negativeCompound_rotate,
+                new float3(-7f)
+            );
+
+            Assert.That(
+                math.mul(new float3x3(transform_identity.GetRotation()), float3x3.Scale(transform_identity.GetScale())),
+                Is.EqualTo((float3x3)transform_identity).Using<float3x3>(EqualityWithTolerance)
+                );
+
+            Assert.That(
+                math.mul(new float3x3(transform_translate.GetRotation()), float3x3.Scale(transform_translate.GetScale())),
+                Is.EqualTo((float3x3)transform_translate).Using<float3x3>(EqualityWithTolerance)
+                );
+            Assert.That(
+                math.mul(new float3x3(transform_negativeTranslate.GetRotation()), float3x3.Scale(transform_negativeTranslate.GetScale())),
+                Is.EqualTo((float3x3)transform_negativeTranslate).Using<float3x3>(EqualityWithTolerance)
+                );
+
+            Assert.That(
+                math.mul(new float3x3(transform_rotate.GetRotation()), float3x3.Scale(transform_rotate.GetScale())),
+                Is.EqualTo((float3x3)transform_rotate).Using<float3x3>(EqualityWithTolerance)
+                );
+            Assert.That(
+                math.mul(new float3x3(transform_Zrotate.GetRotation()), float3x3.Scale(transform_Zrotate.GetScale())),
+                Is.EqualTo((float3x3)transform_Zrotate).Using<float3x3>(EqualityWithTolerance)
+                );
+
+            Assert.That(
+                math.mul(new float3x3(transform_scale.GetRotation()), float3x3.Scale(transform_scale.GetScale())),
+                Is.EqualTo((float3x3)transform_scale).Using<float3x3>(EqualityWithTolerance)
+                );
+            Assert.That(
+                math.mul(new float3x3(transform_negativeScale.GetRotation()), float3x3.Scale(transform_negativeScale.GetScale())),
+                Is.EqualTo((float3x3)transform_negativeScale).Using<float3x3>(EqualityWithTolerance)
+                );
+            Assert.That(
+                math.mul(new float3x3(transform_Zscale.GetRotation()), float3x3.Scale(transform_Zscale.GetScale())),
+                Is.EqualTo((float3x3)transform_Zscale).Using<float3x3>(EqualityWithTolerance)
+                );
+            Assert.That(
+                math.mul(new float3x3(transform_negativeZscale.GetRotation()), float3x3.Scale(transform_negativeZscale.GetScale())),
+                Is.EqualTo((float3x3)transform_negativeZscale).Using<float3x3>(EqualityWithTolerance)
+                );
+
+            Assert.That(
+                math.mul(new float3x3(transform_scale_zero.GetRotation()), float3x3.Scale(transform_scale_zero.GetScale())),
+                Is.EqualTo((float3x3)transform_scale_zero).Using<float3x3>(EqualityWithTolerance)
+                );
+
+            Assert.That(
+                math.mul(new float3x3(transform_compound.GetRotation()), float3x3.Scale(transform_compound.GetScale())),
+                Is.EqualTo((float3x3)transform_compound).Using<float3x3>(EqualityWithTolerance)
+                );
+            Assert.That(
+                math.mul(new float3x3(transform_negativeCompound.GetRotation()), float3x3.Scale(transform_negativeCompound.GetScale())),
+                Is.EqualTo((float3x3)transform_negativeCompound).Using<float3x3>(EqualityWithTolerance)
+                );
+        }
+
+        [Test]
+        public static void GetTranslationTest()
+        {
+            float3 point_zero = float3.zero;
+            float3 point_seven = new float3(7f);
+            float3 point_negativeSeven = new float3(-7f);
+
+            float4x4 transform_identity = float4x4.TRS(point_zero, quaternion.identity, new float3(1f));
+
+            float4x4 transform_translate = float4x4.TRS(point_seven, quaternion.identity, new float3(1f));
+            float4x4 transform_negativeTranslate = float4x4.TRS(point_negativeSeven, quaternion.identity, new float3(1f));
+
+            float4x4 transform_compound = float4x4.TRS(
+                point_seven,
+                quaternion.Euler(math.radians(0), math.radians(0), math.radians(45)),
+                new float3(7f)
+            );
+            float4x4 transform_negativeCompound = float4x4.TRS(
+                point_negativeSeven,
+                quaternion.Euler(math.radians(-45)),
+                new float3(-7f)
+            );
+
+            Assert.That(transform_identity.GetTranslation(), Is.EqualTo(point_zero).Using<float3>(EqualityWithTolerance));
+
+            Assert.That(transform_translate.GetTranslation(), Is.EqualTo(point_seven).Using<float3>(EqualityWithTolerance));
+            Assert.That(transform_negativeTranslate.GetTranslation(), Is.EqualTo(point_negativeSeven).Using<float3>(EqualityWithTolerance));
+
+            Assert.That(transform_compound.GetTranslation(), Is.EqualTo(point_seven).Using<float3>(EqualityWithTolerance));
+            Assert.That(transform_negativeCompound.GetTranslation(), Is.EqualTo(point_negativeSeven).Using<float3>(EqualityWithTolerance));
+        }
+
+        [Test]
+        public static void IsValidTransformTest()
+        {
+            float3 point_zero = float3.zero;
+            float3 point_seven = new float3(7f);
+            float3 point_negativeSeven = new float3(-7f);
+
+            float4x4 transform_identity = float4x4.TRS(point_zero, quaternion.identity, new float3(1f));
+
+            float4x4 transform_translate = float4x4.TRS(point_seven, quaternion.identity, new float3(1f));
+            float4x4 transform_negativeTranslate = float4x4.TRS(point_negativeSeven, quaternion.identity, new float3(1f));
+
+            float4x4 transform_nan = new float4x4(float.NaN);
+            float4x4 transform_scale_zero = float4x4.TRS(float3.zero, quaternion.identity, point_zero);
+
+            float4x4 transform_scale = float4x4.TRS(float3.zero, quaternion.identity, new float3(7f));
+            float4x4 transform_negativeScale = float4x4.TRS(float3.zero, quaternion.identity, new float3(-7f));
+            float4x4 transform_Zscale = float4x4.TRS(float3.zero, quaternion.identity, new float3(1f, 1f, 7f));
+            float4x4 transform_negativeZscale = float4x4.TRS(float3.zero, quaternion.identity, new float3(1f, 1f, -7f));
+
+            float4x4 transform_compound = float4x4.TRS(
+                point_seven,
+                quaternion.Euler(math.radians(0), math.radians(0), math.radians(45)),
+                new float3(7f)
+            );
+            float4x4 transform_negativeCompound = float4x4.TRS(
+                point_negativeSeven,
+                quaternion.Euler(math.radians(-45)),
+                new float3(-7f)
+            );
+
+            Assert.That(transform_identity.IsValidTransform(), Is.True);
+
+            Assert.That(transform_translate.IsValidTransform(), Is.True);
+            Assert.That(transform_negativeTranslate.IsValidTransform(), Is.True);
+
+            Assert.That(transform_nan.IsValidTransform(), Is.False);
+            Assert.That(transform_scale_zero.IsValidTransform(), Is.False);
+
+            Assert.That(transform_scale.IsValidTransform(), Is.True);
+            Assert.That(transform_negativeScale.IsValidTransform(), Is.True);
+            Assert.That(transform_Zscale.IsValidTransform(), Is.True);
+            Assert.That(transform_negativeZscale.IsValidTransform(), Is.True);
+
+            Assert.That(transform_compound.IsValidTransform(), Is.True);
+            Assert.That(transform_negativeCompound.IsValidTransform(), Is.True);
+
         }
     }
 }

--- a/Scripts/Editor/Tests/Mathematics/MathExtensionTests.cs
+++ b/Scripts/Editor/Tests/Mathematics/MathExtensionTests.cs
@@ -2,6 +2,7 @@ using Anvil.Unity.Core;
 using Anvil.Unity.DOTS.Mathematics;
 using NUnit.Framework;
 using Unity.Mathematics;
+using MathExtension = Anvil.Unity.DOTS.Mathematics.MathExtension;
 
 namespace Anvil.Unity.DOTS.Tests.Mathematics
 {
@@ -24,6 +25,8 @@ namespace Anvil.Unity.DOTS.Tests.Mathematics
         [Test]
         public static void GetScaleAndGetRotationTest()
         {
+            Assert.That(nameof(GetScaleAndGetRotationTest), Does.Contain(nameof(MathExtension.GetRotation)).And.Contain(nameof(MathExtension.GetScale)));
+
             float4x4 transform_identity = float4x4.TRS(float3.zero, quaternion.identity, new float3(1f));
 
             float4x4 transform_translate = float4x4.TRS(new float3(7f), quaternion.identity, new float3(1f));
@@ -116,6 +119,8 @@ namespace Anvil.Unity.DOTS.Tests.Mathematics
         [Test]
         public static void GetTranslationTest()
         {
+            Assert.That(nameof(GetTranslationTest), Does.StartWith(nameof(MathExtension.GetTranslation)));
+
             float3 point_zero = float3.zero;
             float3 point_seven = new float3(7f);
             float3 point_negativeSeven = new float3(-7f);
@@ -148,6 +153,8 @@ namespace Anvil.Unity.DOTS.Tests.Mathematics
         [Test]
         public static void IsValidTransformTest()
         {
+            Assert.That(nameof(IsValidTransformTest), Does.StartWith(nameof(MathExtension.IsValidTransform)));
+
             float3 point_zero = float3.zero;
             float3 point_seven = new float3(7f);
             float3 point_negativeSeven = new float3(-7f);

--- a/Scripts/Editor/Tests/Mathematics/MathExtensionTests.cs.meta
+++ b/Scripts/Editor/Tests/Mathematics/MathExtensionTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f774c8463523848c1a50c973f27aaf9a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/Runtime/Mathematics/MathExtension.cs
+++ b/Scripts/Runtime/Mathematics/MathExtension.cs
@@ -1,0 +1,147 @@
+using System.Runtime.CompilerServices;
+using Anvil.CSharp.Mathematics;
+using Unity.Mathematics;
+
+namespace Anvil.Unity.DOTS.Mathematics
+{
+    /// <summary>
+    /// A collection of extension methods for working with types under the <see cref="Unity.Mathematics"/> namespace.
+    /// (float3, int2, etc..)
+    /// </summary>
+    public static class MathExtension
+    {
+        /// <summary>
+        /// Get the inverse of a <see cref="float3"/>.
+        /// </summary>
+        /// <remarks>
+        /// Any components that are 0 will invert to <see cref="float.NaN"/>.
+        /// Use <see cref="GetInverseSafe" /> if this is a possibility.
+        /// </remarks>
+        /// <param name="value">The value to get the inverse of.</param>
+        /// <returns>The inverted value</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static float3 GetInverse(this float3 value)
+        {
+            return 1f / value;
+        }
+
+        /// <summary>
+        /// Get the inverse of a <see cref="float3"/> with any <see cref="float.NaN"/> components set to 0
+        /// </summary>
+        /// <param name="value">The value to get the inverse of.</param>
+        /// <returns>The inverted value</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static float3 GetInverseSafe(this float3 value)
+        {
+            float3 inverse = value.GetInverse();
+            return math.select(inverse, float3.zero, math.isnan(inverse));
+        }
+
+        /// <summary>
+        /// Get the scale component from a TRS matrix.
+        /// On a LocalToWorld matrix this is the world scale.
+        /// </summary>
+        /// <param name="matrix">The matrix to evaluate.</param>
+        /// <returns>The scale component from the matrix.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static float3 GetScale(this float4x4 matrix)
+        {
+            float3 scaleMagnitude = GetScaleMagnitude(matrix);
+            scaleMagnitude.x *= math.select(1, -1, math.determinant(matrix) < 0);
+            return scaleMagnitude;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static float3 GetScaleMagnitude(this float4x4 matrix)
+        {
+            return new float3(
+                math.length(matrix.c0.xyz),
+                math.length(matrix.c1.xyz),
+                math.length(matrix.c2.xyz));
+        }
+
+        /// <summary>
+        /// Get the rotation component from a TRS matrix.
+        /// On a LocalToWorld matrix this is the world rotation.
+        /// </summary>
+        /// <param name="matrix">The matrix to evaluate.</param>
+        /// <returns>The rotation component from the matrix</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static quaternion GetRotation(this float4x4 matrix)
+        {
+            return new quaternion(math.orthonormalize(new float3x3(matrix)));
+
+            //TODO: #117 - Profile
+            // Alternate Implementations
+            // 1. Remove scale from matrix
+            // float3 scale = matrix.GetScaleMagnitude();
+            // if (!math.all(scale.IsApproximately(1f)))
+            // {
+            //     matrix = math.mul(matrix, float4x4.Scale(scale.GetInverseSafe()));
+            // }
+            //
+            // return new quaternion(matrix);
+
+            //OR
+            // 2. Look Rotation Safe
+            // return quaternion.LookRotationSafe(matrix.c2.xyz, matrix.c1.xyz);
+        }
+
+        /// <summary>
+        /// Get the position component from a TRS matrix.
+        /// On a LocalToWorld matrix this is the world position.
+        /// </summary>
+        /// <param name="matrix">The matrix to evaluate.</param>
+        /// <returns>The position component from the matrix</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static float3 GetPosition(this float4x4 matrix)
+        {
+            return new float3(matrix.c0.w, matrix.c1.w, matrix.c2.w);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool IsApproximately(this float a, float b)
+        {
+            return math.abs(a - b) < MathUtil.FLOATING_POINT_EQUALITY_TOLERANCE;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool2 IsApproximately(this float2 a, float2 b)
+        {
+            return math.abs(a - b) < MathUtil.FLOATING_POINT_EQUALITY_TOLERANCE;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool3 IsApproximately(this float3 a, float3 b)
+        {
+            return math.abs(a - b) < MathUtil.FLOATING_POINT_EQUALITY_TOLERANCE;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool4 IsApproximately(this float4 a, float4 b)
+        {
+            return math.abs(a - b) < MathUtil.FLOATING_POINT_EQUALITY_TOLERANCE;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool3x3 IsApproximately(this float3x3 a, float3x3 b)
+        {
+            return new bool3x3(
+                a.c0.IsApproximately(b.c0),
+                a.c1.IsApproximately(b.c1),
+                a.c2.IsApproximately(b.c2)
+            );
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool4x4 IsApproximately(this float4x4 a, float4x4 b)
+        {
+            return new bool4x4(
+                a.c0.IsApproximately(b.c0),
+                a.c1.IsApproximately(b.c1),
+                a.c2.IsApproximately(b.c2),
+                a.c3.IsApproximately(b.c3)
+            );
+        }
+    }
+}

--- a/Scripts/Runtime/Mathematics/MathExtension.cs
+++ b/Scripts/Runtime/Mathematics/MathExtension.cs
@@ -84,7 +84,7 @@ namespace Anvil.Unity.DOTS.Mathematics
         /// An invalid matrix (Ex: with a 0 scale component) cannot be inverted. Special case values must be used when
         /// transforming through an invalid matrix.
         /// </remarks>
-        public static bool isValidTransform(this float4x4 matrix)
+        public static bool IsValidTransform(this float4x4 matrix)
         {
             return math.determinant(matrix) is not 0 and not float.NaN;
         }

--- a/Scripts/Runtime/Mathematics/MathExtension.cs
+++ b/Scripts/Runtime/Mathematics/MathExtension.cs
@@ -11,33 +11,6 @@ namespace Anvil.Unity.DOTS.Mathematics
     public static class MathExtension
     {
         /// <summary>
-        /// Get the inverse of a <see cref="float3"/>.
-        /// </summary>
-        /// <remarks>
-        /// Any components that are 0 will invert to <see cref="float.NaN"/>.
-        /// Use <see cref="GetInverseSafe" /> if this is a possibility.
-        /// </remarks>
-        /// <param name="value">The value to get the inverse of.</param>
-        /// <returns>The inverted value</returns>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static float3 GetInverse(this float3 value)
-        {
-            return 1f / value;
-        }
-
-        /// <summary>
-        /// Get the inverse of a <see cref="float3"/> with any <see cref="float.NaN"/> components set to 0
-        /// </summary>
-        /// <param name="value">The value to get the inverse of.</param>
-        /// <returns>The inverted value</returns>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static float3 GetInverseSafe(this float3 value)
-        {
-            float3 inverse = value.GetInverse();
-            return math.select(inverse, float3.zero, math.isnan(inverse));
-        }
-
-        /// <summary>
         /// Get the scale component from a TRS matrix.
         /// On a LocalToWorld matrix this is the world scale.
         /// </summary>
@@ -97,64 +70,6 @@ namespace Anvil.Unity.DOTS.Mathematics
         public static float3 GetPosition(this float4x4 matrix)
         {
             return new float3(matrix.c0.w, matrix.c1.w, matrix.c2.w);
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool IsApproximately(this float a, float b)
-        {
-            return math.abs(a - b) < MathUtil.FLOATING_POINT_EQUALITY_TOLERANCE;
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool2 IsApproximately(this float2 a, float2 b)
-        {
-            return math.abs(a - b) < MathUtil.FLOATING_POINT_EQUALITY_TOLERANCE;
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool3 IsApproximately(this float3 a, float3 b)
-        {
-            return math.abs(a - b) < MathUtil.FLOATING_POINT_EQUALITY_TOLERANCE;
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool4 IsApproximately(this float4 a, float4 b)
-        {
-            return math.abs(a - b) < MathUtil.FLOATING_POINT_EQUALITY_TOLERANCE;
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool3x3 IsApproximately(this float3x3 a, float3x3 b)
-        {
-            return new bool3x3(
-                a.c0.IsApproximately(b.c0),
-                a.c1.IsApproximately(b.c1),
-                a.c2.IsApproximately(b.c2)
-            );
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool4x4 IsApproximately(this float4x4 a, float4x4 b)
-        {
-            return new bool4x4(
-                a.c0.IsApproximately(b.c0),
-                a.c1.IsApproximately(b.c1),
-                a.c2.IsApproximately(b.c2),
-                a.c3.IsApproximately(b.c3)
-            );
-        }
-
-        /// <summary>
-        /// Converts the components of a value to infinite quantities where:
-        /// >0 = <see cref="float.PositiveInfinity"/>
-        /// <0 = <see cref="float.NegativeInfinity"/>
-        /// 0 = 0
-        /// </summary>
-        /// <param name="value">The value to convert.</param>
-        /// <returns>A signed infinite value.</returns>
-        public static float3 ToSignedInfinite(this float3 value)
-        {
-            return math.select(math.sign(value) * new float3(float.PositiveInfinity), value, value == 0);
         }
 
         /// <summary>

--- a/Scripts/Runtime/Mathematics/MathExtension.cs
+++ b/Scripts/Runtime/Mathematics/MathExtension.cs
@@ -143,5 +143,35 @@ namespace Anvil.Unity.DOTS.Mathematics
                 a.c3.IsApproximately(b.c3)
             );
         }
+
+        /// <summary>
+        /// Converts the components of a value to infinite quantities where:
+        /// >0 = <see cref="float.PositiveInfinity"/>
+        /// <0 = <see cref="float.NegativeInfinity"/>
+        /// 0 = 0
+        /// </summary>
+        /// <param name="value">The value to convert.</param>
+        /// <returns>A signed infinite value.</returns>
+        public static float3 ToSignedInfinite(this float3 value)
+        {
+            return math.select(math.sign(value) * new float3(float.PositiveInfinity), value, value == 0);
+        }
+
+        /// <summary>
+        /// Checks whether a given transformation matrix is valid.
+        /// </summary>
+        /// <param name="matrix"></param>
+        /// <returns></returns>
+        /// <remarks>
+        /// Returns false if:
+        ///  - The determinant is 0 or <see cref="float.NaN"/>.
+        ///
+        /// An invalid matrix (Ex: with a 0 scale component) cannot be inverted. Special case values must be used when
+        /// transforming through an invalid matrix.
+        /// </remarks>
+        public static bool isValidTransform(this float4x4 matrix)
+        {
+            return math.determinant(matrix) is not 0 and not float.NaN;
+        }
     }
 }

--- a/Scripts/Runtime/Mathematics/MathExtension.cs
+++ b/Scripts/Runtime/Mathematics/MathExtension.cs
@@ -1,5 +1,4 @@
 using System.Runtime.CompilerServices;
-using Anvil.CSharp.Mathematics;
 using Unity.Mathematics;
 
 namespace Anvil.Unity.DOTS.Mathematics
@@ -16,6 +15,10 @@ namespace Anvil.Unity.DOTS.Mathematics
         /// </summary>
         /// <param name="matrix">The matrix to evaluate.</param>
         /// <returns>The scale component from the matrix.</returns>
+        /// <remarks>
+        /// This valid is only valid when used in tandem with <see cref="GetRotation"/> as multiple combinations of scale
+        /// and rotation may be used to represent the same transform.
+        /// </remarks>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static float3 GetScale(this float4x4 matrix)
         {
@@ -35,14 +38,18 @@ namespace Anvil.Unity.DOTS.Mathematics
 
         /// <summary>
         /// Get the rotation component from a TRS matrix.
-        /// On a LocalToWorld matrix this is the world rotation.
+        /// On a <see cref="LocalToWorld"/> matrix this is the world rotation.
         /// </summary>
         /// <param name="matrix">The matrix to evaluate.</param>
         /// <returns>The rotation component from the matrix</returns>
+        /// <remarks>
+        /// This valid is only valid when used in tandem with <see cref="GetScale"/> as multiple combinations of scale
+        /// and rotation may be used to represent the same transform.
+        /// </remarks>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static quaternion GetRotation(this float4x4 matrix)
         {
-            return new quaternion(math.orthonormalize(new float3x3(matrix)));
+            return quaternion.LookRotationSafe(matrix.c2.xyz, matrix.c1.xyz);
 
             //TODO: #117 - Profile
             // Alternate Implementations
@@ -56,8 +63,8 @@ namespace Anvil.Unity.DOTS.Mathematics
             // return new quaternion(matrix);
 
             //OR
-            // 2. Look Rotation Safe
-            // return quaternion.LookRotationSafe(matrix.c2.xyz, matrix.c1.xyz);
+            // 2. Orthonormalize quaternion
+            // return new quaternion(math.orthonormalize(new float3x3(matrix)));
         }
 
         /// <summary>
@@ -67,9 +74,9 @@ namespace Anvil.Unity.DOTS.Mathematics
         /// <param name="matrix">The matrix to evaluate.</param>
         /// <returns>The position component from the matrix</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static float3 GetPosition(this float4x4 matrix)
+        public static float3 GetTranslation(this float4x4 matrix)
         {
-            return new float3(matrix.c0.w, matrix.c1.w, matrix.c2.w);
+            return matrix.c3.xyz;
         }
 
         /// <summary>

--- a/Scripts/Runtime/Mathematics/MathExtension.cs.meta
+++ b/Scripts/Runtime/Mathematics/MathExtension.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 87c3c26472794b699ee0202d3ab11334
+timeCreated: 1668708553


### PR DESCRIPTION
Add a collection of extension methods to aid in working with `Unity.Mathematics` from the perspective of DOTS.
This is the DOTS compliment to https://github.com/decline-cookies/anvil-unity-core/pull/96

### What is the current behaviour?

There are some operations that are cumbersome or error prone when working with `Unity.Mathematics`

### What is the new behaviour?

Add the following extension methods:
 - `GetScale(float4x4)` - Get the signed scale component from a 4x4 matrix.
 - `GetScaleMagnitude(float4x4)` - Get the unsigned scale component from a 4x4 matrix.
 - `GetRotation(float4x4)` - Get the rotation component from a 4x4 matrix.
 - `GetTranslation(float4x4)` - Get the translation component from a 4x4 matrix.
 - `IsValidTransform(float4x4)` - Evaluate whether a 4x4 matrix represents a valid transform

### What issues does this resolve?
- None

### What PRs does this depend on?
 - #120 

### Does this introduce a breaking change?
 - [ ] Yes <!-- If so, what are the migration considerations? -->
 - [x] No
