### PR TITLE
Add `TransformUtil`

### DIFF
--- a/Scripts/Editor/Tests/Entities.meta
+++ b/Scripts/Editor/Tests/Entities.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 3d20b81c9f2484fc1a588c7187d093a9
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/Editor/Tests/Entities/Transform.meta
+++ b/Scripts/Editor/Tests/Entities/Transform.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c18dd165e4a9d4fcea09137547ca4c69
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/Editor/Tests/Entities/Transform/TransformUtilTests.cs
+++ b/Scripts/Editor/Tests/Entities/Transform/TransformUtilTests.cs
@@ -1,13 +1,8 @@
-using System.Collections.Generic;
-using System.Collections.ObjectModel;
 using System.Text.RegularExpressions;
 using Anvil.CSharp.Logging;
-using Anvil.CSharp.Mathematics;
 using Anvil.Unity.DOTS.Entities.Transform;
 using Anvil.Unity.DOTS.Mathematics;
-using Anvil.Unity.Logging;
 using NUnit.Framework;
-using Unity.Collections;
 using Unity.Mathematics;
 using Unity.Transforms;
 using UnityEngine;
@@ -18,6 +13,11 @@ namespace Anvil.Unity.DOTS.Tests.Entities.Transform
 {
     public static class TransformUtilTests
     {
+        private static Logger Logger
+        {
+            get => Log.GetStaticLogger(typeof(TransformUtil));
+        }
+
         //TODO: Update to use [DefaultFloatingPointTolerance] when Unity uses NUnit >=3.7 and remove all .Using<float3>(EqualityWithTolerance) uses
         // https://github.com/nunit/nunit/blob/master/src/NUnitFramework/framework/Attributes/DefaultFloatingPointToleranceAttribute.cs
         private const float FLOATING_POINT_TOLERANCE = 0.00001f;
@@ -44,13 +44,14 @@ namespace Anvil.Unity.DOTS.Tests.Entities.Transform
         [Test]
         public static void ConvertWorldToLocalPointTest_Identity()
         {
+            float3 point_zero = float3.zero;
             float3 point_one = new float3(1, 1, 1);
             float3 point_seven = point_one * 7f;
             float3 point_sevenXY = new float3(point_seven.xy, 0);
 
             LocalToWorld localToWorld_Identity = new LocalToWorld() { Value = float4x4.identity };
             float4x4 worldToLocal_TranslatedOne = math.inverse(localToWorld_Identity.Value);
-            Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_Identity, float3.zero), Is.EqualTo(float3.zero).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_Identity, point_zero), Is.EqualTo(point_zero).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_Identity, point_one), Is.EqualTo(point_one).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_Identity, point_seven), Is.EqualTo(point_seven).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_Identity, point_sevenXY), Is.EqualTo(point_sevenXY).Using<float3>(EqualityWithTolerance));
@@ -58,7 +59,7 @@ namespace Anvil.Unity.DOTS.Tests.Entities.Transform
             Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_Identity, -point_seven), Is.EqualTo(-point_seven).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_Identity, -point_sevenXY), Is.EqualTo(-point_sevenXY).Using<float3>(EqualityWithTolerance));
 
-            Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_TranslatedOne, float3.zero), Is.EqualTo(float3.zero).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_TranslatedOne, point_zero), Is.EqualTo(point_zero).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_TranslatedOne, point_one), Is.EqualTo(point_one).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_TranslatedOne, point_seven), Is.EqualTo(point_seven).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_TranslatedOne, point_sevenXY), Is.EqualTo(point_sevenXY).Using<float3>(EqualityWithTolerance));
@@ -70,6 +71,7 @@ namespace Anvil.Unity.DOTS.Tests.Entities.Transform
         [Test]
         public static void ConvertWorldToLocalPointTest_Translate()
         {
+            float3 point_zero = float3.zero;
             float3 point_one = new float3(1, 1, 1);
             float3 point_seven = point_one * 7f;
             float3 point_oneXY = new float3(1, 1, 0);
@@ -80,16 +82,16 @@ namespace Anvil.Unity.DOTS.Tests.Entities.Transform
                 Value = float4x4.TRS(point_one, quaternion.identity, point_one)
             };
             float4x4 worldToLocal_TranslatedOne = math.inverse(localToWorld_TranslatedOne.Value);
-            Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_TranslatedOne, float3.zero), Is.EqualTo(-point_one).Using<float3>(EqualityWithTolerance));
-            Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_TranslatedOne, point_one), Is.EqualTo(float3.zero).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_TranslatedOne, point_zero), Is.EqualTo(-point_one).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_TranslatedOne, point_one), Is.EqualTo(point_zero).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_TranslatedOne, point_seven), Is.EqualTo(point_seven-point_one).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_TranslatedOne, point_sevenXY), Is.EqualTo(point_sevenXY-point_one).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_TranslatedOne, -point_one), Is.EqualTo(-point_one-point_one).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_TranslatedOne, -point_seven), Is.EqualTo(-point_seven-point_one).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_TranslatedOne, -point_sevenXY), Is.EqualTo(-point_sevenXY-point_one).Using<float3>(EqualityWithTolerance));
 
-            Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_TranslatedOne, float3.zero), Is.EqualTo(-point_one).Using<float3>(EqualityWithTolerance));
-            Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_TranslatedOne, point_one), Is.EqualTo(float3.zero).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_TranslatedOne, point_zero), Is.EqualTo(-point_one).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_TranslatedOne, point_one), Is.EqualTo(point_zero).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_TranslatedOne, point_seven), Is.EqualTo(point_seven-point_one).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_TranslatedOne, point_sevenXY), Is.EqualTo(point_sevenXY-point_one).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_TranslatedOne, -point_one), Is.EqualTo(-point_one-point_one).Using<float3>(EqualityWithTolerance));
@@ -102,19 +104,19 @@ namespace Anvil.Unity.DOTS.Tests.Entities.Transform
                 Value = float4x4.TRS(-point_one, quaternion.identity, point_one)
             };
             float4x4 worldToLocal_TranslatedNegativeOne = math.inverse(localToWorld_TranslatedNegativeOne.Value);
-            Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_TranslatedNegativeOne, float3.zero), Is.EqualTo(point_one).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_TranslatedNegativeOne, point_zero), Is.EqualTo(point_one).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_TranslatedNegativeOne, point_one), Is.EqualTo(point_one+point_one).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_TranslatedNegativeOne, point_seven), Is.EqualTo(point_seven+point_one).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_TranslatedNegativeOne, point_sevenXY), Is.EqualTo(point_sevenXY+point_one).Using<float3>(EqualityWithTolerance));
-            Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_TranslatedNegativeOne, -point_one), Is.EqualTo(float3.zero).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_TranslatedNegativeOne, -point_one), Is.EqualTo(point_zero).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_TranslatedNegativeOne, -point_seven), Is.EqualTo(-point_seven+point_one).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_TranslatedNegativeOne, -point_sevenXY), Is.EqualTo(-point_sevenXY+point_one).Using<float3>(EqualityWithTolerance));
 
-            Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_TranslatedNegativeOne, float3.zero), Is.EqualTo(point_one).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_TranslatedNegativeOne, point_zero), Is.EqualTo(point_one).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_TranslatedNegativeOne, point_one), Is.EqualTo(point_one+point_one).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_TranslatedNegativeOne, point_seven), Is.EqualTo(point_seven+point_one).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_TranslatedNegativeOne, point_sevenXY), Is.EqualTo(point_sevenXY+point_one).Using<float3>(EqualityWithTolerance));
-            Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_TranslatedNegativeOne, -point_one), Is.EqualTo(float3.zero).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_TranslatedNegativeOne, -point_one), Is.EqualTo(point_zero).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_TranslatedNegativeOne, -point_seven), Is.EqualTo(-point_seven+point_one).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_TranslatedNegativeOne, -point_sevenXY), Is.EqualTo(-point_sevenXY+point_one).Using<float3>(EqualityWithTolerance));
 
@@ -124,17 +126,17 @@ namespace Anvil.Unity.DOTS.Tests.Entities.Transform
                 Value = float4x4.TRS(point_seven, quaternion.identity, point_one)
             };
             float4x4 worldToLocal_TranslatedSeven = math.inverse(localToWorld_TranslatedSeven.Value);
-            Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_TranslatedSeven, float3.zero), Is.EqualTo(-point_seven).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_TranslatedSeven, point_zero), Is.EqualTo(-point_seven).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_TranslatedSeven, point_one), Is.EqualTo(-point_seven+point_one).Using<float3>(EqualityWithTolerance));
-            Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_TranslatedSeven, point_seven), Is.EqualTo(float3.zero).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_TranslatedSeven, point_seven), Is.EqualTo(point_zero).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_TranslatedSeven, point_sevenXY), Is.EqualTo(point_sevenXY - point_seven).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_TranslatedSeven, -point_one), Is.EqualTo(-point_seven-point_one).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_TranslatedSeven, -point_seven), Is.EqualTo(-point_seven-point_seven).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_TranslatedSeven, -point_sevenXY), Is.EqualTo(-point_sevenXY-point_seven).Using<float3>(EqualityWithTolerance));
 
-            Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_TranslatedSeven, float3.zero), Is.EqualTo(-point_seven).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_TranslatedSeven, point_zero), Is.EqualTo(-point_seven).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_TranslatedSeven, point_one), Is.EqualTo(-point_seven+point_one).Using<float3>(EqualityWithTolerance));
-            Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_TranslatedSeven, point_seven), Is.EqualTo(float3.zero).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_TranslatedSeven, point_seven), Is.EqualTo(point_zero).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_TranslatedSeven, point_sevenXY), Is.EqualTo(point_sevenXY - point_seven).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_TranslatedSeven, -point_one), Is.EqualTo(-point_seven-point_one).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_TranslatedSeven, -point_seven), Is.EqualTo(-point_seven-point_seven).Using<float3>(EqualityWithTolerance));
@@ -146,20 +148,20 @@ namespace Anvil.Unity.DOTS.Tests.Entities.Transform
                 Value = float4x4.TRS(-point_seven, quaternion.identity, point_one)
             };
             float4x4 worldToLocal_TranslatedNegativeSeven = math.inverse(localToWorld_TranslatedNegativeSeven.Value);
-            Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_TranslatedNegativeSeven, float3.zero), Is.EqualTo(point_seven).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_TranslatedNegativeSeven, point_zero), Is.EqualTo(point_seven).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_TranslatedNegativeSeven, point_one), Is.EqualTo(point_seven+point_one).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_TranslatedNegativeSeven, point_seven), Is.EqualTo(point_seven+point_seven).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_TranslatedNegativeSeven, point_sevenXY), Is.EqualTo(point_sevenXY+point_seven).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_TranslatedNegativeSeven, -point_one), Is.EqualTo(point_seven-point_one).Using<float3>(EqualityWithTolerance));
-            Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_TranslatedNegativeSeven, -point_seven), Is.EqualTo(float3.zero).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_TranslatedNegativeSeven, -point_seven), Is.EqualTo(point_zero).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_TranslatedNegativeSeven, -point_sevenXY), Is.EqualTo(point_seven-point_sevenXY).Using<float3>(EqualityWithTolerance));
 
-            Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_TranslatedNegativeSeven, float3.zero), Is.EqualTo(point_seven).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_TranslatedNegativeSeven, point_zero), Is.EqualTo(point_seven).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_TranslatedNegativeSeven, point_one), Is.EqualTo(point_seven+point_one).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_TranslatedNegativeSeven, point_seven), Is.EqualTo(point_seven+point_seven).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_TranslatedNegativeSeven, point_sevenXY), Is.EqualTo(point_sevenXY+point_seven).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_TranslatedNegativeSeven, -point_one), Is.EqualTo(point_seven-point_one).Using<float3>(EqualityWithTolerance));
-            Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_TranslatedNegativeSeven, -point_seven), Is.EqualTo(float3.zero).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_TranslatedNegativeSeven, -point_seven), Is.EqualTo(point_zero).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_TranslatedNegativeSeven, -point_sevenXY), Is.EqualTo(point_seven-point_sevenXY).Using<float3>(EqualityWithTolerance));
 
 
@@ -168,18 +170,18 @@ namespace Anvil.Unity.DOTS.Tests.Entities.Transform
                 Value = float4x4.TRS(point_sevenXY, quaternion.identity, point_one)
             };
             float4x4 worldToLocal_TranslatedSevenXY = math.inverse(localToWorld_TranslatedSevenXY.Value);
-            Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_TranslatedSevenXY, float3.zero), Is.EqualTo(-point_sevenXY).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_TranslatedSevenXY, point_zero), Is.EqualTo(-point_sevenXY).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_TranslatedSevenXY, point_one), Is.EqualTo(-point_sevenXY+point_one).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_TranslatedSevenXY, point_seven), Is.EqualTo(point_seven-point_sevenXY).Using<float3>(EqualityWithTolerance));
-            Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_TranslatedSevenXY, point_sevenXY), Is.EqualTo(float3.zero).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_TranslatedSevenXY, point_sevenXY), Is.EqualTo(point_zero).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_TranslatedSevenXY, -point_one), Is.EqualTo(-point_sevenXY-point_one).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_TranslatedSevenXY, -point_seven), Is.EqualTo(-point_seven-point_sevenXY).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_TranslatedSevenXY, -point_sevenXY), Is.EqualTo(-point_sevenXY-point_sevenXY).Using<float3>(EqualityWithTolerance));
 
-            Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_TranslatedSevenXY, float3.zero), Is.EqualTo(-point_sevenXY).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_TranslatedSevenXY, point_zero), Is.EqualTo(-point_sevenXY).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_TranslatedSevenXY, point_one), Is.EqualTo(-point_sevenXY+point_one).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_TranslatedSevenXY, point_seven), Is.EqualTo(point_seven-point_sevenXY).Using<float3>(EqualityWithTolerance));
-            Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_TranslatedSevenXY, point_sevenXY), Is.EqualTo(float3.zero).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_TranslatedSevenXY, point_sevenXY), Is.EqualTo(point_zero).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_TranslatedSevenXY, -point_one), Is.EqualTo(-point_sevenXY-point_one).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_TranslatedSevenXY, -point_seven), Is.EqualTo(-point_seven-point_sevenXY).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_TranslatedSevenXY, -point_sevenXY), Is.EqualTo(-point_sevenXY-point_sevenXY).Using<float3>(EqualityWithTolerance));
@@ -188,21 +190,22 @@ namespace Anvil.Unity.DOTS.Tests.Entities.Transform
         [Test]
         public static void ConvertWorldToLocalPointTest_Rotate()
         {
+            float3 point_zero = float3.zero;
             float3 point_one = new float3(1, 1, 1);
             float3 point_seven = point_one * 7f;
 
             LocalToWorld localToWorld_RotatedZ90 = new LocalToWorld()
             {
-                Value = float4x4.TRS(float3.zero, quaternion.Euler(0, 0, math.radians(90)), point_one)
+                Value = float4x4.TRS(point_zero, quaternion.Euler(0, 0, math.radians(90)), point_one)
             };
             float4x4 worldToLocal_RotatedZ90 = math.inverse(localToWorld_RotatedZ90.Value);
-            Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_RotatedZ90, float3.zero), Is.EqualTo(float3.zero).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_RotatedZ90, point_zero), Is.EqualTo(point_zero).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_RotatedZ90, point_one), Is.EqualTo(new float3(1f, -1f, 1f)).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_RotatedZ90, point_seven), Is.EqualTo(new float3(7f, -7f, 7f)).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_RotatedZ90, -point_one), Is.EqualTo(new float3(-1f, 1f, -1f)).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_RotatedZ90, -point_seven), Is.EqualTo(new float3(-7f, 7f, -7f)).Using<float3>(EqualityWithTolerance));
 
-            Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_RotatedZ90, float3.zero), Is.EqualTo(float3.zero).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_RotatedZ90, point_zero), Is.EqualTo(point_zero).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_RotatedZ90, point_one), Is.EqualTo(new float3(1f, -1f, 1f)).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_RotatedZ90, point_seven), Is.EqualTo(new float3(7f, -7f, 7f)).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_RotatedZ90, -point_one), Is.EqualTo(new float3(-1f, 1f, -1f)).Using<float3>(EqualityWithTolerance));
@@ -211,16 +214,16 @@ namespace Anvil.Unity.DOTS.Tests.Entities.Transform
 
             LocalToWorld localToWorld_RotatedZNegative90 = new LocalToWorld()
             {
-                Value = float4x4.TRS(float3.zero, quaternion.Euler(0, 0, math.radians(-90)), point_one)
+                Value = float4x4.TRS(point_zero, quaternion.Euler(0, 0, math.radians(-90)), point_one)
             };
             float4x4 worldToLocal_RotatedNegative90 = math.inverse(localToWorld_RotatedZNegative90.Value);
-            Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_RotatedZNegative90, float3.zero), Is.EqualTo(float3.zero).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_RotatedZNegative90, point_zero), Is.EqualTo(point_zero).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_RotatedZNegative90, point_one), Is.EqualTo(new float3(-1f, 1f, 1f)).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_RotatedZNegative90, point_seven), Is.EqualTo(new float3(-7f, 7f, 7f)).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_RotatedZNegative90, -point_one), Is.EqualTo(new float3(1f, -1f, -1f)).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_RotatedZNegative90, -point_seven), Is.EqualTo(new float3(7f, -7f, -7f)).Using<float3>(EqualityWithTolerance));
 
-            Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_RotatedNegative90, float3.zero), Is.EqualTo(float3.zero).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_RotatedNegative90, point_zero), Is.EqualTo(point_zero).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_RotatedNegative90, point_one), Is.EqualTo(new float3(-1f, 1f, 1f)).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_RotatedNegative90, point_seven), Is.EqualTo(new float3(-7f, 7f, 7f)).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_RotatedNegative90, -point_one), Is.EqualTo(new float3(1f, -1f, -1f)).Using<float3>(EqualityWithTolerance));
@@ -229,16 +232,16 @@ namespace Anvil.Unity.DOTS.Tests.Entities.Transform
 
             LocalToWorld localToWorld_RotatedZX90 = new LocalToWorld()
             {
-                Value = float4x4.TRS(float3.zero, quaternion.Euler(math.radians(90), 0, math.radians(90)), point_one)
+                Value = float4x4.TRS(point_zero, quaternion.Euler(math.radians(90), 0, math.radians(90)), point_one)
             };
             float4x4 worldToLocal_RotatedZX90 = math.inverse(localToWorld_RotatedZX90.Value);
-            Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_RotatedZX90, float3.zero), Is.EqualTo(float3.zero).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_RotatedZX90, point_zero), Is.EqualTo(point_zero).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_RotatedZX90, point_one), Is.EqualTo(new float3(1f, -1f, -1f)).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_RotatedZX90, point_seven), Is.EqualTo(new float3(7f, -7f, -7f)).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_RotatedZX90, -point_one), Is.EqualTo(new float3(-1f, 1f, 1f)).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_RotatedZX90, -point_seven), Is.EqualTo(new float3(-7f, 7f, 7f)).Using<float3>(EqualityWithTolerance));
 
-            Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_RotatedZX90, float3.zero), Is.EqualTo(float3.zero).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_RotatedZX90, point_zero), Is.EqualTo(point_zero).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_RotatedZX90, point_one), Is.EqualTo(new float3(1f, -1f, -1f)).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_RotatedZX90, point_seven), Is.EqualTo(new float3(7f, -7f, -7f)).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_RotatedZX90, -point_one), Is.EqualTo(new float3(-1f, 1f, 1f)).Using<float3>(EqualityWithTolerance));
@@ -247,16 +250,16 @@ namespace Anvil.Unity.DOTS.Tests.Entities.Transform
 
             LocalToWorld localToWorld_RotatedZXNegative90 = new LocalToWorld()
             {
-                Value = float4x4.TRS(float3.zero, quaternion.Euler(math.radians(-90), 0, math.radians(-90)), point_one)
+                Value = float4x4.TRS(point_zero, quaternion.Euler(math.radians(-90), 0, math.radians(-90)), point_one)
             };
             float4x4 worldToLocal_RotatedZXNegative90 = math.inverse(localToWorld_RotatedZXNegative90.Value);
-            Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_RotatedZXNegative90, float3.zero), Is.EqualTo(float3.zero));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_RotatedZXNegative90, point_zero), Is.EqualTo(point_zero));
             Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_RotatedZXNegative90, point_one), Is.EqualTo(point_one).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_RotatedZXNegative90, point_seven), Is.EqualTo(point_seven).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_RotatedZXNegative90, -point_one), Is.EqualTo(-point_one).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_RotatedZXNegative90, -point_seven), Is.EqualTo(-point_seven).Using<float3>(EqualityWithTolerance));
 
-            Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_RotatedZXNegative90, float3.zero), Is.EqualTo(float3.zero).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_RotatedZXNegative90, point_zero), Is.EqualTo(point_zero).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_RotatedZXNegative90, point_one), Is.EqualTo(point_one).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_RotatedZXNegative90, point_seven), Is.EqualTo(point_seven).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_RotatedZXNegative90, -point_one), Is.EqualTo(-point_one).Using<float3>(EqualityWithTolerance));
@@ -265,16 +268,16 @@ namespace Anvil.Unity.DOTS.Tests.Entities.Transform
 
             LocalToWorld localToWorld_RotatedZX45 = new LocalToWorld()
             {
-                Value = float4x4.TRS(float3.zero, quaternion.Euler(math.radians(45), 0, math.radians(45)), point_one)
+                Value = float4x4.TRS(point_zero, quaternion.Euler(math.radians(45), 0, math.radians(45)), point_one)
             };
             float4x4 worldToLocal_RotatedZX45 = math.inverse(localToWorld_RotatedZX45.Value);
-            Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_RotatedZX45, float3.zero), Is.EqualTo(float3.zero).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_RotatedZX45, point_zero), Is.EqualTo(point_zero).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_RotatedZX45, point_one), Is.EqualTo(new float3(1.70710683f,0.292893201f,0f)).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_RotatedZX45, point_seven), Is.EqualTo(new float3(11.9497471f,2.0502522f,0f)).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_RotatedZX45, -point_one), Is.EqualTo(new float3(-1.70710683f,-0.292893201f,0f)).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_RotatedZX45, -point_seven), Is.EqualTo(new float3(-11.9497471f,-2.0502522f,0f)).Using<float3>(EqualityWithTolerance));
 
-            Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_RotatedZX45, float3.zero), Is.EqualTo(float3.zero).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_RotatedZX45, point_zero), Is.EqualTo(point_zero).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_RotatedZX45, point_one), Is.EqualTo(new float3(1.70710683f,0.292893201f,0f)).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_RotatedZX45, point_seven), Is.EqualTo(new float3(11.9497471f,2.0502522f,0f)).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_RotatedZX45, -point_one), Is.EqualTo(new float3(-1.70710683f,-0.292893201f,0f)).Using<float3>(EqualityWithTolerance));
@@ -284,21 +287,25 @@ namespace Anvil.Unity.DOTS.Tests.Entities.Transform
         [Test]
         public static void ConvertWorldToLocalPointTest_Scale()
         {
+            Regex invalidMatrixError_point = new Regex(@"This transform is invalid\. Returning a signed infinite position\.");
+
+            float3 point_infinity = new float3(float.PositiveInfinity);
+            float3 point_zero = float3.zero;
             float3 point_one = new float3(1, 1, 1);
             float3 point_seven = point_one * 7f;
 
             LocalToWorld localToWorld_Scaled2 = new LocalToWorld()
             {
-                Value = float4x4.TRS(float3.zero, quaternion.identity, point_one*2f)
+                Value = float4x4.TRS(point_zero, quaternion.identity, point_one*2f)
             };
             float4x4 worldToLocal_Scaled2 = math.inverse(localToWorld_Scaled2.Value);
-            Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_Scaled2, float3.zero), Is.EqualTo(float3.zero).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_Scaled2, point_zero), Is.EqualTo(point_zero).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_Scaled2, point_one), Is.EqualTo(point_one/2f).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_Scaled2, point_seven), Is.EqualTo(point_seven/2f).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_Scaled2, -point_one), Is.EqualTo(-point_one/2f).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_Scaled2, -point_seven), Is.EqualTo(-point_seven/2f).Using<float3>(EqualityWithTolerance));
 
-            Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_Scaled2, float3.zero), Is.EqualTo(float3.zero).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_Scaled2, point_zero), Is.EqualTo(point_zero).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_Scaled2, point_one), Is.EqualTo(point_one/2f).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_Scaled2, point_seven), Is.EqualTo(point_seven/2f).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_Scaled2, -point_one), Is.EqualTo(-point_one/2f).Using<float3>(EqualityWithTolerance));
@@ -307,16 +314,16 @@ namespace Anvil.Unity.DOTS.Tests.Entities.Transform
 
             LocalToWorld localToWorld_ScaledNegative2 = new LocalToWorld()
             {
-                Value = float4x4.TRS(float3.zero, quaternion.identity, point_one*-2f)
+                Value = float4x4.TRS(point_zero, quaternion.identity, point_one*-2f)
             };
             float4x4 worldToLocal_ScaledNegative2 = math.inverse(localToWorld_ScaledNegative2.Value);
-            Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_ScaledNegative2, float3.zero), Is.EqualTo(float3.zero).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_ScaledNegative2, point_zero), Is.EqualTo(point_zero).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_ScaledNegative2, point_one), Is.EqualTo(-point_one/2f).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_ScaledNegative2, point_seven), Is.EqualTo(-point_seven/2f).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_ScaledNegative2, -point_one), Is.EqualTo(point_one/2f).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_ScaledNegative2, -point_seven), Is.EqualTo(point_seven/2f).Using<float3>(EqualityWithTolerance));
 
-            Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_ScaledNegative2, float3.zero), Is.EqualTo(float3.zero).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_ScaledNegative2, point_zero), Is.EqualTo(point_zero).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_ScaledNegative2, point_one), Is.EqualTo(-point_one/2f).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_ScaledNegative2, point_seven), Is.EqualTo(-point_seven/2f).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_ScaledNegative2, -point_one), Is.EqualTo(point_one/2f).Using<float3>(EqualityWithTolerance));
@@ -326,16 +333,16 @@ namespace Anvil.Unity.DOTS.Tests.Entities.Transform
             float3 scaleZ2 = new float3(point_one.xy, 2f);
             LocalToWorld localToWorld_ScaledZ2 = new LocalToWorld()
             {
-                Value = float4x4.TRS(float3.zero, quaternion.identity, scaleZ2)
+                Value = float4x4.TRS(point_zero, quaternion.identity, scaleZ2)
             };
             float4x4 worldToLocal_ScaledZ2 = math.inverse(localToWorld_ScaledZ2.Value);
-            Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_ScaledZ2, float3.zero), Is.EqualTo(float3.zero).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_ScaledZ2, point_zero), Is.EqualTo(point_zero).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_ScaledZ2, point_one), Is.EqualTo(point_one/scaleZ2).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_ScaledZ2, point_seven), Is.EqualTo(point_seven/scaleZ2).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_ScaledZ2, -point_one), Is.EqualTo(-point_one/scaleZ2).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_ScaledZ2, -point_seven), Is.EqualTo(-point_seven/scaleZ2).Using<float3>(EqualityWithTolerance));
 
-            Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_ScaledZ2, float3.zero), Is.EqualTo(float3.zero).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_ScaledZ2, point_zero), Is.EqualTo(point_zero).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_ScaledZ2, point_one), Is.EqualTo(point_one/scaleZ2).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_ScaledZ2, point_seven), Is.EqualTo(point_seven/scaleZ2).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_ScaledZ2, -point_one), Is.EqualTo(-point_one/scaleZ2).Using<float3>(EqualityWithTolerance));
@@ -345,16 +352,16 @@ namespace Anvil.Unity.DOTS.Tests.Entities.Transform
             float3 scaleZNegative2 = new float3(point_one.xy, -2f);
             LocalToWorld localToWorld_ScaledZNegative2 = new LocalToWorld()
             {
-                Value = float4x4.TRS(float3.zero, quaternion.identity, scaleZNegative2)
+                Value = float4x4.TRS(point_zero, quaternion.identity, scaleZNegative2)
             };
             float4x4 worldToLocal_ScaledZNegative2 = math.inverse(localToWorld_ScaledZNegative2.Value);
-            Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_ScaledZNegative2, float3.zero), Is.EqualTo(float3.zero).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_ScaledZNegative2, point_zero), Is.EqualTo(point_zero).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_ScaledZNegative2, point_one), Is.EqualTo(point_one/scaleZNegative2).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_ScaledZNegative2, point_seven), Is.EqualTo(point_seven/scaleZNegative2).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_ScaledZNegative2, -point_one), Is.EqualTo(-point_one/scaleZNegative2).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_ScaledZNegative2, -point_seven), Is.EqualTo(-point_seven/scaleZNegative2).Using<float3>(EqualityWithTolerance));
 
-            Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_ScaledZNegative2, float3.zero), Is.EqualTo(float3.zero).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_ScaledZNegative2, point_zero), Is.EqualTo(point_zero).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_ScaledZNegative2, point_one), Is.EqualTo(point_one/scaleZNegative2).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_ScaledZNegative2, point_seven), Is.EqualTo(point_seven/scaleZNegative2).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_ScaledZNegative2, -point_one), Is.EqualTo(-point_one/scaleZNegative2).Using<float3>(EqualityWithTolerance));
@@ -364,25 +371,67 @@ namespace Anvil.Unity.DOTS.Tests.Entities.Transform
             float3 scaleZXOnePointFive = new float3(1.5f, 1f, 1.5f);
             LocalToWorld localToWorld_ScaledZXOnePointFive = new LocalToWorld()
             {
-                Value = float4x4.TRS(float3.zero, quaternion.identity, scaleZXOnePointFive)
+                Value = float4x4.TRS(point_zero, quaternion.identity, scaleZXOnePointFive)
             };
             float4x4 worldToLocal_ScaledZXOnePointFive = math.inverse(localToWorld_ScaledZXOnePointFive.Value);
-            Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_ScaledZXOnePointFive, float3.zero), Is.EqualTo(float3.zero).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_ScaledZXOnePointFive, point_zero), Is.EqualTo(point_zero).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_ScaledZXOnePointFive, point_one), Is.EqualTo(point_one/scaleZXOnePointFive).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_ScaledZXOnePointFive, point_seven), Is.EqualTo(point_seven/scaleZXOnePointFive).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_ScaledZXOnePointFive, -point_one), Is.EqualTo(-point_one/scaleZXOnePointFive).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_ScaledZXOnePointFive, -point_seven), Is.EqualTo(-point_seven/scaleZXOnePointFive).Using<float3>(EqualityWithTolerance));
 
-            Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_ScaledZXOnePointFive, float3.zero), Is.EqualTo(float3.zero).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_ScaledZXOnePointFive, point_zero), Is.EqualTo(point_zero).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_ScaledZXOnePointFive, point_one), Is.EqualTo(point_one/scaleZXOnePointFive).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_ScaledZXOnePointFive, point_seven), Is.EqualTo(point_seven/scaleZXOnePointFive).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_ScaledZXOnePointFive, -point_one), Is.EqualTo(-point_one/scaleZXOnePointFive).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_ScaledZXOnePointFive, -point_seven), Is.EqualTo(-point_seven/scaleZXOnePointFive).Using<float3>(EqualityWithTolerance));
+
+
+            LocalToWorld localToWorld_zero = new LocalToWorld()
+            {
+                Value = float4x4.TRS(point_zero, quaternion.identity, point_zero)
+            };
+            float4x4 worldToLocal_zero = float4x4.TRS(point_zero, quaternion.identity, point_zero);
+
+            Logger.Debug("BEGIN: Expected error messages.");
+            LogAssert.Expect(LogType.Error, invalidMatrixError_point);
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_zero, point_zero), Is.EqualTo(point_zero));
+            LogAssert.Expect(LogType.Error, invalidMatrixError_point);
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_zero, point_one), Is.EqualTo(point_infinity));
+            LogAssert.Expect(LogType.Error, invalidMatrixError_point);
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_zero, point_seven), Is.EqualTo(point_infinity));
+            LogAssert.Expect(LogType.Error, invalidMatrixError_point);
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_zero, -point_one), Is.EqualTo(-point_infinity));
+            LogAssert.Expect(LogType.Error, invalidMatrixError_point);
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_zero, -point_seven), Is.EqualTo(-point_infinity));
+            LogAssert.Expect(LogType.Error, invalidMatrixError_point);
+            Assert.That(
+                TransformUtil.ConvertWorldToLocalPoint(localToWorld_zero, new float3(2, -2, 0)),
+                Is.EqualTo(new float3(float.PositiveInfinity, float.NegativeInfinity, 0))
+                );
+
+            LogAssert.Expect(LogType.Error, invalidMatrixError_point);
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_zero, point_zero), Is.EqualTo(point_zero));
+            LogAssert.Expect(LogType.Error, invalidMatrixError_point);
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_zero, point_one), Is.EqualTo(point_infinity));
+            LogAssert.Expect(LogType.Error, invalidMatrixError_point);
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_zero, point_seven), Is.EqualTo(point_infinity));
+            LogAssert.Expect(LogType.Error, invalidMatrixError_point);
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_zero, -point_one), Is.EqualTo(-point_infinity));
+            LogAssert.Expect(LogType.Error, invalidMatrixError_point);
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_zero, -point_seven), Is.EqualTo(-point_infinity));
+            LogAssert.Expect(LogType.Error, invalidMatrixError_point);
+            Assert.That(
+                TransformUtil.ConvertWorldToLocalPoint(worldToLocal_zero, new float3(2, -2, 0)),
+                Is.EqualTo(new float3(float.PositiveInfinity, float.NegativeInfinity, 0))
+            );
+            Logger.Debug("END: Expected error messages.");
         }
 
         [Test]
         public static void ConvertWorldToLocalPointTest_Compound()
         {
+            float3 point_zero = float3.zero;
             float3 point_one = new float3(1f, 1f, 1f);
             float3 point_seven = point_one * 7f;
             float3 point_sevenXY = new float3(point_seven.xy, 0f);
@@ -392,13 +441,13 @@ namespace Anvil.Unity.DOTS.Tests.Entities.Transform
                 Value = float4x4.TRS(point_sevenXY, quaternion.Euler(math.radians(45), 0, math.radians(45)), point_one*2f)
             };
             float4x4 worldToLocal_Compound = math.inverse(localToWorld_Compound.Value);
-            Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_Compound, float3.zero), Is.EqualTo(new float3(-4.22487354f, 0.7248739f, 2.47487402f)).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_Compound, point_zero), Is.EqualTo(new float3(-4.22487354f, 0.7248739f, 2.47487402f)).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_Compound, point_one), Is.EqualTo(new float3(-3.37132025f, 0.871320367f, 2.47487402f)).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_Compound, point_seven), Is.EqualTo(new float3(1.75f, 1.75f, 2.47487378f)).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_Compound, -point_one), Is.EqualTo(new float3(-5.07842731f, 0.578427196f, 2.47487402f)).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_Compound, -point_seven), Is.EqualTo(new float3(-10.1997471f, -0.300252199f, 2.4748745f)).Using<float3>(EqualityWithTolerance));
 
-            Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_Compound, float3.zero), Is.EqualTo(new float3(-4.22487354f, 0.7248739f, 2.47487402f)).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_Compound, point_zero), Is.EqualTo(new float3(-4.22487354f, 0.7248739f, 2.47487402f)).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_Compound, point_one), Is.EqualTo(new float3(-3.37132025f, 0.871320367f, 2.47487402f)).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_Compound, point_seven), Is.EqualTo(new float3(1.75f, 1.75f, 2.47487378f)).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_Compound, -point_one), Is.EqualTo(new float3(-5.07842731f, 0.578427196f, 2.47487402f)).Using<float3>(EqualityWithTolerance));
@@ -410,13 +459,13 @@ namespace Anvil.Unity.DOTS.Tests.Entities.Transform
                 Value = float4x4.TRS(-point_sevenXY, quaternion.Euler(math.radians(-45), 0, math.radians(-45)), point_one*-2f)
             };
             float4x4 worldToLocal_CompoundNegative = math.inverse(localToWorld_CompoundNegative.Value);
-            Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_CompoundNegative, float3.zero), Is.EqualTo(new float3(-0.724873781f, -4.22487402f, -2.47487402f)).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_CompoundNegative, point_zero), Is.EqualTo(new float3(-0.724873781f, -4.22487402f, -2.47487402f)).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_CompoundNegative, point_one), Is.EqualTo(new float3(-1.07842731f, -4.57842731f, -3.18198061f)).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_CompoundNegative, point_seven), Is.EqualTo(new float3(-3.19974756f,-6.69974804f,-7.42462158f)).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_CompoundNegative, -point_one), Is.EqualTo(new float3(-0.371320248f, -3.87132072f, -1.76776719f)).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_CompoundNegative, -point_seven), Is.EqualTo(new float3(1.75f, -1.75f, 2.47487378f)).Using<float3>(EqualityWithTolerance));
 
-            Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_CompoundNegative, float3.zero), Is.EqualTo(new float3(-0.724873781f, -4.22487402f, -2.47487402f)).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_CompoundNegative, point_zero), Is.EqualTo(new float3(-0.724873781f, -4.22487402f, -2.47487402f)).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_CompoundNegative, point_one), Is.EqualTo(new float3(-1.07842731f, -4.57842731f, -3.18198061f)).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_CompoundNegative, point_seven), Is.EqualTo(new float3(-3.19974756f,-6.69974804f,-7.42462158f)).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_CompoundNegative, -point_one), Is.EqualTo(new float3(-0.371320248f, -3.87132072f, -1.76776719f)).Using<float3>(EqualityWithTolerance));
@@ -427,13 +476,14 @@ namespace Anvil.Unity.DOTS.Tests.Entities.Transform
         [Test]
         public static void ConvertLocalToWorldPointTest_Identity()
         {
+            float3 point_zero = float3.zero;
             float3 point_one = new float3(1, 1, 1);
             float3 point_seven = point_one * 7f;
             float3 point_oneXY = new float3(1, 1, 0);
             float3 point_sevenXY = point_oneXY * 7f;
 
             LocalToWorld localToWorld_Identity = new LocalToWorld() { Value = float4x4.identity };
-            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_Identity, float3.zero), Is.EqualTo(float3.zero).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_Identity, point_zero), Is.EqualTo(point_zero).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_Identity, point_one), Is.EqualTo(point_one).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_Identity, point_seven), Is.EqualTo(point_seven).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_Identity, point_sevenXY), Is.EqualTo(point_sevenXY).Using<float3>(EqualityWithTolerance));
@@ -441,7 +491,7 @@ namespace Anvil.Unity.DOTS.Tests.Entities.Transform
             Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_Identity, -point_seven), Is.EqualTo(-point_seven).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_Identity, -point_sevenXY), Is.EqualTo(-point_sevenXY).Using<float3>(EqualityWithTolerance));
 
-            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_Identity.Value, float3.zero), Is.EqualTo(float3.zero).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_Identity.Value, point_zero), Is.EqualTo(point_zero).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_Identity.Value, point_one), Is.EqualTo(point_one).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_Identity.Value, point_seven), Is.EqualTo(point_seven).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_Identity.Value, point_sevenXY), Is.EqualTo(point_sevenXY).Using<float3>(EqualityWithTolerance));
@@ -453,6 +503,7 @@ namespace Anvil.Unity.DOTS.Tests.Entities.Transform
         [Test]
         public static void ConvertLocalToWorldPointTest_Translate()
         {
+            float3 point_zero = float3.zero;
             float3 point_one = new float3(1, 1, 1);
             float3 point_seven = point_one * 7f;
             float3 point_oneXY = new float3(1, 1, 0);
@@ -463,19 +514,19 @@ namespace Anvil.Unity.DOTS.Tests.Entities.Transform
             {
                 Value = float4x4.TRS(point_one, quaternion.identity, point_one)
             };
-            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_TranslatedOne, float3.zero), Is.EqualTo(point_one).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_TranslatedOne, point_zero), Is.EqualTo(point_one).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_TranslatedOne, point_one), Is.EqualTo(point_one+point_one).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_TranslatedOne, point_seven), Is.EqualTo(point_seven+point_one).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_TranslatedOne, point_sevenXY), Is.EqualTo(point_sevenXY+point_one).Using<float3>(EqualityWithTolerance));
-            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_TranslatedOne, -point_one), Is.EqualTo(float3.zero).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_TranslatedOne, -point_one), Is.EqualTo(point_zero).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_TranslatedOne, -point_seven), Is.EqualTo(-point_seven+point_one).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_TranslatedOne, -point_sevenXY), Is.EqualTo(-point_sevenXY+point_one).Using<float3>(EqualityWithTolerance));
 
-            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_TranslatedOne.Value, float3.zero), Is.EqualTo(point_one).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_TranslatedOne.Value, point_zero), Is.EqualTo(point_one).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_TranslatedOne.Value, point_one), Is.EqualTo(point_one+point_one).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_TranslatedOne.Value, point_seven), Is.EqualTo(point_seven+point_one).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_TranslatedOne.Value, point_sevenXY), Is.EqualTo(point_sevenXY+point_one).Using<float3>(EqualityWithTolerance));
-            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_TranslatedOne.Value, -point_one), Is.EqualTo(float3.zero).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_TranslatedOne.Value, -point_one), Is.EqualTo(point_zero).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_TranslatedOne.Value, -point_seven), Is.EqualTo(-point_seven+point_one).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_TranslatedOne.Value, -point_sevenXY), Is.EqualTo(-point_sevenXY+point_one).Using<float3>(EqualityWithTolerance));
 
@@ -484,16 +535,16 @@ namespace Anvil.Unity.DOTS.Tests.Entities.Transform
             {
                 Value = float4x4.TRS(-point_one, quaternion.identity, point_one)
             };
-            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_TranslatedNegativeOne, float3.zero), Is.EqualTo(-point_one).Using<float3>(EqualityWithTolerance));
-            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_TranslatedNegativeOne, point_one), Is.EqualTo(float3.zero).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_TranslatedNegativeOne, point_zero), Is.EqualTo(-point_one).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_TranslatedNegativeOne, point_one), Is.EqualTo(point_zero).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_TranslatedNegativeOne, point_seven), Is.EqualTo(point_seven-point_one).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_TranslatedNegativeOne, point_sevenXY), Is.EqualTo(point_sevenXY-point_one).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_TranslatedNegativeOne, -point_one), Is.EqualTo(-point_one-point_one).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_TranslatedNegativeOne, -point_seven), Is.EqualTo(-point_seven-point_one).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_TranslatedNegativeOne, -point_sevenXY), Is.EqualTo(-point_sevenXY-point_one).Using<float3>(EqualityWithTolerance));
 
-            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_TranslatedNegativeOne.Value, float3.zero), Is.EqualTo(-point_one).Using<float3>(EqualityWithTolerance));
-            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_TranslatedNegativeOne.Value, point_one), Is.EqualTo(float3.zero).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_TranslatedNegativeOne.Value, point_zero), Is.EqualTo(-point_one).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_TranslatedNegativeOne.Value, point_one), Is.EqualTo(point_zero).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_TranslatedNegativeOne.Value, point_seven), Is.EqualTo(point_seven-point_one).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_TranslatedNegativeOne.Value, point_sevenXY), Is.EqualTo(point_sevenXY-point_one).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_TranslatedNegativeOne.Value, -point_one), Is.EqualTo(-point_one-point_one).Using<float3>(EqualityWithTolerance));
@@ -505,20 +556,20 @@ namespace Anvil.Unity.DOTS.Tests.Entities.Transform
             {
                 Value = float4x4.TRS(point_seven, quaternion.identity, point_one)
             };
-            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_TranslatedSeven, float3.zero), Is.EqualTo(point_seven).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_TranslatedSeven, point_zero), Is.EqualTo(point_seven).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_TranslatedSeven, point_one), Is.EqualTo(point_seven+point_one).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_TranslatedSeven, point_seven), Is.EqualTo(point_seven+point_seven).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_TranslatedSeven, point_sevenXY), Is.EqualTo(point_sevenXY+point_seven).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_TranslatedSeven, -point_one), Is.EqualTo(point_seven-point_one).Using<float3>(EqualityWithTolerance));
-            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_TranslatedSeven, -point_seven), Is.EqualTo(float3.zero).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_TranslatedSeven, -point_seven), Is.EqualTo(point_zero).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_TranslatedSeven, -point_sevenXY), Is.EqualTo(-point_sevenXY+point_seven).Using<float3>(EqualityWithTolerance));
 
-            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_TranslatedSeven.Value, float3.zero), Is.EqualTo(point_seven).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_TranslatedSeven.Value, point_zero), Is.EqualTo(point_seven).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_TranslatedSeven.Value, point_one), Is.EqualTo(point_seven+point_one).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_TranslatedSeven.Value, point_seven), Is.EqualTo(point_seven+point_seven).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_TranslatedSeven.Value, point_sevenXY), Is.EqualTo(point_sevenXY+point_seven).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_TranslatedSeven.Value, -point_one), Is.EqualTo(point_seven-point_one).Using<float3>(EqualityWithTolerance));
-            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_TranslatedSeven.Value, -point_seven), Is.EqualTo(float3.zero).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_TranslatedSeven.Value, -point_seven), Is.EqualTo(point_zero).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_TranslatedSeven.Value, -point_sevenXY), Is.EqualTo(-point_sevenXY+point_seven).Using<float3>(EqualityWithTolerance));
 
 
@@ -526,17 +577,17 @@ namespace Anvil.Unity.DOTS.Tests.Entities.Transform
             {
                 Value = float4x4.TRS(-point_seven, quaternion.identity, point_one)
             };
-            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_TranslatedNegativeSeven, float3.zero), Is.EqualTo(-point_seven).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_TranslatedNegativeSeven, point_zero), Is.EqualTo(-point_seven).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_TranslatedNegativeSeven, point_one), Is.EqualTo(-point_seven+point_one).Using<float3>(EqualityWithTolerance));
-            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_TranslatedNegativeSeven, point_seven), Is.EqualTo(float3.zero).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_TranslatedNegativeSeven, point_seven), Is.EqualTo(point_zero).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_TranslatedNegativeSeven, point_sevenXY), Is.EqualTo(point_sevenXY-point_seven).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_TranslatedNegativeSeven, -point_one), Is.EqualTo(-point_seven-point_one).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_TranslatedNegativeSeven, -point_seven), Is.EqualTo(-point_seven-point_seven).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_TranslatedNegativeSeven, -point_sevenXY), Is.EqualTo(-point_sevenXY-point_seven).Using<float3>(EqualityWithTolerance));
 
-            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_TranslatedNegativeSeven.Value, float3.zero), Is.EqualTo(-point_seven).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_TranslatedNegativeSeven.Value, point_zero), Is.EqualTo(-point_seven).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_TranslatedNegativeSeven.Value, point_one), Is.EqualTo(-point_seven+point_one).Using<float3>(EqualityWithTolerance));
-            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_TranslatedNegativeSeven.Value, point_seven), Is.EqualTo(float3.zero).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_TranslatedNegativeSeven.Value, point_seven), Is.EqualTo(point_zero).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_TranslatedNegativeSeven.Value, point_sevenXY), Is.EqualTo(point_sevenXY-point_seven).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_TranslatedNegativeSeven.Value, -point_one), Is.EqualTo(-point_seven-point_one).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_TranslatedNegativeSeven.Value, -point_seven), Is.EqualTo(-point_seven-point_seven).Using<float3>(EqualityWithTolerance));
@@ -547,40 +598,41 @@ namespace Anvil.Unity.DOTS.Tests.Entities.Transform
             {
                 Value = float4x4.TRS(point_sevenXY, quaternion.identity, point_one)
             };
-            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_TranslatedSevenXY, float3.zero), Is.EqualTo(point_sevenXY).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_TranslatedSevenXY, point_zero), Is.EqualTo(point_sevenXY).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_TranslatedSevenXY, point_one), Is.EqualTo(point_one+point_sevenXY).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_TranslatedSevenXY, point_seven), Is.EqualTo(point_seven+point_sevenXY).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_TranslatedSevenXY, point_sevenXY), Is.EqualTo(point_sevenXY+point_sevenXY).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_TranslatedSevenXY, -point_one), Is.EqualTo(point_sevenXY-point_one).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_TranslatedSevenXY, -point_seven), Is.EqualTo(point_sevenXY-point_seven).Using<float3>(EqualityWithTolerance));
-            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_TranslatedSevenXY, -point_sevenXY), Is.EqualTo(float3.zero).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_TranslatedSevenXY, -point_sevenXY), Is.EqualTo(point_zero).Using<float3>(EqualityWithTolerance));
 
-            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_TranslatedSevenXY.Value, float3.zero), Is.EqualTo(point_sevenXY).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_TranslatedSevenXY.Value, point_zero), Is.EqualTo(point_sevenXY).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_TranslatedSevenXY.Value, point_one), Is.EqualTo(point_one+point_sevenXY).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_TranslatedSevenXY.Value, point_seven), Is.EqualTo(point_seven+point_sevenXY).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_TranslatedSevenXY.Value, point_sevenXY), Is.EqualTo(point_sevenXY+point_sevenXY).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_TranslatedSevenXY.Value, -point_one), Is.EqualTo(point_sevenXY-point_one).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_TranslatedSevenXY.Value, -point_seven), Is.EqualTo(point_sevenXY-point_seven).Using<float3>(EqualityWithTolerance));
-            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_TranslatedSevenXY.Value, -point_sevenXY), Is.EqualTo(float3.zero).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_TranslatedSevenXY.Value, -point_sevenXY), Is.EqualTo(point_zero).Using<float3>(EqualityWithTolerance));
         }
 
         [Test]
         public static void ConvertLocalToWorldPointTest_Rotate()
         {
+            float3 point_zero = float3.zero;
             float3 point_one = new float3(1, 1, 1);
             float3 point_seven = point_one * 7f;
 
             LocalToWorld localToWorld_RotatedZ90 = new LocalToWorld()
             {
-                Value = float4x4.TRS(float3.zero, quaternion.Euler(0, 0, math.radians(90)), point_one)
+                Value = float4x4.TRS(point_zero, quaternion.Euler(0, 0, math.radians(90)), point_one)
             };
-            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_RotatedZ90, float3.zero), Is.EqualTo(float3.zero).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_RotatedZ90, point_zero), Is.EqualTo(point_zero).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_RotatedZ90, point_one), Is.EqualTo(new float3(-1f, 1f, 1f)).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_RotatedZ90, point_seven), Is.EqualTo(new float3(-7f, 7f, 7f)).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_RotatedZ90, -point_one), Is.EqualTo(new float3(1f, -1f, -1f)).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_RotatedZ90, -point_seven), Is.EqualTo(new float3(7f, -7f, -7f)).Using<float3>(EqualityWithTolerance));
 
-            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_RotatedZ90.Value, float3.zero), Is.EqualTo(float3.zero).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_RotatedZ90.Value, point_zero), Is.EqualTo(point_zero).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_RotatedZ90.Value, point_one), Is.EqualTo(new float3(-1f, 1f, 1f)).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_RotatedZ90.Value, point_seven), Is.EqualTo(new float3(-7f, 7f, 7f)).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_RotatedZ90.Value, -point_one), Is.EqualTo(new float3(1f, -1f, -1f)).Using<float3>(EqualityWithTolerance));
@@ -589,15 +641,15 @@ namespace Anvil.Unity.DOTS.Tests.Entities.Transform
 
             LocalToWorld localToWorld_RotatedZNegative90 = new LocalToWorld()
             {
-                Value = float4x4.TRS(float3.zero, quaternion.Euler(0, 0, math.radians(-90)), point_one)
+                Value = float4x4.TRS(point_zero, quaternion.Euler(0, 0, math.radians(-90)), point_one)
             };
-            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_RotatedZNegative90, float3.zero), Is.EqualTo(float3.zero).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_RotatedZNegative90, point_zero), Is.EqualTo(point_zero).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_RotatedZNegative90, point_one), Is.EqualTo(new float3(1f, -1f, 1f)).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_RotatedZNegative90, point_seven), Is.EqualTo(new float3(7f, -7f, 7f)).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_RotatedZNegative90, -point_one), Is.EqualTo(new float3(-1f, 1f, -1f)).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_RotatedZNegative90, -point_seven), Is.EqualTo(new float3(-7f, 7f, -7f)).Using<float3>(EqualityWithTolerance));
 
-            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_RotatedZNegative90.Value, float3.zero), Is.EqualTo(float3.zero).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_RotatedZNegative90.Value, point_zero), Is.EqualTo(point_zero).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_RotatedZNegative90.Value, point_one), Is.EqualTo(new float3(1f, -1f, 1f)).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_RotatedZNegative90.Value, point_seven), Is.EqualTo(new float3(7f, -7f, 7f)).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_RotatedZNegative90.Value, -point_one), Is.EqualTo(new float3(-1f, 1f, -1f)).Using<float3>(EqualityWithTolerance));
@@ -606,15 +658,15 @@ namespace Anvil.Unity.DOTS.Tests.Entities.Transform
 
             LocalToWorld localToWorld_RotatedZX90 = new LocalToWorld()
             {
-                Value = float4x4.TRS(float3.zero, quaternion.Euler(math.radians(90), 0, math.radians(90)), point_one)
+                Value = float4x4.TRS(point_zero, quaternion.Euler(math.radians(90), 0, math.radians(90)), point_one)
             };
-            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_RotatedZX90, float3.zero), Is.EqualTo(float3.zero).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_RotatedZX90, point_zero), Is.EqualTo(point_zero).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_RotatedZX90, point_one), Is.EqualTo(new float3(-1f, -1f, 1f)).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_RotatedZX90, point_seven), Is.EqualTo(new float3(-7f, -7f, 7f)).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_RotatedZX90, -point_one), Is.EqualTo(new float3(1f, 1f, -1f)).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_RotatedZX90, -point_seven), Is.EqualTo(new float3(7f, 7f, -7f)).Using<float3>(EqualityWithTolerance));
 
-            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_RotatedZX90.Value, float3.zero), Is.EqualTo(float3.zero).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_RotatedZX90.Value, point_zero), Is.EqualTo(point_zero).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_RotatedZX90.Value, point_one), Is.EqualTo(new float3(-1f, -1f, 1f)).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_RotatedZX90.Value, point_seven), Is.EqualTo(new float3(-7f, -7f, 7f)).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_RotatedZX90.Value, -point_one), Is.EqualTo(new float3(1f, 1f, -1f)).Using<float3>(EqualityWithTolerance));
@@ -623,15 +675,15 @@ namespace Anvil.Unity.DOTS.Tests.Entities.Transform
 
             LocalToWorld localToWorld_RotatedZXNegative90 = new LocalToWorld()
             {
-                Value = float4x4.TRS(float3.zero, quaternion.Euler(math.radians(-90), 0, math.radians(-90)), point_one)
+                Value = float4x4.TRS(point_zero, quaternion.Euler(math.radians(-90), 0, math.radians(-90)), point_one)
             };
-            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_RotatedZXNegative90, float3.zero), Is.EqualTo(float3.zero).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_RotatedZXNegative90, point_zero), Is.EqualTo(point_zero).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_RotatedZXNegative90, point_one), Is.EqualTo(point_one).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_RotatedZXNegative90, point_seven), Is.EqualTo(point_seven).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_RotatedZXNegative90, -point_one), Is.EqualTo(-point_one).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_RotatedZXNegative90, -point_seven), Is.EqualTo(-point_seven).Using<float3>(EqualityWithTolerance));
 
-            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_RotatedZXNegative90.Value, float3.zero), Is.EqualTo(float3.zero).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_RotatedZXNegative90.Value, point_zero), Is.EqualTo(point_zero).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_RotatedZXNegative90.Value, point_one), Is.EqualTo(point_one).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_RotatedZXNegative90.Value, point_seven), Is.EqualTo(point_seven).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_RotatedZXNegative90.Value, -point_one), Is.EqualTo(-point_one).Using<float3>(EqualityWithTolerance));
@@ -640,15 +692,15 @@ namespace Anvil.Unity.DOTS.Tests.Entities.Transform
 
             LocalToWorld localToWorld_RotatedZX45 = new LocalToWorld()
             {
-                Value = float4x4.TRS(float3.zero, quaternion.Euler(math.radians(45), 0, math.radians(45)), point_one)
+                Value = float4x4.TRS(point_zero, quaternion.Euler(math.radians(45), 0, math.radians(45)), point_one)
             };
-            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_RotatedZX45, float3.zero), Is.EqualTo(float3.zero).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_RotatedZX45, point_zero), Is.EqualTo(point_zero).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_RotatedZX45, point_one), Is.EqualTo(new float3(0f,0.292893201f,1.70710683f)).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_RotatedZX45, point_seven), Is.EqualTo(new float3(0f,2.0502522f,11.9497471f)).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_RotatedZX45, -point_one), Is.EqualTo(new float3(0f,-0.292893201f,-1.70710683f)).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_RotatedZX45, -point_seven), Is.EqualTo(new float3(0f,-2.0502522f,-11.9497471f)).Using<float3>(EqualityWithTolerance));
 
-            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_RotatedZX45.Value, float3.zero), Is.EqualTo(float3.zero).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_RotatedZX45.Value, point_zero), Is.EqualTo(point_zero).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_RotatedZX45.Value, point_one), Is.EqualTo(new float3(0f,0.292893201f,1.70710683f)).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_RotatedZX45.Value, point_seven), Is.EqualTo(new float3(0f,2.0502522f,11.9497471f)).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_RotatedZX45.Value, -point_one), Is.EqualTo(new float3(0f,-0.292893201f,-1.70710683f)).Using<float3>(EqualityWithTolerance));
@@ -658,20 +710,24 @@ namespace Anvil.Unity.DOTS.Tests.Entities.Transform
         [Test]
         public static void ConvertLocalToWorldPointTest_Scale()
         {
+            Regex invalidMatrixError_point = new Regex(@"This transform is invalid\. Returning a signed infinite position\.");
+
+            float3 point_infinity = new float3(float.PositiveInfinity);
+            float3 point_zero = float3.zero;
             float3 point_one = new float3(1, 1, 1);
             float3 point_seven = point_one * 7f;
 
             LocalToWorld localToWorld_Scaled2 = new LocalToWorld()
             {
-                Value = float4x4.TRS(float3.zero, quaternion.identity, point_one*2f)
+                Value = float4x4.TRS(point_zero, quaternion.identity, point_one*2f)
             };
-            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_Scaled2, float3.zero), Is.EqualTo(float3.zero).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_Scaled2, point_zero), Is.EqualTo(point_zero).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_Scaled2, point_one), Is.EqualTo(point_one*2f).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_Scaled2, point_seven), Is.EqualTo(point_seven*2f).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_Scaled2, -point_one), Is.EqualTo(-point_one*2f).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_Scaled2, -point_seven), Is.EqualTo(-point_seven*2f).Using<float3>(EqualityWithTolerance));
 
-            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_Scaled2.Value, float3.zero), Is.EqualTo(float3.zero).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_Scaled2.Value, point_zero), Is.EqualTo(point_zero).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_Scaled2.Value, point_one), Is.EqualTo(point_one*2f).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_Scaled2.Value, point_seven), Is.EqualTo(point_seven*2f).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_Scaled2.Value, -point_one), Is.EqualTo(-point_one*2f).Using<float3>(EqualityWithTolerance));
@@ -680,15 +736,15 @@ namespace Anvil.Unity.DOTS.Tests.Entities.Transform
 
             LocalToWorld localToWorld_ScaledNegative2 = new LocalToWorld()
             {
-                Value = float4x4.TRS(float3.zero, quaternion.identity, point_one*-2f)
+                Value = float4x4.TRS(point_zero, quaternion.identity, point_one*-2f)
             };
-            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_ScaledNegative2, float3.zero), Is.EqualTo(float3.zero).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_ScaledNegative2, point_zero), Is.EqualTo(point_zero).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_ScaledNegative2, point_one), Is.EqualTo(-point_one*2f).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_ScaledNegative2, point_seven), Is.EqualTo(-point_seven*2f).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_ScaledNegative2, -point_one), Is.EqualTo(point_one*2f).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_ScaledNegative2, -point_seven), Is.EqualTo(point_seven*2f).Using<float3>(EqualityWithTolerance));
 
-            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_ScaledNegative2.Value, float3.zero), Is.EqualTo(float3.zero).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_ScaledNegative2.Value, point_zero), Is.EqualTo(point_zero).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_ScaledNegative2.Value, point_one), Is.EqualTo(-point_one*2f).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_ScaledNegative2.Value, point_seven), Is.EqualTo(-point_seven*2f).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_ScaledNegative2.Value, -point_one), Is.EqualTo(point_one*2f).Using<float3>(EqualityWithTolerance));
@@ -698,15 +754,15 @@ namespace Anvil.Unity.DOTS.Tests.Entities.Transform
             float3 scaleZ2 = new float3(point_one.xy, 2f);
             LocalToWorld localToWorld_ScaledZ2 = new LocalToWorld()
             {
-                Value = float4x4.TRS(float3.zero, quaternion.identity, scaleZ2)
+                Value = float4x4.TRS(point_zero, quaternion.identity, scaleZ2)
             };
-            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_ScaledZ2, float3.zero), Is.EqualTo(float3.zero).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_ScaledZ2, point_zero), Is.EqualTo(point_zero).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_ScaledZ2, point_one), Is.EqualTo(point_one*scaleZ2).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_ScaledZ2, point_seven), Is.EqualTo(point_seven*scaleZ2).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_ScaledZ2, -point_one), Is.EqualTo(-point_one*scaleZ2).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_ScaledZ2, -point_seven), Is.EqualTo(-point_seven*scaleZ2).Using<float3>(EqualityWithTolerance));
 
-            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_ScaledZ2.Value, float3.zero), Is.EqualTo(float3.zero).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_ScaledZ2.Value, point_zero), Is.EqualTo(point_zero).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_ScaledZ2.Value, point_one), Is.EqualTo(point_one*scaleZ2).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_ScaledZ2.Value, point_seven), Is.EqualTo(point_seven*scaleZ2).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_ScaledZ2.Value, -point_one), Is.EqualTo(-point_one*scaleZ2).Using<float3>(EqualityWithTolerance));
@@ -716,15 +772,15 @@ namespace Anvil.Unity.DOTS.Tests.Entities.Transform
             float3 scaleZNegative2 = new float3(point_one.xy, -2f);
             LocalToWorld localToWorld_ScaledZNegative2 = new LocalToWorld()
             {
-                Value = float4x4.TRS(float3.zero, quaternion.identity, scaleZNegative2)
+                Value = float4x4.TRS(point_zero, quaternion.identity, scaleZNegative2)
             };
-            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_ScaledZNegative2, float3.zero), Is.EqualTo(float3.zero).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_ScaledZNegative2, point_zero), Is.EqualTo(point_zero).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_ScaledZNegative2, point_one), Is.EqualTo(point_one*scaleZNegative2).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_ScaledZNegative2, point_seven), Is.EqualTo(point_seven*scaleZNegative2).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_ScaledZNegative2, -point_one), Is.EqualTo(-point_one*scaleZNegative2).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_ScaledZNegative2, -point_seven), Is.EqualTo(-point_seven*scaleZNegative2).Using<float3>(EqualityWithTolerance));
 
-            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_ScaledZNegative2.Value, float3.zero), Is.EqualTo(float3.zero).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_ScaledZNegative2.Value, point_zero), Is.EqualTo(point_zero).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_ScaledZNegative2.Value, point_one), Is.EqualTo(point_one*scaleZNegative2).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_ScaledZNegative2.Value, point_seven), Is.EqualTo(point_seven*scaleZNegative2).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_ScaledZNegative2.Value, -point_one), Is.EqualTo(-point_one*scaleZNegative2).Using<float3>(EqualityWithTolerance));
@@ -734,24 +790,65 @@ namespace Anvil.Unity.DOTS.Tests.Entities.Transform
             float3 scaleZXOnePointFive = new float3(1.5f, 1f, 1.5f);
             LocalToWorld localToWorld_ScaledZXOnePointFive = new LocalToWorld()
             {
-                Value = float4x4.TRS(float3.zero, quaternion.identity, scaleZXOnePointFive)
+                Value = float4x4.TRS(point_zero, quaternion.identity, scaleZXOnePointFive)
             };
-            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_ScaledZXOnePointFive, float3.zero), Is.EqualTo(float3.zero).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_ScaledZXOnePointFive, point_zero), Is.EqualTo(point_zero).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_ScaledZXOnePointFive, point_one), Is.EqualTo(point_one*scaleZXOnePointFive).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_ScaledZXOnePointFive, point_seven), Is.EqualTo(point_seven*scaleZXOnePointFive).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_ScaledZXOnePointFive, -point_one), Is.EqualTo(-point_one*scaleZXOnePointFive).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_ScaledZXOnePointFive, -point_seven), Is.EqualTo(-point_seven*scaleZXOnePointFive).Using<float3>(EqualityWithTolerance));
 
-            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_ScaledZXOnePointFive.Value, float3.zero), Is.EqualTo(float3.zero).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_ScaledZXOnePointFive.Value, point_zero), Is.EqualTo(point_zero).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_ScaledZXOnePointFive.Value, point_one), Is.EqualTo(point_one*scaleZXOnePointFive).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_ScaledZXOnePointFive.Value, point_seven), Is.EqualTo(point_seven*scaleZXOnePointFive).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_ScaledZXOnePointFive.Value, -point_one), Is.EqualTo(-point_one*scaleZXOnePointFive).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_ScaledZXOnePointFive.Value, -point_seven), Is.EqualTo(-point_seven*scaleZXOnePointFive).Using<float3>(EqualityWithTolerance));
+
+
+            LocalToWorld localToWorld_zero = new LocalToWorld()
+            {
+                Value = float4x4.TRS(point_zero, quaternion.identity, point_zero)
+            };
+
+            Logger.Debug("BEGIN: Expected error messages.");
+            LogAssert.Expect(LogType.Error, invalidMatrixError_point);
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_zero, point_zero), Is.EqualTo(point_zero));
+            LogAssert.Expect(LogType.Error, invalidMatrixError_point);
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_zero, point_one), Is.EqualTo(point_infinity));
+            LogAssert.Expect(LogType.Error, invalidMatrixError_point);
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_zero, point_seven), Is.EqualTo(point_infinity));
+            LogAssert.Expect(LogType.Error, invalidMatrixError_point);
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_zero, -point_one), Is.EqualTo(-point_infinity));
+            LogAssert.Expect(LogType.Error, invalidMatrixError_point);
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_zero, -point_seven), Is.EqualTo(-point_infinity));
+            LogAssert.Expect(LogType.Error, invalidMatrixError_point);
+            Assert.That(
+                TransformUtil.ConvertLocalToWorldPoint(localToWorld_zero, new float3(2, -2, 0)),
+                Is.EqualTo(new float3(float.PositiveInfinity, float.NegativeInfinity, 0))
+                );
+
+            LogAssert.Expect(LogType.Error, invalidMatrixError_point);
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_zero.Value, point_zero), Is.EqualTo(point_zero));
+            LogAssert.Expect(LogType.Error, invalidMatrixError_point);
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_zero.Value, point_one), Is.EqualTo(point_infinity));
+            LogAssert.Expect(LogType.Error, invalidMatrixError_point);
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_zero.Value, point_seven), Is.EqualTo(point_infinity));
+            LogAssert.Expect(LogType.Error, invalidMatrixError_point);
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_zero.Value, -point_one), Is.EqualTo(-point_infinity));
+            LogAssert.Expect(LogType.Error, invalidMatrixError_point);
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_zero.Value, -point_seven), Is.EqualTo(-point_infinity));
+            LogAssert.Expect(LogType.Error, invalidMatrixError_point);
+            Assert.That(
+                TransformUtil.ConvertLocalToWorldPoint(localToWorld_zero.Value, new float3(2, -2, 0)),
+                Is.EqualTo(new float3(float.PositiveInfinity, float.NegativeInfinity, 0))
+            );
+            Logger.Debug("END: Expected error messages.");
         }
 
         [Test]
         public static void ConvertLocalToWorldPointTest_Compound()
         {
+            float3 point_zero = float3.zero;
             float3 point_one = new float3(1f, 1f, 1f);
             float3 point_seven = point_one * 7f;
             float3 point_sevenXY = new float3(point_seven.xy, 0f);
@@ -760,13 +857,13 @@ namespace Anvil.Unity.DOTS.Tests.Entities.Transform
             {
                 Value = float4x4.TRS(point_sevenXY, quaternion.Euler(math.radians(45), 0, math.radians(45)), point_one*2f)
             };
-            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_Compound, float3.zero), Is.EqualTo(point_sevenXY).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_Compound, point_zero), Is.EqualTo(point_sevenXY).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_Compound, point_one), Is.EqualTo(new float3(7f, 7.58578634f, 3.41421366f)).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_Compound, point_seven), Is.EqualTo(new float3(7f, 11.1005039f, 23.8994942f)).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_Compound, -point_one), Is.EqualTo(new float3(7f,6.41421366f, -3.41421366f)).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_Compound, -point_seven), Is.EqualTo(new float3(7f, 2.89949608f, -23.8994942f)).Using<float3>(EqualityWithTolerance));
 
-            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_Compound.Value, float3.zero), Is.EqualTo(point_sevenXY).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_Compound.Value, point_zero), Is.EqualTo(point_sevenXY).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_Compound.Value, point_one), Is.EqualTo(new float3(7 ,7.58578634f, 3.41421366f)).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_Compound.Value, point_seven), Is.EqualTo(new float3(7 ,11.1005039f, 23.8994942f)).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_Compound.Value, -point_one), Is.EqualTo(new float3(7 ,6.41421366f, -3.41421366f)).Using<float3>(EqualityWithTolerance));
@@ -777,13 +874,13 @@ namespace Anvil.Unity.DOTS.Tests.Entities.Transform
             {
                 Value = float4x4.TRS(-point_sevenXY, quaternion.Euler(math.radians(-45), 0, math.radians(-45)), point_one*-2f)
             };
-            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_CompoundNegative, float3.zero), Is.EqualTo(-point_sevenXY).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_CompoundNegative, point_zero), Is.EqualTo(-point_sevenXY).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_CompoundNegative, point_one), Is.EqualTo(new float3(-9.82842731f, -8.41421318f, -1.41421366f)).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_CompoundNegative, point_seven), Is.EqualTo(new float3(-26.7989922f, -16.8994961f, -9.89949512f)).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_CompoundNegative, -point_one), Is.EqualTo(new float3(-4.17157269f, -5.58578634f, 1.41421366f)).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_CompoundNegative, -point_seven), Is.EqualTo(new float3(12.7989922f, 2.89949608f, 9.89949512f)).Using<float3>(EqualityWithTolerance));
 
-            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_CompoundNegative.Value, float3.zero), Is.EqualTo(-point_sevenXY).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_CompoundNegative.Value, point_zero), Is.EqualTo(-point_sevenXY).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_CompoundNegative.Value, point_one), Is.EqualTo(new float3(-9.82842731f, -8.41421318f, -1.41421366f)).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_CompoundNegative.Value, point_seven), Is.EqualTo(new float3(-26.7989922f, -16.8994961f, -9.89949512f)).Using<float3>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_CompoundNegative.Value, -point_one), Is.EqualTo(new float3(-4.17157269f, -5.58578634f, 1.41421366f)).Using<float3>(EqualityWithTolerance));
@@ -794,7 +891,9 @@ namespace Anvil.Unity.DOTS.Tests.Entities.Transform
         [Test]
         public static void ConvertWorldToLocalRotationTest_Rotate()
         {
+            float3 point_zero = float3.zero;
             float3 point_one = new float3(1f, 1f, 1f);
+
             quaternion rotation_fortyFive = quaternion.Euler(math.radians(45f), math.radians(45f), math.radians(45f));
             quaternion rotation_fortyFive_inverse = math.inverse(rotation_fortyFive);
 
@@ -810,7 +909,7 @@ namespace Anvil.Unity.DOTS.Tests.Entities.Transform
 
             LocalToWorld localToWorld_nintey = new LocalToWorld()
             {
-                Value = float4x4.TRS(float3.zero, rotation_nintey, point_one)
+                Value = float4x4.TRS(point_zero, rotation_nintey, point_one)
             };
             float4x4 worldToLocal_nintey = math.inverse(localToWorld_nintey.Value);
             Assert.That(TransformUtil.ConvertWorldToLocalRotation(localToWorld_nintey, quaternion.identity), Is.EqualTo(math.mul(rotation_nintey_inverse, quaternion.identity)).Using<quaternion>(EqualityWithTolerance));
@@ -828,7 +927,7 @@ namespace Anvil.Unity.DOTS.Tests.Entities.Transform
 
             LocalToWorld localToWorld_fortyFive = new LocalToWorld()
             {
-                Value = float4x4.TRS(float3.zero, rotation_fortyFive, point_one)
+                Value = float4x4.TRS(point_zero, rotation_fortyFive, point_one)
             };
             float4x4 worldToLocal_fortyFive = math.inverse(localToWorld_fortyFive.Value);
             Assert.That(TransformUtil.ConvertWorldToLocalRotation(localToWorld_fortyFive, quaternion.identity), Is.EqualTo(math.mul(rotation_fortyFive_inverse, quaternion.identity)).Using<quaternion>(EqualityWithTolerance));
@@ -846,7 +945,7 @@ namespace Anvil.Unity.DOTS.Tests.Entities.Transform
 
             LocalToWorld localToWorld_Znintey = new LocalToWorld()
             {
-                Value = float4x4.TRS(float3.zero, rotation_Znintey, point_one)
+                Value = float4x4.TRS(point_zero, rotation_Znintey, point_one)
             };
             float4x4 worldToLocal_Znintey = math.inverse(localToWorld_Znintey.Value);
             Assert.That(TransformUtil.ConvertWorldToLocalRotation(localToWorld_Znintey, quaternion.identity), Is.EqualTo(math.mul(rotation_Znintey_inverse, quaternion.identity)).Using<quaternion>(EqualityWithTolerance));
@@ -864,7 +963,7 @@ namespace Anvil.Unity.DOTS.Tests.Entities.Transform
 
             LocalToWorld localToWorld_ZfortyFive = new LocalToWorld()
             {
-                Value = float4x4.TRS(float3.zero, rotation_ZfortyFive, point_one)
+                Value = float4x4.TRS(point_zero, rotation_ZfortyFive, point_one)
             };
             float4x4 worldToLocal_ZfortyFive = math.inverse(localToWorld_ZfortyFive.Value);
             Assert.That(TransformUtil.ConvertWorldToLocalRotation(localToWorld_ZfortyFive, quaternion.identity), Is.EqualTo(math.mul(rotation_ZfortyFive_inverse, quaternion.identity)).Using<quaternion>(EqualityWithTolerance));
@@ -883,6 +982,9 @@ namespace Anvil.Unity.DOTS.Tests.Entities.Transform
         [Test]
         public static void ConvertWorldToLocalRotationTest_Compound()
         {
+            Regex invalidMatrixError_rotate = new Regex(@"Transform is not valid\. Returning identity rotation\.");
+
+            float3 point_zero = float3.zero;
             float3 point_one = new float3(1f, 1f, 1f);
             float3 point_sevenXY = new float3(7f, 7f, 0f);
             quaternion rotation_fortyFive = quaternion.Euler(math.radians(45f), math.radians(45f), math.radians(45f));
@@ -950,7 +1052,7 @@ namespace Anvil.Unity.DOTS.Tests.Entities.Transform
                 Value = float4x4.TRS(-point_sevenXY, rotation_XZ_negativeFortyFive, new float3(2f, 2f, -2f))
             };
             float4x4 worldToLocal_compound_negativeZ = math.inverse(localToWorld_compound_negativeZ.Value);
-            float3x3 worldToLocal_compound_negativeZScale = float3x3.Scale(worldToLocal_compound_negativeZ.GetScale());
+            float3x3 worldToLocal_compound_negativeZScale = float3x3.Scale(TransformUtil.ConvertWorldToLocalScale(worldToLocal_compound_negativeZ, new float3(1f)));
 
             Assert.That(
                 math.mul(new float3x3(TransformUtil.ConvertWorldToLocalRotation(localToWorld_compound_negativeZ, quaternion.identity)), worldToLocal_compound_negativeZScale),
@@ -995,23 +1097,77 @@ namespace Anvil.Unity.DOTS.Tests.Entities.Transform
             );
 
 
+            LocalToWorld localToWorld_compound_zeroScale = new LocalToWorld()
+            {
+                Value = float4x4.TRS(point_zero, rotation_ZfortyFive, point_zero)
+            };
+            float4x4 worldToLocal_compound_zeroScale =
+                float4x4.TRS(point_zero, Quaternion.Inverse(rotation_ZfortyFive), point_zero);
+
+            Logger.Debug("BEGIN: Expected error messages.");
+            LogAssert.Expect(LogType.Error, invalidMatrixError_rotate);
+            Assert.That(TransformUtil.ConvertWorldToLocalRotation(localToWorld_compound_zeroScale, quaternion.identity), Is.EqualTo(quaternion.identity));
+            LogAssert.Expect(LogType.Error, invalidMatrixError_rotate);
+            Assert.That(TransformUtil.ConvertWorldToLocalRotation(localToWorld_compound_zeroScale, rotation_nintey), Is.EqualTo(quaternion.identity));
+            LogAssert.Expect(LogType.Error, invalidMatrixError_rotate);
+            Assert.That(TransformUtil.ConvertWorldToLocalRotation(localToWorld_compound_zeroScale, rotation_Znintey), Is.EqualTo(quaternion.identity));
+            LogAssert.Expect(LogType.Error, invalidMatrixError_rotate);
+            Assert.That(TransformUtil.ConvertWorldToLocalRotation(localToWorld_compound_zeroScale, rotation_fortyFive), Is.EqualTo(quaternion.identity));
+            LogAssert.Expect(LogType.Error, invalidMatrixError_rotate);
+            Assert.That(TransformUtil.ConvertWorldToLocalRotation(localToWorld_compound_zeroScale, rotation_ZfortyFive), Is.EqualTo(quaternion.identity));
+
+            LogAssert.Expect(LogType.Error, invalidMatrixError_rotate);
+            Assert.That(TransformUtil.ConvertWorldToLocalRotation(worldToLocal_compound_zeroScale, quaternion.identity), Is.EqualTo(quaternion.identity));
+            LogAssert.Expect(LogType.Error, invalidMatrixError_rotate);
+            Assert.That(TransformUtil.ConvertWorldToLocalRotation(worldToLocal_compound_zeroScale, rotation_nintey), Is.EqualTo(quaternion.identity));
+            LogAssert.Expect(LogType.Error, invalidMatrixError_rotate);
+            Assert.That(TransformUtil.ConvertWorldToLocalRotation(worldToLocal_compound_zeroScale, rotation_Znintey), Is.EqualTo(quaternion.identity));
+            LogAssert.Expect(LogType.Error, invalidMatrixError_rotate);
+            Assert.That(TransformUtil.ConvertWorldToLocalRotation(worldToLocal_compound_zeroScale, rotation_fortyFive), Is.EqualTo(quaternion.identity));
+            LogAssert.Expect(LogType.Error, invalidMatrixError_rotate);
+            Assert.That(TransformUtil.ConvertWorldToLocalRotation(worldToLocal_compound_zeroScale, rotation_ZfortyFive), Is.EqualTo(quaternion.identity));
+            Logger.Debug("END: Expected error messages.");
+
+
             //TODO: #116 - Transforms with non-uniform scale operations are not currently supported.
+            // Tests with assertions commented out below would replace these tests.
             LocalToWorld localToWorld_compound_negativeYZ = new LocalToWorld()
             {
                 Value = float4x4.TRS(-point_sevenXY, quaternion.identity, new float3(1f, -2f, -1.5f))
             };
             float4x4 worldToLocal_compound_negativeYZ = math.inverse(localToWorld_compound_negativeYZ.Value);
-            float3x3 worldToLocal_compound_negativeYZScale = float3x3.Scale(worldToLocal_compound_negativeYZ.GetScale());
 
 #if DEBUG
+            Logger.Debug("BEGIN: Expected error messages.");
             // The assert ensures the utility method emits a log message when a non-uniform transform is provided.
             LogAssert.Expect(LogType.Error, s_NonUniformScaleError);
             TransformUtil.ConvertWorldToLocalRotation(localToWorld_compound_negativeYZ, quaternion.identity);
-            Log.GetLogger(typeof(TransformUtilTests)).Debug("The previous error message is expected.");
+
+            LogAssert.Expect(LogType.Error, s_NonUniformScaleError);
+            TransformUtil.ConvertWorldToLocalRotation(localToWorld_compound_negativeYZ, rotation_nintey);
+            LogAssert.Expect(LogType.Error, s_NonUniformScaleError);
+            TransformUtil.ConvertWorldToLocalRotation(localToWorld_compound_negativeYZ, rotation_Znintey);
+            LogAssert.Expect(LogType.Error, s_NonUniformScaleError);
+            TransformUtil.ConvertWorldToLocalRotation(localToWorld_compound_negativeYZ, rotation_fortyFive);
+            LogAssert.Expect(LogType.Error, s_NonUniformScaleError);
+            TransformUtil.ConvertWorldToLocalRotation(localToWorld_compound_negativeYZ, rotation_ZfortyFive);
+
+            LogAssert.Expect(LogType.Error, s_NonUniformScaleError);
+            TransformUtil.ConvertWorldToLocalRotation(worldToLocal_compound_negativeYZ, quaternion.identity);
+            LogAssert.Expect(LogType.Error, s_NonUniformScaleError);
+            TransformUtil.ConvertWorldToLocalRotation(worldToLocal_compound_negativeYZ, rotation_nintey);
+            LogAssert.Expect(LogType.Error, s_NonUniformScaleError);
+            TransformUtil.ConvertWorldToLocalRotation(worldToLocal_compound_negativeYZ, rotation_Znintey);
+            LogAssert.Expect(LogType.Error, s_NonUniformScaleError);
+            TransformUtil.ConvertWorldToLocalRotation(worldToLocal_compound_negativeYZ, rotation_fortyFive);
+            LogAssert.Expect(LogType.Error, s_NonUniformScaleError);
+            TransformUtil.ConvertWorldToLocalRotation(worldToLocal_compound_negativeYZ, rotation_ZfortyFive);
+            Logger.Debug("END: Expected error messages.");
 #endif
 
             // // These follow the template of the asserts for uniform scale transforms. They may or may not result in correct values for
             // // non-uniform scaling.
+            // float3x3 worldToLocal_compound_negativeYZScale = float3x3.Scale(TransformUtil.ConvertWorldToLocalScale(worldToLocal_compound_negativeYZ, new float3(1f)));
             // Assert.That(
             //     math.mul(new float3x3(TransformUtil.ConvertWorldToLocalRotation(localToWorld_compound_negativeYZ, quaternion.identity)), worldToLocal_compound_negativeYZScale),
             //     Is.EqualTo(math.mul((float3x3)worldToLocal_compound_negativeYZ, new float3x3(quaternion.identity))).Using<float3x3>(EqualityWithTolerance)
@@ -1059,6 +1215,7 @@ namespace Anvil.Unity.DOTS.Tests.Entities.Transform
         [Test]
         public static void ConvertLocalToWorldRotationTest_Rotate()
         {
+            float3 point_zero = float3.zero;
             float3 point_one = new float3(1f, 1f, 1f);
             quaternion rotation_fortyFive = quaternion.Euler(math.radians(45f), math.radians(45f), math.radians(45f));
             quaternion rotation_nintey = quaternion.Euler(math.radians(90f), math.radians(90f), math.radians(90f));
@@ -1068,7 +1225,7 @@ namespace Anvil.Unity.DOTS.Tests.Entities.Transform
 
             LocalToWorld localToWorld_nintey = new LocalToWorld()
             {
-                Value = float4x4.TRS(float3.zero, rotation_nintey, point_one)
+                Value = float4x4.TRS(point_zero, rotation_nintey, point_one)
             };
             Assert.That(TransformUtil.ConvertLocalToWorldRotation(localToWorld_nintey, quaternion.identity), Is.EqualTo(math.mul(rotation_nintey, quaternion.identity)).Using<quaternion>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertLocalToWorldRotation(localToWorld_nintey, rotation_nintey), Is.EqualTo(math.mul(rotation_nintey, rotation_nintey)).Using<quaternion>(EqualityWithTolerance));
@@ -1085,7 +1242,7 @@ namespace Anvil.Unity.DOTS.Tests.Entities.Transform
 
             LocalToWorld localToWorld_fortyFive = new LocalToWorld()
             {
-                Value = float4x4.TRS(float3.zero, rotation_fortyFive, point_one)
+                Value = float4x4.TRS(point_zero, rotation_fortyFive, point_one)
             };
             Assert.That(TransformUtil.ConvertLocalToWorldRotation(localToWorld_fortyFive, quaternion.identity), Is.EqualTo(math.mul(rotation_fortyFive, quaternion.identity)).Using<quaternion>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertLocalToWorldRotation(localToWorld_fortyFive, rotation_nintey), Is.EqualTo(math.mul(rotation_fortyFive, rotation_nintey)).Using<quaternion>(EqualityWithTolerance));
@@ -1102,7 +1259,7 @@ namespace Anvil.Unity.DOTS.Tests.Entities.Transform
 
             LocalToWorld localToWorld_Znintey = new LocalToWorld()
             {
-                Value = float4x4.TRS(float3.zero, rotation_Znintey, point_one)
+                Value = float4x4.TRS(point_zero, rotation_Znintey, point_one)
             };
             Assert.That(TransformUtil.ConvertLocalToWorldRotation(localToWorld_Znintey, quaternion.identity), Is.EqualTo(math.mul(rotation_Znintey, quaternion.identity)).Using<quaternion>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertLocalToWorldRotation(localToWorld_Znintey, rotation_nintey), Is.EqualTo(math.mul(rotation_Znintey, rotation_nintey)).Using<quaternion>(EqualityWithTolerance));
@@ -1119,7 +1276,7 @@ namespace Anvil.Unity.DOTS.Tests.Entities.Transform
 
             LocalToWorld localToWorld_ZfortyFive = new LocalToWorld()
             {
-                Value = float4x4.TRS(float3.zero, rotation_ZfortyFive, point_one)
+                Value = float4x4.TRS(point_zero, rotation_ZfortyFive, point_one)
             };
             Assert.That(TransformUtil.ConvertLocalToWorldRotation(localToWorld_ZfortyFive, quaternion.identity), Is.EqualTo(math.mul(rotation_ZfortyFive, quaternion.identity)).Using<quaternion>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertLocalToWorldRotation(localToWorld_ZfortyFive, rotation_nintey), Is.EqualTo(math.mul(rotation_ZfortyFive, rotation_nintey)).Using<quaternion>(EqualityWithTolerance));
@@ -1137,6 +1294,9 @@ namespace Anvil.Unity.DOTS.Tests.Entities.Transform
         [Test]
         public static void ConvertLocalToWorldRotationTest_Compound()
         {
+            Regex invalidMatrixError_rotate = new Regex(@"Transform is not valid\. Returning identity rotation\.");
+
+            float3 point_zero = float3.zero;
             float3 point_one = new float3(1f, 1f, 1f);
             float3 point_sevenXY = new float3(7f, 7f, 0f);
             quaternion rotation_fortyFive = quaternion.Euler(math.radians(45f), math.radians(45f), math.radians(45f));
@@ -1202,7 +1362,7 @@ namespace Anvil.Unity.DOTS.Tests.Entities.Transform
                 Value = float4x4.TRS(-point_sevenXY, rotation_XZ_negativeFortyFive, new float3(2f, 2f, -2f))
             };
             float4x4 localToWorldMatrix_compound_negativeZ = localToWorld_compound_negativeZ.Value;
-            float3x3 localToWorld_compound_negativeZScale = float3x3.Scale(localToWorldMatrix_compound_negativeZ.GetScale());
+            float3x3 localToWorld_compound_negativeZScale = float3x3.Scale(TransformUtil.ConvertLocalToWorldScale(localToWorldMatrix_compound_negativeZ, new float3(1f)));
 
             Assert.That(
                 math.mul(new float3x3(TransformUtil.ConvertLocalToWorldRotation(localToWorld_compound_negativeZ, quaternion.identity)), localToWorld_compound_negativeZScale),
@@ -1247,23 +1407,73 @@ namespace Anvil.Unity.DOTS.Tests.Entities.Transform
             );
 
 
+            LocalToWorld localToWorld_compound_zeroScale = new LocalToWorld()
+            {
+                Value = float4x4.TRS(point_zero, rotation_ZfortyFive, point_zero)
+            };
+
+            Logger.Debug("BEGIN: Expected error messages.");
+            LogAssert.Expect(LogType.Error, invalidMatrixError_rotate);
+            Assert.That(TransformUtil.ConvertLocalToWorldRotation(localToWorld_compound_zeroScale, quaternion.identity), Is.EqualTo(quaternion.identity));
+            LogAssert.Expect(LogType.Error, invalidMatrixError_rotate);
+            Assert.That(TransformUtil.ConvertLocalToWorldRotation(localToWorld_compound_zeroScale, rotation_nintey), Is.EqualTo(quaternion.identity));
+            LogAssert.Expect(LogType.Error, invalidMatrixError_rotate);
+            Assert.That(TransformUtil.ConvertLocalToWorldRotation(localToWorld_compound_zeroScale, rotation_Znintey), Is.EqualTo(quaternion.identity));
+            LogAssert.Expect(LogType.Error, invalidMatrixError_rotate);
+            Assert.That(TransformUtil.ConvertLocalToWorldRotation(localToWorld_compound_zeroScale, rotation_fortyFive), Is.EqualTo(quaternion.identity));
+            LogAssert.Expect(LogType.Error, invalidMatrixError_rotate);
+            Assert.That(TransformUtil.ConvertLocalToWorldRotation(localToWorld_compound_zeroScale, rotation_ZfortyFive), Is.EqualTo(quaternion.identity));
+
+            LogAssert.Expect(LogType.Error, invalidMatrixError_rotate);
+            Assert.That(TransformUtil.ConvertLocalToWorldRotation(localToWorld_compound_zeroScale.Value, quaternion.identity), Is.EqualTo(quaternion.identity));
+            LogAssert.Expect(LogType.Error, invalidMatrixError_rotate);
+            Assert.That(TransformUtil.ConvertLocalToWorldRotation(localToWorld_compound_zeroScale.Value, rotation_nintey), Is.EqualTo(quaternion.identity));
+            LogAssert.Expect(LogType.Error, invalidMatrixError_rotate);
+            Assert.That(TransformUtil.ConvertLocalToWorldRotation(localToWorld_compound_zeroScale.Value, rotation_Znintey), Is.EqualTo(quaternion.identity));
+            LogAssert.Expect(LogType.Error, invalidMatrixError_rotate);
+            Assert.That(TransformUtil.ConvertLocalToWorldRotation(localToWorld_compound_zeroScale.Value, rotation_fortyFive), Is.EqualTo(quaternion.identity));
+            LogAssert.Expect(LogType.Error, invalidMatrixError_rotate);
+            Assert.That(TransformUtil.ConvertLocalToWorldRotation(localToWorld_compound_zeroScale.Value, rotation_ZfortyFive), Is.EqualTo(quaternion.identity));
+            Logger.Debug("END: Expected error messages.");
+
+
             //TODO: #116 - Transforms with non-uniform scale operations are not currently supported.
+            // Once supported, actual tests are commented out below.
             LocalToWorld localToWorld_compound_negativeYZ = new LocalToWorld()
             {
                 Value = float4x4.TRS(-point_sevenXY, quaternion.identity, new float3(1f, -2f, -1.5f))
             };
             float4x4 localToWorldMatrix_compound_negativeYZ = localToWorld_compound_negativeYZ.Value;
-            float3x3 localToWorld_compound_negativeYZScale = float3x3.Scale(localToWorldMatrix_compound_negativeYZ.GetScale());
 
 #if DEBUG
-            // The assert ensures the utility method emits a log message when a non-uniform transform is provided.
+            Logger.Debug("BEGIN: Expected error messages.");
             LogAssert.Expect(LogType.Error, s_NonUniformScaleError);
             TransformUtil.ConvertLocalToWorldRotation(localToWorld_compound_negativeYZ, quaternion.identity);
-            Log.GetLogger(typeof(TransformUtilTests)).Debug("The previous error message is expected.");
+            LogAssert.Expect(LogType.Error, s_NonUniformScaleError);
+            TransformUtil.ConvertLocalToWorldRotation(localToWorld_compound_negativeYZ, rotation_nintey);
+            LogAssert.Expect(LogType.Error, s_NonUniformScaleError);
+            TransformUtil.ConvertLocalToWorldRotation(localToWorld_compound_negativeYZ, rotation_Znintey);
+            LogAssert.Expect(LogType.Error, s_NonUniformScaleError);
+            TransformUtil.ConvertLocalToWorldRotation(localToWorld_compound_negativeYZ, rotation_fortyFive);
+            LogAssert.Expect(LogType.Error, s_NonUniformScaleError);
+            TransformUtil.ConvertLocalToWorldRotation(localToWorld_compound_negativeYZ, rotation_ZfortyFive);
+
+            LogAssert.Expect(LogType.Error, s_NonUniformScaleError);
+            TransformUtil.ConvertLocalToWorldRotation(localToWorldMatrix_compound_negativeYZ, quaternion.identity);
+            LogAssert.Expect(LogType.Error, s_NonUniformScaleError);
+            TransformUtil.ConvertLocalToWorldRotation(localToWorldMatrix_compound_negativeYZ, rotation_nintey);
+            LogAssert.Expect(LogType.Error, s_NonUniformScaleError);
+            TransformUtil.ConvertLocalToWorldRotation(localToWorldMatrix_compound_negativeYZ, rotation_Znintey);
+            LogAssert.Expect(LogType.Error, s_NonUniformScaleError);
+            TransformUtil.ConvertLocalToWorldRotation(localToWorldMatrix_compound_negativeYZ, rotation_fortyFive);
+            LogAssert.Expect(LogType.Error, s_NonUniformScaleError);
+            TransformUtil.ConvertLocalToWorldRotation(localToWorldMatrix_compound_negativeYZ, rotation_ZfortyFive);
+            Logger.Debug("END: Expected error messages.");
 #endif
 
             // // These follow the template of the asserts for uniform scale transforms. They may or may not result in correct values for
             // // non-uniform scaling.
+            // float3x3 localToWorld_compound_negativeYZScale = float3x3.Scale(TransformUtil.ConvertLocalToWorldScale(localToWorldMatrix_compound_negativeYZ, new float3(1f));
             // Assert.That(
             //     math.mul(new float3x3(TransformUtil.ConvertLocalToWorldRotation(localToWorld_compound_negativeYZ, quaternion.identity)), localToWorld_compound_negativeYZScale),
             //     Is.EqualTo(math.mul((float3x3)localToWorldMatrix_compound_negativeYZ, new float3x3(quaternion.identity))).Using<float3x3>(EqualityWithTolerance)
@@ -1311,6 +1521,7 @@ namespace Anvil.Unity.DOTS.Tests.Entities.Transform
         [Test]
         public static void ConvertWorldToLocalScaleTest_Scale()
         {
+            Regex invalidMatrixError_scale = new Regex(@"This transform is invalid\. Returning a signed infinite scale\.");
             float3 point_zero = float3.zero;
             float3 point_one = new float3(1f, 1f, 1f);
             float3 point_two = point_one * 2f;
@@ -1319,7 +1530,7 @@ namespace Anvil.Unity.DOTS.Tests.Entities.Transform
 
             LocalToWorld localToWorld_one = new LocalToWorld()
             {
-                Value = float4x4.TRS(float3.zero, quaternion.identity, point_one)
+                Value = float4x4.TRS(point_zero, quaternion.identity, point_one)
             };
             float4x4 worldToLocal_one = math.inverse(localToWorld_one.Value);
 
@@ -1338,7 +1549,7 @@ namespace Anvil.Unity.DOTS.Tests.Entities.Transform
 
             LocalToWorld localToWorld_two = new LocalToWorld()
             {
-                Value = float4x4.TRS(float3.zero, quaternion.identity, point_two)
+                Value = float4x4.TRS(point_zero, quaternion.identity, point_two)
             };
             float4x4 worldToLocal_two = math.inverse(localToWorld_two.Value);
 
@@ -1357,7 +1568,7 @@ namespace Anvil.Unity.DOTS.Tests.Entities.Transform
 
             LocalToWorld localToWorld_negativeOne = new LocalToWorld()
             {
-                Value = float4x4.TRS(float3.zero, quaternion.identity, -point_one)
+                Value = float4x4.TRS(point_zero, quaternion.identity, -point_one)
             };
             float4x4 worldToLocal_negativeOne = math.inverse(localToWorld_negativeOne.Value);
             float3x3 worldToLocal_negativeOneRotation = new float3x3(TransformUtil.ConvertWorldToLocalRotation(worldToLocal_negativeOne, quaternion.identity));
@@ -1407,7 +1618,7 @@ namespace Anvil.Unity.DOTS.Tests.Entities.Transform
 
             LocalToWorld localToWorld_negativeTwo = new LocalToWorld()
             {
-                Value = float4x4.TRS(float3.zero, quaternion.identity, -point_two)
+                Value = float4x4.TRS(point_zero, quaternion.identity, -point_two)
             };
             float4x4 worldToLocal_negativeTwo = math.inverse(localToWorld_negativeTwo.Value);
             float3x3 worldToLocal_negativeTwoRotation = new float3x3(TransformUtil.ConvertWorldToLocalRotation(worldToLocal_negativeTwo, quaternion.identity));
@@ -1457,51 +1668,623 @@ namespace Anvil.Unity.DOTS.Tests.Entities.Transform
 
             LocalToWorld localToWorld_zero = new LocalToWorld()
             {
-                Value = float4x4.TRS(float3.zero, quaternion.identity, point_zero)
+                Value = float4x4.TRS(point_zero, quaternion.identity, point_zero)
             };
             float4x4 worldToLocal_zero = math.inverse(localToWorld_zero.Value);
-            Regex invalidMatrixError = new Regex(@"This transform is invalid. Returning a signed infinite scale\.");
 
-            LogAssert.Expect(LogType.Error, invalidMatrixError);
+            Logger.Debug("BEGIN: Expected error messages.");
+            LogAssert.Expect(LogType.Error, invalidMatrixError_scale);
             Assert.That(TransformUtil.ConvertWorldToLocalScale(localToWorld_zero, point_one), Is.EqualTo(point_infinity));
-            LogAssert.Expect(LogType.Error, invalidMatrixError);
+            LogAssert.Expect(LogType.Error, invalidMatrixError_scale);
             Assert.That(TransformUtil.ConvertWorldToLocalScale(localToWorld_zero, point_two), Is.EqualTo(point_infinity));
-            LogAssert.Expect(LogType.Error, invalidMatrixError);
+            LogAssert.Expect(LogType.Error, invalidMatrixError_scale);
             Assert.That(TransformUtil.ConvertWorldToLocalScale(localToWorld_zero, -point_one), Is.EqualTo(-point_infinity));
-            LogAssert.Expect(LogType.Error, invalidMatrixError);
+            LogAssert.Expect(LogType.Error, invalidMatrixError_scale);
             Assert.That(TransformUtil.ConvertWorldToLocalScale(localToWorld_zero, -point_two), Is.EqualTo(-point_infinity));
-            LogAssert.Expect(LogType.Error, invalidMatrixError);
+            LogAssert.Expect(LogType.Error, invalidMatrixError_scale);
             Assert.That(TransformUtil.ConvertWorldToLocalScale(localToWorld_zero, point_zero), Is.EqualTo(point_zero));
-            LogAssert.Expect(LogType.Error, invalidMatrixError);
+            LogAssert.Expect(LogType.Error, invalidMatrixError_scale);
             Assert.That(
                 TransformUtil.ConvertWorldToLocalScale(localToWorld_zero, new float3(2, -2, 0)),
                 Is.EqualTo(new float3(float.PositiveInfinity, float.NegativeInfinity, 0))
                 );
 
-            LogAssert.Expect(LogType.Error, invalidMatrixError);
+            LogAssert.Expect(LogType.Error, invalidMatrixError_scale);
             Assert.That(TransformUtil.ConvertWorldToLocalScale(worldToLocal_zero, point_one), Is.EqualTo(point_infinity));
-            LogAssert.Expect(LogType.Error, invalidMatrixError);
+            LogAssert.Expect(LogType.Error, invalidMatrixError_scale);
             Assert.That(TransformUtil.ConvertWorldToLocalScale(worldToLocal_zero, point_two), Is.EqualTo(point_infinity));
-            LogAssert.Expect(LogType.Error, invalidMatrixError);
+            LogAssert.Expect(LogType.Error, invalidMatrixError_scale);
             Assert.That(TransformUtil.ConvertWorldToLocalScale(worldToLocal_zero, -point_one), Is.EqualTo(-point_infinity));
-            LogAssert.Expect(LogType.Error, invalidMatrixError);
+            LogAssert.Expect(LogType.Error, invalidMatrixError_scale);
             Assert.That(TransformUtil.ConvertWorldToLocalScale(worldToLocal_zero, -point_two), Is.EqualTo(-point_infinity));
-            LogAssert.Expect(LogType.Error, invalidMatrixError);
+            LogAssert.Expect(LogType.Error, invalidMatrixError_scale);
             Assert.That(TransformUtil.ConvertWorldToLocalScale(worldToLocal_zero, point_zero), Is.EqualTo(point_zero));
-            LogAssert.Expect(LogType.Error, invalidMatrixError);
+            LogAssert.Expect(LogType.Error, invalidMatrixError_scale);
             Assert.That(
                 TransformUtil.ConvertWorldToLocalScale(worldToLocal_zero, new float3(2, -2, 0)),
                 Is.EqualTo(new float3(float.PositiveInfinity, float.NegativeInfinity, 0))
             );
+            Logger.Debug("END: Expected error messages.");
+
+
+            //TODO: #116 - Transforms with non-uniform scale operations are not currently supported.
+            // Tests with assertions commented out below would replace these tests.
+            LocalToWorld localToWorld_nonUniform = new LocalToWorld()
+            {
+                Value = float4x4.TRS(point_zero, quaternion.identity, new float3(1.5f, 3, 1))
+            };
+            float4x4 worldToLocal_nonUniform = math.inverse(localToWorld_nonUniform.Value);
+
+#if DEBUG
+            Logger.Debug("BEGIN: Expected error messages.");
+            LogAssert.Expect(LogType.Error, s_NonUniformScaleError);
+            TransformUtil.ConvertWorldToLocalScale(localToWorld_nonUniform, point_one);
+            LogAssert.Expect(LogType.Error, s_NonUniformScaleError);
+            TransformUtil.ConvertWorldToLocalScale(localToWorld_nonUniform, point_two);
+            LogAssert.Expect(LogType.Error, s_NonUniformScaleError);
+            TransformUtil.ConvertWorldToLocalScale(localToWorld_nonUniform, -point_one);
+            LogAssert.Expect(LogType.Error, s_NonUniformScaleError);
+            TransformUtil.ConvertWorldToLocalScale(localToWorld_nonUniform, -point_two);
+            LogAssert.Expect(LogType.Error, s_NonUniformScaleError);
+            TransformUtil.ConvertWorldToLocalScale(localToWorld_nonUniform, point_zero);
+            LogAssert.Expect(LogType.Error, s_NonUniformScaleError);
+            TransformUtil.ConvertWorldToLocalScale(localToWorld_nonUniform, new float3(2, -2, 0));
+
+            LogAssert.Expect(LogType.Error, s_NonUniformScaleError);
+            TransformUtil.ConvertWorldToLocalScale(worldToLocal_nonUniform, point_one);
+            LogAssert.Expect(LogType.Error, s_NonUniformScaleError);
+            TransformUtil.ConvertWorldToLocalScale(worldToLocal_nonUniform, point_two);
+            LogAssert.Expect(LogType.Error, s_NonUniformScaleError);
+            TransformUtil.ConvertWorldToLocalScale(worldToLocal_nonUniform, -point_one);
+            LogAssert.Expect(LogType.Error, s_NonUniformScaleError);
+            TransformUtil.ConvertWorldToLocalScale(worldToLocal_nonUniform, -point_two);
+            LogAssert.Expect(LogType.Error, s_NonUniformScaleError);
+            TransformUtil.ConvertWorldToLocalScale(worldToLocal_nonUniform, point_zero);
+            LogAssert.Expect(LogType.Error, s_NonUniformScaleError);
+            TransformUtil.ConvertWorldToLocalScale(worldToLocal_nonUniform, new float3(2, -2, 0));
+            Logger.Debug("END: Expected error messages.");
+#endif
+
+            // float3x3 worldToLocal_nonUniformRotation = new float3x3(TransformUtil.ConvertWorldToLocalRotation(worldToLocal_nonUniform, quaternion.identity));
+            // Assert.That(
+            //     math.mul(worldToLocal_nonUniformRotation, float3x3.Scale(TransformUtil.ConvertWorldToLocalScale(localToWorld_nonUniform, point_one))),
+            //     Is.EqualTo(math.mul((float3x3)worldToLocal_nonUniform, float3x3.Scale(point_one))).Using<float3x3>(EqualityWithTolerance)
+            // );
+            // Assert.That(
+            //     math.mul(worldToLocal_nonUniformRotation, float3x3.Scale(TransformUtil.ConvertWorldToLocalScale(localToWorld_nonUniform, point_two))),
+            //     Is.EqualTo(math.mul((float3x3)worldToLocal_nonUniform, float3x3.Scale(point_two))).Using<float3x3>(EqualityWithTolerance)
+            // );
+            // Assert.That(
+            //     math.mul(worldToLocal_nonUniformRotation, float3x3.Scale(TransformUtil.ConvertWorldToLocalScale(localToWorld_nonUniform, -point_one))),
+            //     Is.EqualTo(math.mul((float3x3)worldToLocal_nonUniform, float3x3.Scale(-point_one))).Using<float3x3>(EqualityWithTolerance)
+            // );
+            // Assert.That(
+            //     math.mul(worldToLocal_nonUniformRotation, float3x3.Scale(TransformUtil.ConvertWorldToLocalScale(localToWorld_nonUniform, -point_two))),
+            //     Is.EqualTo(math.mul((float3x3)worldToLocal_nonUniform, float3x3.Scale(-point_two))).Using<float3x3>(EqualityWithTolerance)
+            // );
+            // Assert.That(
+            //     math.mul(worldToLocal_nonUniformRotation, float3x3.Scale(TransformUtil.ConvertWorldToLocalScale(localToWorld_nonUniform, point_zero))),
+            //     Is.EqualTo(math.mul((float3x3)worldToLocal_nonUniform, float3x3.Scale(point_zero))).Using<float3x3>(EqualityWithTolerance)
+            // );
+            //
+            // Assert.That(
+            //     math.mul(worldToLocal_nonUniformRotation, float3x3.Scale(TransformUtil.ConvertWorldToLocalScale(worldToLocal_nonUniform, point_one))),
+            //     Is.EqualTo(math.mul((float3x3)worldToLocal_nonUniform, float3x3.Scale(point_one))).Using<float3x3>(EqualityWithTolerance)
+            // );
+            // Assert.That(
+            //     math.mul(worldToLocal_nonUniformRotation, float3x3.Scale(TransformUtil.ConvertWorldToLocalScale(worldToLocal_nonUniform, point_two))),
+            //     Is.EqualTo(math.mul((float3x3)worldToLocal_nonUniform, float3x3.Scale(point_two))).Using<float3x3>(EqualityWithTolerance)
+            // );
+            // Assert.That(
+            //     math.mul(worldToLocal_nonUniformRotation, float3x3.Scale(TransformUtil.ConvertWorldToLocalScale(worldToLocal_nonUniform, -point_one))),
+            //     Is.EqualTo(math.mul((float3x3)worldToLocal_nonUniform, float3x3.Scale(-point_one))).Using<float3x3>(EqualityWithTolerance)
+            // );
+            // Assert.That(
+            //     math.mul(worldToLocal_nonUniformRotation, float3x3.Scale(TransformUtil.ConvertWorldToLocalScale(worldToLocal_nonUniform, -point_two))),
+            //     Is.EqualTo(math.mul((float3x3)worldToLocal_nonUniform, float3x3.Scale(-point_two))).Using<float3x3>(EqualityWithTolerance)
+            // );
+            // Assert.That(
+            //     math.mul(worldToLocal_nonUniformRotation, float3x3.Scale(TransformUtil.ConvertWorldToLocalScale(worldToLocal_nonUniform, point_zero))),
+            //     Is.EqualTo(math.mul((float3x3)worldToLocal_nonUniform, float3x3.Scale(point_zero))).Using<float3x3>(EqualityWithTolerance)
+            // );
+
         }
 
-        //
-        // [Test]
-        // public static float3 ConvertLocalToWorldScaleTest()
-        // {
-        //     return ConvertLocalToWorldScale(localToWorld.Value, scale);
-        // }
-        //
+        [Test]
+        public static void ConvertWorldToLocalScaleTest_Compound()
+        {
+            float3 point_zero = float3.zero;
+            float3 point_one = new float3(1f, 1f, 1f);
+            float3 point_two = point_one * 2f;
+            float3 point_sevenXY = new float3(7f, 7f, 0f);
+
+            quaternion rotation_XZ_fortyFive = quaternion.Euler(math.radians(45), 0, math.radians(45));
+            quaternion rotation_XZ_negativeFortyFive = quaternion.Euler(math.radians(-45), 0, math.radians(-45));
+
+
+            LocalToWorld localToWorld_compound = new LocalToWorld()
+            {
+                Value = float4x4.TRS(point_sevenXY, rotation_XZ_fortyFive, point_one*2f)
+            };
+            float4x4 worldToLocal_compound = math.inverse(localToWorld_compound.Value);
+            float3x3 worldToLocal_compound_rotation = new float3x3(TransformUtil.ConvertWorldToLocalRotation(worldToLocal_compound, quaternion.identity));
+
+            Assert.That(
+                math.mul(worldToLocal_compound_rotation, float3x3.Scale(TransformUtil.ConvertWorldToLocalScale(localToWorld_compound, point_one))),
+                Is.EqualTo(math.mul((float3x3)worldToLocal_compound, float3x3.Scale(point_one))).Using<float3x3>(EqualityWithTolerance)
+            );
+            Assert.That(
+                math.mul(worldToLocal_compound_rotation, float3x3.Scale(TransformUtil.ConvertWorldToLocalScale(localToWorld_compound, point_two))),
+                Is.EqualTo(math.mul((float3x3)worldToLocal_compound, float3x3.Scale(point_two))).Using<float3x3>(EqualityWithTolerance)
+            );
+            Assert.That(
+                math.mul(worldToLocal_compound_rotation, float3x3.Scale(TransformUtil.ConvertWorldToLocalScale(localToWorld_compound, -point_one))),
+                Is.EqualTo(math.mul((float3x3)worldToLocal_compound, float3x3.Scale(-point_one))).Using<float3x3>(EqualityWithTolerance)
+            );
+            Assert.That(
+                math.mul(worldToLocal_compound_rotation, float3x3.Scale(TransformUtil.ConvertWorldToLocalScale(localToWorld_compound, -point_two))),
+                Is.EqualTo(math.mul((float3x3)worldToLocal_compound, float3x3.Scale(-point_two))).Using<float3x3>(EqualityWithTolerance)
+            );
+            Assert.That(
+                math.mul(worldToLocal_compound_rotation, float3x3.Scale(TransformUtil.ConvertWorldToLocalScale(localToWorld_compound, point_zero))),
+                Is.EqualTo(math.mul((float3x3)worldToLocal_compound, float3x3.Scale(point_zero))).Using<float3x3>(EqualityWithTolerance)
+            );
+
+            Assert.That(
+                math.mul(worldToLocal_compound_rotation, float3x3.Scale(TransformUtil.ConvertWorldToLocalScale(worldToLocal_compound, point_one))),
+                Is.EqualTo(math.mul((float3x3)worldToLocal_compound, float3x3.Scale(point_one))).Using<float3x3>(EqualityWithTolerance)
+            );
+            Assert.That(
+                math.mul(worldToLocal_compound_rotation, float3x3.Scale(TransformUtil.ConvertWorldToLocalScale(worldToLocal_compound, point_two))),
+                Is.EqualTo(math.mul((float3x3)worldToLocal_compound, float3x3.Scale(point_two))).Using<float3x3>(EqualityWithTolerance)
+            );
+            Assert.That(
+                math.mul(worldToLocal_compound_rotation, float3x3.Scale(TransformUtil.ConvertWorldToLocalScale(worldToLocal_compound, -point_one))),
+                Is.EqualTo(math.mul((float3x3)worldToLocal_compound, float3x3.Scale(-point_one))).Using<float3x3>(EqualityWithTolerance)
+            );
+            Assert.That(
+                math.mul(worldToLocal_compound_rotation, float3x3.Scale(TransformUtil.ConvertWorldToLocalScale(worldToLocal_compound, -point_two))),
+                Is.EqualTo(math.mul((float3x3)worldToLocal_compound, float3x3.Scale(-point_two))).Using<float3x3>(EqualityWithTolerance)
+            );
+            Assert.That(
+                math.mul(worldToLocal_compound_rotation, float3x3.Scale(TransformUtil.ConvertWorldToLocalScale(worldToLocal_compound, point_zero))),
+                Is.EqualTo(math.mul((float3x3)worldToLocal_compound, float3x3.Scale(point_zero))).Using<float3x3>(EqualityWithTolerance)
+            );
+
+
+            LocalToWorld localToWorld_compound_negativeZ = new LocalToWorld()
+            {
+                Value = float4x4.TRS(-point_sevenXY, rotation_XZ_negativeFortyFive, new float3(2f, 2f, -2f))
+            };
+            float4x4 worldToLocal_compound_negativeZ = math.inverse(localToWorld_compound_negativeZ.Value);
+            float3x3 worldToLocal_compound_negativeZRotation = new float3x3(TransformUtil.ConvertWorldToLocalRotation(worldToLocal_compound_negativeZ, quaternion.identity));
+
+            Assert.That(
+                math.mul(worldToLocal_compound_negativeZRotation, float3x3.Scale(TransformUtil.ConvertWorldToLocalScale(localToWorld_compound_negativeZ, point_one))),
+                Is.EqualTo(math.mul((float3x3)worldToLocal_compound_negativeZ, float3x3.Scale(point_one))).Using<float3x3>(EqualityWithTolerance)
+            );
+            Assert.That(
+                math.mul(worldToLocal_compound_negativeZRotation, float3x3.Scale(TransformUtil.ConvertWorldToLocalScale(localToWorld_compound_negativeZ, point_two))),
+                Is.EqualTo(math.mul((float3x3)worldToLocal_compound_negativeZ, float3x3.Scale(point_two))).Using<float3x3>(EqualityWithTolerance)
+            );
+            Assert.That(
+                math.mul(worldToLocal_compound_negativeZRotation, float3x3.Scale(TransformUtil.ConvertWorldToLocalScale(localToWorld_compound_negativeZ, -point_one))),
+                Is.EqualTo(math.mul((float3x3)worldToLocal_compound_negativeZ, float3x3.Scale(-point_one))).Using<float3x3>(EqualityWithTolerance)
+            );
+            Assert.That(
+                math.mul(worldToLocal_compound_negativeZRotation, float3x3.Scale(TransformUtil.ConvertWorldToLocalScale(localToWorld_compound_negativeZ, -point_two))),
+                Is.EqualTo(math.mul((float3x3)worldToLocal_compound_negativeZ, float3x3.Scale(-point_two))).Using<float3x3>(EqualityWithTolerance)
+            );
+            Assert.That(
+                math.mul(worldToLocal_compound_negativeZRotation, float3x3.Scale(TransformUtil.ConvertWorldToLocalScale(localToWorld_compound_negativeZ, point_zero))),
+                Is.EqualTo(math.mul((float3x3)worldToLocal_compound_negativeZ, float3x3.Scale(point_zero))).Using<float3x3>(EqualityWithTolerance)
+            );
+
+            Assert.That(
+                math.mul(worldToLocal_compound_negativeZRotation, float3x3.Scale(TransformUtil.ConvertWorldToLocalScale(worldToLocal_compound_negativeZ, point_one))),
+                Is.EqualTo(math.mul((float3x3)worldToLocal_compound_negativeZ, float3x3.Scale(point_one))).Using<float3x3>(EqualityWithTolerance)
+            );
+            Assert.That(
+                math.mul(worldToLocal_compound_negativeZRotation, float3x3.Scale(TransformUtil.ConvertWorldToLocalScale(worldToLocal_compound_negativeZ, point_two))),
+                Is.EqualTo(math.mul((float3x3)worldToLocal_compound_negativeZ, float3x3.Scale(point_two))).Using<float3x3>(EqualityWithTolerance)
+            );
+            Assert.That(
+                math.mul(worldToLocal_compound_negativeZRotation, float3x3.Scale(TransformUtil.ConvertWorldToLocalScale(worldToLocal_compound_negativeZ, -point_one))),
+                Is.EqualTo(math.mul((float3x3)worldToLocal_compound_negativeZ, float3x3.Scale(-point_one))).Using<float3x3>(EqualityWithTolerance)
+            );
+            Assert.That(
+                math.mul(worldToLocal_compound_negativeZRotation, float3x3.Scale(TransformUtil.ConvertWorldToLocalScale(worldToLocal_compound_negativeZ, -point_two))),
+                Is.EqualTo(math.mul((float3x3)worldToLocal_compound_negativeZ, float3x3.Scale(-point_two))).Using<float3x3>(EqualityWithTolerance)
+            );
+            Assert.That(
+                math.mul(worldToLocal_compound_negativeZRotation, float3x3.Scale(TransformUtil.ConvertWorldToLocalScale(worldToLocal_compound_negativeZ, point_zero))),
+                Is.EqualTo(math.mul((float3x3)worldToLocal_compound_negativeZ, float3x3.Scale(point_zero))).Using<float3x3>(EqualityWithTolerance)
+            );
+        }
+
+        [Test]
+        public static void ConvertLocalToWorldScaleTest_Scale()
+        {
+            Regex invalidMatrixError_scale = new Regex(@"This transform is invalid\. Returning a signed infinite scale\.");
+            float3 point_zero = float3.zero;
+            float3 point_one = new float3(1f, 1f, 1f);
+            float3 point_two = point_one * 2f;
+            float3 point_infinity = new float3(float.PositiveInfinity);
+
+
+            LocalToWorld localToWorld_one = new LocalToWorld()
+            {
+                Value = float4x4.TRS(point_zero, quaternion.identity, point_one)
+            };
+            float4x4 localToWorldMatrix_one = localToWorld_one.Value;
+
+            Assert.That(TransformUtil.ConvertLocalToWorldScale(localToWorld_one, point_one), Is.EqualTo(point_one).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldScale(localToWorld_one, point_two), Is.EqualTo(point_two).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldScale(localToWorld_one, -point_one), Is.EqualTo(-point_one).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldScale(localToWorld_one, -point_two), Is.EqualTo(-point_two).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldScale(localToWorld_one, point_zero), Is.EqualTo(point_zero).Using<float3>(EqualityWithTolerance));
+
+            Assert.That(TransformUtil.ConvertLocalToWorldScale(localToWorldMatrix_one, point_one), Is.EqualTo(point_one).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldScale(localToWorldMatrix_one, point_two), Is.EqualTo(point_two).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldScale(localToWorldMatrix_one, -point_one), Is.EqualTo(-point_one).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldScale(localToWorldMatrix_one, -point_two), Is.EqualTo(-point_two).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldScale(localToWorldMatrix_one, point_zero), Is.EqualTo(point_zero).Using<float3>(EqualityWithTolerance));
+
+
+            LocalToWorld localToWorld_two = new LocalToWorld()
+            {
+                Value = float4x4.TRS(point_zero, quaternion.identity, point_two)
+            };
+            float4x4 localToWorldMatrix_two = localToWorld_two.Value;
+
+            Assert.That(TransformUtil.ConvertLocalToWorldScale(localToWorld_two, point_one), Is.EqualTo(point_one*point_two).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldScale(localToWorld_two, point_two), Is.EqualTo(point_two*point_two).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldScale(localToWorld_two, -point_one), Is.EqualTo(-point_one*point_two).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldScale(localToWorld_two, -point_two), Is.EqualTo(-point_two*point_two).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldScale(localToWorld_two, point_zero), Is.EqualTo(point_zero*point_two).Using<float3>(EqualityWithTolerance));
+
+            Assert.That(TransformUtil.ConvertLocalToWorldScale(localToWorldMatrix_two, point_one), Is.EqualTo(point_one*point_two).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldScale(localToWorldMatrix_two, point_two), Is.EqualTo(point_two*point_two).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldScale(localToWorldMatrix_two, -point_one), Is.EqualTo(-point_one*point_two).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldScale(localToWorldMatrix_two, -point_two), Is.EqualTo(-point_two*point_two).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldScale(localToWorldMatrix_two, point_zero), Is.EqualTo(point_zero*point_two).Using<float3>(EqualityWithTolerance));
+
+
+            LocalToWorld localToWorld_negativeOne = new LocalToWorld()
+            {
+                Value = float4x4.TRS(point_zero, quaternion.identity, -point_one)
+            };
+            float4x4 localToWorldMatrix_negativeOne = localToWorld_negativeOne.Value;
+            float3x3 localToWorld_negativeOneRotation = new float3x3(TransformUtil.ConvertLocalToWorldRotation(localToWorldMatrix_negativeOne, quaternion.identity));
+
+            Assert.That(
+                math.mul(localToWorld_negativeOneRotation, float3x3.Scale(TransformUtil.ConvertLocalToWorldScale(localToWorld_negativeOne, point_one))),
+                Is.EqualTo(math.mul((float3x3)localToWorldMatrix_negativeOne, float3x3.Scale(point_one))).Using<float3x3>(EqualityWithTolerance)
+            );
+            Assert.That(
+                math.mul(localToWorld_negativeOneRotation, float3x3.Scale(TransformUtil.ConvertLocalToWorldScale(localToWorld_negativeOne, point_two))),
+                Is.EqualTo(math.mul((float3x3)localToWorldMatrix_negativeOne, float3x3.Scale(point_two))).Using<float3x3>(EqualityWithTolerance)
+            );
+            Assert.That(
+                math.mul(localToWorld_negativeOneRotation, float3x3.Scale(TransformUtil.ConvertLocalToWorldScale(localToWorld_negativeOne, -point_one))),
+                Is.EqualTo(math.mul((float3x3)localToWorldMatrix_negativeOne, float3x3.Scale(-point_one))).Using<float3x3>(EqualityWithTolerance)
+            );
+            Assert.That(
+                math.mul(localToWorld_negativeOneRotation, float3x3.Scale(TransformUtil.ConvertLocalToWorldScale(localToWorld_negativeOne, -point_two))),
+                Is.EqualTo(math.mul((float3x3)localToWorldMatrix_negativeOne, float3x3.Scale(-point_two))).Using<float3x3>(EqualityWithTolerance)
+            );
+            Assert.That(
+                math.mul(localToWorld_negativeOneRotation, float3x3.Scale(TransformUtil.ConvertLocalToWorldScale(localToWorld_negativeOne, point_zero))),
+                Is.EqualTo(math.mul((float3x3)localToWorldMatrix_negativeOne, float3x3.Scale(point_zero))).Using<float3x3>(EqualityWithTolerance)
+            );
+
+            Assert.That(
+                math.mul(localToWorld_negativeOneRotation, float3x3.Scale(TransformUtil.ConvertLocalToWorldScale(localToWorldMatrix_negativeOne, point_one))),
+                Is.EqualTo(math.mul((float3x3)localToWorldMatrix_negativeOne, float3x3.Scale(point_one))).Using<float3x3>(EqualityWithTolerance)
+            );
+            Assert.That(
+                math.mul(localToWorld_negativeOneRotation, float3x3.Scale(TransformUtil.ConvertLocalToWorldScale(localToWorldMatrix_negativeOne, point_two))),
+                Is.EqualTo(math.mul((float3x3)localToWorldMatrix_negativeOne, float3x3.Scale(point_two))).Using<float3x3>(EqualityWithTolerance)
+            );
+            Assert.That(
+                math.mul(localToWorld_negativeOneRotation, float3x3.Scale(TransformUtil.ConvertLocalToWorldScale(localToWorldMatrix_negativeOne, -point_one))),
+                Is.EqualTo(math.mul((float3x3)localToWorldMatrix_negativeOne, float3x3.Scale(-point_one))).Using<float3x3>(EqualityWithTolerance)
+            );
+            Assert.That(
+                math.mul(localToWorld_negativeOneRotation, float3x3.Scale(TransformUtil.ConvertLocalToWorldScale(localToWorldMatrix_negativeOne, -point_two))),
+                Is.EqualTo(math.mul((float3x3)localToWorldMatrix_negativeOne, float3x3.Scale(-point_two))).Using<float3x3>(EqualityWithTolerance)
+            );
+            Assert.That(
+                math.mul(localToWorld_negativeOneRotation, float3x3.Scale(TransformUtil.ConvertLocalToWorldScale(localToWorldMatrix_negativeOne, point_zero))),
+                Is.EqualTo(math.mul((float3x3)localToWorldMatrix_negativeOne, float3x3.Scale(point_zero))).Using<float3x3>(EqualityWithTolerance)
+            );
+
+
+            LocalToWorld localToWorld_negativeTwo = new LocalToWorld()
+            {
+                Value = float4x4.TRS(point_zero, quaternion.identity, -point_two)
+            };
+            float4x4 localToWorldMatrix_negativeTwo = localToWorld_negativeTwo.Value;
+            float3x3 localToWorld_negativeTwoRotation = new float3x3(TransformUtil.ConvertLocalToWorldRotation(localToWorldMatrix_negativeTwo, quaternion.identity));
+
+            Assert.That(
+                math.mul(localToWorld_negativeTwoRotation, float3x3.Scale(TransformUtil.ConvertLocalToWorldScale(localToWorld_negativeTwo, point_one))),
+                Is.EqualTo(math.mul((float3x3)localToWorldMatrix_negativeTwo, float3x3.Scale(point_one))).Using<float3x3>(EqualityWithTolerance)
+            );
+            Assert.That(
+                math.mul(localToWorld_negativeTwoRotation, float3x3.Scale(TransformUtil.ConvertLocalToWorldScale(localToWorld_negativeTwo, point_two))),
+                Is.EqualTo(math.mul((float3x3)localToWorldMatrix_negativeTwo, float3x3.Scale(point_two))).Using<float3x3>(EqualityWithTolerance)
+            );
+            Assert.That(
+                math.mul(localToWorld_negativeTwoRotation, float3x3.Scale(TransformUtil.ConvertLocalToWorldScale(localToWorld_negativeTwo, -point_one))),
+                Is.EqualTo(math.mul((float3x3)localToWorldMatrix_negativeTwo, float3x3.Scale(-point_one))).Using<float3x3>(EqualityWithTolerance)
+            );
+            Assert.That(
+                math.mul(localToWorld_negativeTwoRotation, float3x3.Scale(TransformUtil.ConvertLocalToWorldScale(localToWorld_negativeTwo, -point_two))),
+                Is.EqualTo(math.mul((float3x3)localToWorldMatrix_negativeTwo, float3x3.Scale(-point_two))).Using<float3x3>(EqualityWithTolerance)
+            );
+            Assert.That(
+                math.mul(localToWorld_negativeTwoRotation, float3x3.Scale(TransformUtil.ConvertLocalToWorldScale(localToWorld_negativeTwo, point_zero))),
+                Is.EqualTo(math.mul((float3x3)localToWorldMatrix_negativeTwo, float3x3.Scale(point_zero))).Using<float3x3>(EqualityWithTolerance)
+            );
+
+            Assert.That(
+                math.mul(localToWorld_negativeTwoRotation, float3x3.Scale(TransformUtil.ConvertLocalToWorldScale(localToWorldMatrix_negativeTwo, point_one))),
+                Is.EqualTo(math.mul((float3x3)localToWorldMatrix_negativeTwo, float3x3.Scale(point_one))).Using<float3x3>(EqualityWithTolerance)
+            );
+            Assert.That(
+                math.mul(localToWorld_negativeTwoRotation, float3x3.Scale(TransformUtil.ConvertLocalToWorldScale(localToWorldMatrix_negativeTwo, point_two))),
+                Is.EqualTo(math.mul((float3x3)localToWorldMatrix_negativeTwo, float3x3.Scale(point_two))).Using<float3x3>(EqualityWithTolerance)
+            );
+            Assert.That(
+                math.mul(localToWorld_negativeTwoRotation, float3x3.Scale(TransformUtil.ConvertLocalToWorldScale(localToWorldMatrix_negativeTwo, -point_one))),
+                Is.EqualTo(math.mul((float3x3)localToWorldMatrix_negativeTwo, float3x3.Scale(-point_one))).Using<float3x3>(EqualityWithTolerance)
+            );
+            Assert.That(
+                math.mul(localToWorld_negativeTwoRotation, float3x3.Scale(TransformUtil.ConvertLocalToWorldScale(localToWorldMatrix_negativeTwo, -point_two))),
+                Is.EqualTo(math.mul((float3x3)localToWorldMatrix_negativeTwo, float3x3.Scale(-point_two))).Using<float3x3>(EqualityWithTolerance)
+            );
+            Assert.That(
+                math.mul(localToWorld_negativeTwoRotation, float3x3.Scale(TransformUtil.ConvertLocalToWorldScale(localToWorldMatrix_negativeTwo, point_zero))),
+                Is.EqualTo(math.mul((float3x3)localToWorldMatrix_negativeTwo, float3x3.Scale(point_zero))).Using<float3x3>(EqualityWithTolerance)
+            );
+
+
+            LocalToWorld localToWorld_zero = new LocalToWorld()
+            {
+                Value = float4x4.TRS(point_zero, quaternion.identity, point_zero)
+            };
+            float4x4 localToWorldMatrix_zero = localToWorld_zero.Value;
+
+            Logger.Debug("BEGIN: Expected error messages.");
+            LogAssert.Expect(LogType.Error, invalidMatrixError_scale);
+            Assert.That(TransformUtil.ConvertLocalToWorldScale(localToWorld_zero, point_one), Is.EqualTo(point_infinity));
+            LogAssert.Expect(LogType.Error, invalidMatrixError_scale);
+            Assert.That(TransformUtil.ConvertLocalToWorldScale(localToWorld_zero, point_two), Is.EqualTo(point_infinity));
+            LogAssert.Expect(LogType.Error, invalidMatrixError_scale);
+            Assert.That(TransformUtil.ConvertLocalToWorldScale(localToWorld_zero, -point_one), Is.EqualTo(-point_infinity));
+            LogAssert.Expect(LogType.Error, invalidMatrixError_scale);
+            Assert.That(TransformUtil.ConvertLocalToWorldScale(localToWorld_zero, -point_two), Is.EqualTo(-point_infinity));
+            LogAssert.Expect(LogType.Error, invalidMatrixError_scale);
+            Assert.That(TransformUtil.ConvertLocalToWorldScale(localToWorld_zero, point_zero), Is.EqualTo(point_zero));
+            LogAssert.Expect(LogType.Error, invalidMatrixError_scale);
+            Assert.That(
+                TransformUtil.ConvertLocalToWorldScale(localToWorld_zero, new float3(2, -2, 0)),
+                Is.EqualTo(new float3(float.PositiveInfinity, float.NegativeInfinity, 0))
+                );
+
+            LogAssert.Expect(LogType.Error, invalidMatrixError_scale);
+            Assert.That(TransformUtil.ConvertLocalToWorldScale(localToWorldMatrix_zero, point_one), Is.EqualTo(point_infinity));
+            LogAssert.Expect(LogType.Error, invalidMatrixError_scale);
+            Assert.That(TransformUtil.ConvertLocalToWorldScale(localToWorldMatrix_zero, point_two), Is.EqualTo(point_infinity));
+            LogAssert.Expect(LogType.Error, invalidMatrixError_scale);
+            Assert.That(TransformUtil.ConvertLocalToWorldScale(localToWorldMatrix_zero, -point_one), Is.EqualTo(-point_infinity));
+            LogAssert.Expect(LogType.Error, invalidMatrixError_scale);
+            Assert.That(TransformUtil.ConvertLocalToWorldScale(localToWorldMatrix_zero, -point_two), Is.EqualTo(-point_infinity));
+            LogAssert.Expect(LogType.Error, invalidMatrixError_scale);
+            Assert.That(TransformUtil.ConvertLocalToWorldScale(localToWorldMatrix_zero, point_zero), Is.EqualTo(point_zero));
+            LogAssert.Expect(LogType.Error, invalidMatrixError_scale);
+            Assert.That(
+                TransformUtil.ConvertLocalToWorldScale(localToWorldMatrix_zero, new float3(2, -2, 0)),
+                Is.EqualTo(new float3(float.PositiveInfinity, float.NegativeInfinity, 0))
+            );
+            Logger.Debug("END: Expected error messages.");
+
+
+            //TODO: #116 - Transforms with non-uniform scale operations are not currently supported.
+            // Tests with assertions commented out below would replace these tests.
+            LocalToWorld localToWorld_nonUniform = new LocalToWorld()
+            {
+                Value = float4x4.TRS(point_zero, quaternion.identity, new float3(1.5f, 3, 1))
+            };
+            float4x4 localToWorldMatrix_nonUniform = localToWorld_nonUniform.Value;
+
+#if DEBUG
+            Logger.Debug("BEGIN: Expected error messages.");
+            LogAssert.Expect(LogType.Error, s_NonUniformScaleError);
+            TransformUtil.ConvertLocalToWorldScale(localToWorld_nonUniform, point_one);
+            LogAssert.Expect(LogType.Error, s_NonUniformScaleError);
+            TransformUtil.ConvertLocalToWorldScale(localToWorld_nonUniform, point_two);
+            LogAssert.Expect(LogType.Error, s_NonUniformScaleError);
+            TransformUtil.ConvertLocalToWorldScale(localToWorld_nonUniform, -point_one);
+            LogAssert.Expect(LogType.Error, s_NonUniformScaleError);
+            TransformUtil.ConvertLocalToWorldScale(localToWorld_nonUniform, -point_two);
+            LogAssert.Expect(LogType.Error, s_NonUniformScaleError);
+            TransformUtil.ConvertLocalToWorldScale(localToWorld_nonUniform, point_zero);
+            LogAssert.Expect(LogType.Error, s_NonUniformScaleError);
+            TransformUtil.ConvertLocalToWorldScale(localToWorld_nonUniform, new float3(2, -2, 0));
+
+            LogAssert.Expect(LogType.Error, s_NonUniformScaleError);
+            TransformUtil.ConvertLocalToWorldScale(localToWorldMatrix_nonUniform, point_one);
+            LogAssert.Expect(LogType.Error, s_NonUniformScaleError);
+            TransformUtil.ConvertLocalToWorldScale(localToWorldMatrix_nonUniform, point_two);
+            LogAssert.Expect(LogType.Error, s_NonUniformScaleError);
+            TransformUtil.ConvertLocalToWorldScale(localToWorldMatrix_nonUniform, -point_one);
+            LogAssert.Expect(LogType.Error, s_NonUniformScaleError);
+            TransformUtil.ConvertLocalToWorldScale(localToWorldMatrix_nonUniform, -point_two);
+            LogAssert.Expect(LogType.Error, s_NonUniformScaleError);
+            TransformUtil.ConvertLocalToWorldScale(localToWorldMatrix_nonUniform, point_zero);
+            LogAssert.Expect(LogType.Error, s_NonUniformScaleError);
+            TransformUtil.ConvertLocalToWorldScale(localToWorldMatrix_nonUniform, new float3(2, -2, 0));
+            Logger.Debug("END: Expected error messages.");
+#endif
+
+            // float3x3 localToWorld_nonUniformRotation = new float3x3(TransformUtil.ConvertLocalToWorldRotation(localToWorldMatrix_nonUniform, quaternion.identity));
+            // Assert.That(
+            //     math.mul(localToWorld_nonUniformRotation, float3x3.Scale(TransformUtil.ConvertLocalToWorldScale(localToWorld_nonUniform, point_one))),
+            //     Is.EqualTo(math.mul((float3x3)localToWorldMatrix_nonUniform, float3x3.Scale(point_one))).Using<float3x3>(EqualityWithTolerance)
+            // );
+            // Assert.That(
+            //     math.mul(localToWorld_nonUniformRotation, float3x3.Scale(TransformUtil.ConvertLocalToWorldScale(localToWorld_nonUniform, point_two))),
+            //     Is.EqualTo(math.mul((float3x3)localToWorldMatrix_nonUniform, float3x3.Scale(point_two))).Using<float3x3>(EqualityWithTolerance)
+            // );
+            // Assert.That(
+            //     math.mul(localToWorld_nonUniformRotation, float3x3.Scale(TransformUtil.ConvertLocalToWorldScale(localToWorld_nonUniform, -point_one))),
+            //     Is.EqualTo(math.mul((float3x3)localToWorldMatrix_nonUniform, float3x3.Scale(-point_one))).Using<float3x3>(EqualityWithTolerance)
+            // );
+            // Assert.That(
+            //     math.mul(localToWorld_nonUniformRotation, float3x3.Scale(TransformUtil.ConvertLocalToWorldScale(localToWorld_nonUniform, -point_two))),
+            //     Is.EqualTo(math.mul((float3x3)localToWorldMatrix_nonUniform, float3x3.Scale(-point_two))).Using<float3x3>(EqualityWithTolerance)
+            // );
+            // Assert.That(
+            //     math.mul(localToWorld_nonUniformRotation, float3x3.Scale(TransformUtil.ConvertLocalToWorldScale(localToWorld_nonUniform, point_zero))),
+            //     Is.EqualTo(math.mul((float3x3)localToWorldMatrix_nonUniform, float3x3.Scale(point_zero))).Using<float3x3>(EqualityWithTolerance)
+            // );
+            //
+            // Assert.That(
+            //     math.mul(localToWorld_nonUniformRotation, float3x3.Scale(TransformUtil.ConvertLocalToWorldScale(localToWorldMatrix_nonUniform, point_one))),
+            //     Is.EqualTo(math.mul((float3x3)localToWorldMatrix_nonUniform, float3x3.Scale(point_one))).Using<float3x3>(EqualityWithTolerance)
+            // );
+            // Assert.That(
+            //     math.mul(localToWorld_nonUniformRotation, float3x3.Scale(TransformUtil.ConvertLocalToWorldScale(localToWorldMatrix_nonUniform, point_two))),
+            //     Is.EqualTo(math.mul((float3x3)localToWorldMatrix_nonUniform, float3x3.Scale(point_two))).Using<float3x3>(EqualityWithTolerance)
+            // );
+            // Assert.That(
+            //     math.mul(localToWorld_nonUniformRotation, float3x3.Scale(TransformUtil.ConvertLocalToWorldScale(localToWorldMatrix_nonUniform, -point_one))),
+            //     Is.EqualTo(math.mul((float3x3)localToWorldMatrix_nonUniform, float3x3.Scale(-point_one))).Using<float3x3>(EqualityWithTolerance)
+            // );
+            // Assert.That(
+            //     math.mul(localToWorld_nonUniformRotation, float3x3.Scale(TransformUtil.ConvertLocalToWorldScale(localToWorldMatrix_nonUniform, -point_two))),
+            //     Is.EqualTo(math.mul((float3x3)localToWorldMatrix_nonUniform, float3x3.Scale(-point_two))).Using<float3x3>(EqualityWithTolerance)
+            // );
+            // Assert.That(
+            //     math.mul(localToWorld_nonUniformRotation, float3x3.Scale(TransformUtil.ConvertLocalToWorldScale(localToWorldMatrix_nonUniform, point_zero))),
+            //     Is.EqualTo(math.mul((float3x3)localToWorldMatrix_nonUniform, float3x3.Scale(point_zero))).Using<float3x3>(EqualityWithTolerance)
+            // );
+        }
+
+        [Test]
+        public static void ConvertLocalToWorldScaleTest_Compound()
+        {
+            float3 point_zero = float3.zero;
+            float3 point_one = new float3(1f, 1f, 1f);
+            float3 point_two = point_one * 2f;
+            float3 point_sevenXY = new float3(7f, 7f, 0f);
+
+            quaternion rotation_XZ_fortyFive = quaternion.Euler(math.radians(45), 0, math.radians(45));
+            quaternion rotation_XZ_negativeFortyFive = quaternion.Euler(math.radians(-45), 0, math.radians(-45));
+
+
+            LocalToWorld localToWorld_compound = new LocalToWorld()
+            {
+                Value = float4x4.TRS(point_sevenXY, rotation_XZ_fortyFive, point_one*2f)
+            };
+            float4x4 localToWorldMatrix_compound = localToWorld_compound.Value;
+            float3x3 localToWorld_compound_rotation = new float3x3(TransformUtil.ConvertLocalToWorldRotation(localToWorldMatrix_compound, quaternion.identity));
+
+            Assert.That(
+                math.mul(localToWorld_compound_rotation, float3x3.Scale(TransformUtil.ConvertLocalToWorldScale(localToWorld_compound, point_one))),
+                Is.EqualTo(math.mul((float3x3)localToWorldMatrix_compound, float3x3.Scale(point_one))).Using<float3x3>(EqualityWithTolerance)
+            );
+            Assert.That(
+                math.mul(localToWorld_compound_rotation, float3x3.Scale(TransformUtil.ConvertLocalToWorldScale(localToWorld_compound, point_two))),
+                Is.EqualTo(math.mul((float3x3)localToWorldMatrix_compound, float3x3.Scale(point_two))).Using<float3x3>(EqualityWithTolerance)
+            );
+            Assert.That(
+                math.mul(localToWorld_compound_rotation, float3x3.Scale(TransformUtil.ConvertLocalToWorldScale(localToWorld_compound, -point_one))),
+                Is.EqualTo(math.mul((float3x3)localToWorldMatrix_compound, float3x3.Scale(-point_one))).Using<float3x3>(EqualityWithTolerance)
+            );
+            Assert.That(
+                math.mul(localToWorld_compound_rotation, float3x3.Scale(TransformUtil.ConvertLocalToWorldScale(localToWorld_compound, -point_two))),
+                Is.EqualTo(math.mul((float3x3)localToWorldMatrix_compound, float3x3.Scale(-point_two))).Using<float3x3>(EqualityWithTolerance)
+            );
+            Assert.That(
+                math.mul(localToWorld_compound_rotation, float3x3.Scale(TransformUtil.ConvertLocalToWorldScale(localToWorld_compound, point_zero))),
+                Is.EqualTo(math.mul((float3x3)localToWorldMatrix_compound, float3x3.Scale(point_zero))).Using<float3x3>(EqualityWithTolerance)
+            );
+
+            Assert.That(
+                math.mul(localToWorld_compound_rotation, float3x3.Scale(TransformUtil.ConvertLocalToWorldScale(localToWorldMatrix_compound, point_one))),
+                Is.EqualTo(math.mul((float3x3)localToWorldMatrix_compound, float3x3.Scale(point_one))).Using<float3x3>(EqualityWithTolerance)
+            );
+            Assert.That(
+                math.mul(localToWorld_compound_rotation, float3x3.Scale(TransformUtil.ConvertLocalToWorldScale(localToWorldMatrix_compound, point_two))),
+                Is.EqualTo(math.mul((float3x3)localToWorldMatrix_compound, float3x3.Scale(point_two))).Using<float3x3>(EqualityWithTolerance)
+            );
+            Assert.That(
+                math.mul(localToWorld_compound_rotation, float3x3.Scale(TransformUtil.ConvertLocalToWorldScale(localToWorldMatrix_compound, -point_one))),
+                Is.EqualTo(math.mul((float3x3)localToWorldMatrix_compound, float3x3.Scale(-point_one))).Using<float3x3>(EqualityWithTolerance)
+            );
+            Assert.That(
+                math.mul(localToWorld_compound_rotation, float3x3.Scale(TransformUtil.ConvertLocalToWorldScale(localToWorldMatrix_compound, -point_two))),
+                Is.EqualTo(math.mul((float3x3)localToWorldMatrix_compound, float3x3.Scale(-point_two))).Using<float3x3>(EqualityWithTolerance)
+            );
+            Assert.That(
+                math.mul(localToWorld_compound_rotation, float3x3.Scale(TransformUtil.ConvertLocalToWorldScale(localToWorldMatrix_compound, point_zero))),
+                Is.EqualTo(math.mul((float3x3)localToWorldMatrix_compound, float3x3.Scale(point_zero))).Using<float3x3>(EqualityWithTolerance)
+            );
+
+
+            LocalToWorld localToWorld_compound_negativeZ = new LocalToWorld()
+            {
+                Value = float4x4.TRS(-point_sevenXY, rotation_XZ_negativeFortyFive, new float3(2f, 2f, -2f))
+            };
+            float4x4 localToWorldMatrix_compound_negativeZ = localToWorld_compound_negativeZ.Value;
+            float3x3 localToWorld_compound_negativeZRotation = new float3x3(TransformUtil.ConvertLocalToWorldRotation(localToWorldMatrix_compound_negativeZ, quaternion.identity));
+
+            Assert.That(
+                math.mul(localToWorld_compound_negativeZRotation, float3x3.Scale(TransformUtil.ConvertLocalToWorldScale(localToWorld_compound_negativeZ, point_one))),
+                Is.EqualTo(math.mul((float3x3)localToWorldMatrix_compound_negativeZ, float3x3.Scale(point_one))).Using<float3x3>(EqualityWithTolerance)
+            );
+            Assert.That(
+                math.mul(localToWorld_compound_negativeZRotation, float3x3.Scale(TransformUtil.ConvertLocalToWorldScale(localToWorld_compound_negativeZ, point_two))),
+                Is.EqualTo(math.mul((float3x3)localToWorldMatrix_compound_negativeZ, float3x3.Scale(point_two))).Using<float3x3>(EqualityWithTolerance)
+            );
+            Assert.That(
+                math.mul(localToWorld_compound_negativeZRotation, float3x3.Scale(TransformUtil.ConvertLocalToWorldScale(localToWorld_compound_negativeZ, -point_one))),
+                Is.EqualTo(math.mul((float3x3)localToWorldMatrix_compound_negativeZ, float3x3.Scale(-point_one))).Using<float3x3>(EqualityWithTolerance)
+            );
+            Assert.That(
+                math.mul(localToWorld_compound_negativeZRotation, float3x3.Scale(TransformUtil.ConvertLocalToWorldScale(localToWorld_compound_negativeZ, -point_two))),
+                Is.EqualTo(math.mul((float3x3)localToWorldMatrix_compound_negativeZ, float3x3.Scale(-point_two))).Using<float3x3>(EqualityWithTolerance)
+            );
+            Assert.That(
+                math.mul(localToWorld_compound_negativeZRotation, float3x3.Scale(TransformUtil.ConvertLocalToWorldScale(localToWorld_compound_negativeZ, point_zero))),
+                Is.EqualTo(math.mul((float3x3)localToWorldMatrix_compound_negativeZ, float3x3.Scale(point_zero))).Using<float3x3>(EqualityWithTolerance)
+            );
+
+            Assert.That(
+                math.mul(localToWorld_compound_negativeZRotation, float3x3.Scale(TransformUtil.ConvertLocalToWorldScale(localToWorldMatrix_compound_negativeZ, point_one))),
+                Is.EqualTo(math.mul((float3x3)localToWorldMatrix_compound_negativeZ, float3x3.Scale(point_one))).Using<float3x3>(EqualityWithTolerance)
+            );
+            Assert.That(
+                math.mul(localToWorld_compound_negativeZRotation, float3x3.Scale(TransformUtil.ConvertLocalToWorldScale(localToWorldMatrix_compound_negativeZ, point_two))),
+                Is.EqualTo(math.mul((float3x3)localToWorldMatrix_compound_negativeZ, float3x3.Scale(point_two))).Using<float3x3>(EqualityWithTolerance)
+            );
+            Assert.That(
+                math.mul(localToWorld_compound_negativeZRotation, float3x3.Scale(TransformUtil.ConvertLocalToWorldScale(localToWorldMatrix_compound_negativeZ, -point_one))),
+                Is.EqualTo(math.mul((float3x3)localToWorldMatrix_compound_negativeZ, float3x3.Scale(-point_one))).Using<float3x3>(EqualityWithTolerance)
+            );
+            Assert.That(
+                math.mul(localToWorld_compound_negativeZRotation, float3x3.Scale(TransformUtil.ConvertLocalToWorldScale(localToWorldMatrix_compound_negativeZ, -point_two))),
+                Is.EqualTo(math.mul((float3x3)localToWorldMatrix_compound_negativeZ, float3x3.Scale(-point_two))).Using<float3x3>(EqualityWithTolerance)
+            );
+            Assert.That(
+                math.mul(localToWorld_compound_negativeZRotation, float3x3.Scale(TransformUtil.ConvertLocalToWorldScale(localToWorldMatrix_compound_negativeZ, point_zero))),
+                Is.EqualTo(math.mul((float3x3)localToWorldMatrix_compound_negativeZ, float3x3.Scale(point_zero))).Using<float3x3>(EqualityWithTolerance)
+            );
+        }
+        
         // [Test]
         // public static Rect ConvertWorldToLocalRectTest()
         // {

--- a/Scripts/Editor/Tests/Entities/Transform/TransformUtilTests.cs
+++ b/Scripts/Editor/Tests/Entities/Transform/TransformUtilTests.cs
@@ -1779,6 +1779,8 @@ namespace Anvil.Unity.DOTS.Tests.Entities.Transform
             Logger.Debug("END: Expected error messages.");
 #endif
 
+            // // These follow the template of the asserts for uniform scale transforms. They may or may not result in correct values for
+            // // non-uniform scaling.
             // float3x3 worldToLocal_nonUniformRotation = new float3x3(TransformUtil.ConvertWorldToLocalRotation(worldToLocal_nonUniform, quaternion.identity));
             // Assert.That(
             //     math.mul(worldToLocal_nonUniformRotation, float3x3.Scale(TransformUtil.ConvertWorldToLocalScale(localToWorld_nonUniform, point_one))),
@@ -2168,6 +2170,8 @@ namespace Anvil.Unity.DOTS.Tests.Entities.Transform
             Logger.Debug("END: Expected error messages.");
 #endif
 
+            // // These follow the template of the asserts for uniform scale transforms. They may or may not result in correct values for
+            // // non-uniform scaling.
             // float3x3 localToWorld_nonUniformRotation = new float3x3(TransformUtil.ConvertLocalToWorldRotation(localToWorldMatrix_nonUniform, quaternion.identity));
             // Assert.That(
             //     math.mul(localToWorld_nonUniformRotation, float3x3.Scale(TransformUtil.ConvertLocalToWorldScale(localToWorld_nonUniform, point_one))),

--- a/Scripts/Editor/Tests/Entities/Transform/TransformUtilTests.cs
+++ b/Scripts/Editor/Tests/Entities/Transform/TransformUtilTests.cs
@@ -2,7 +2,6 @@ using System.Text.RegularExpressions;
 using Anvil.CSharp.Logging;
 using Anvil.Unity.Core;
 using Anvil.Unity.DOTS.Entities.Transform;
-using Anvil.Unity.DOTS.Mathematics;
 using NUnit.Framework;
 using Unity.Mathematics;
 using Unity.Transforms;
@@ -46,7 +45,7 @@ namespace Anvil.Unity.DOTS.Tests.Entities.Transform
             return RectUtil.AreEquivalent(a, b) ? 0 : 1;
         }
 
-        // ----- ConvertWorldToLocalPointTest ----- //
+        // ----- ConvertWorldToLocalPoint ----- //
         [Test]
         public static void ConvertWorldToLocalPointTest_Identity()
         {
@@ -478,7 +477,7 @@ namespace Anvil.Unity.DOTS.Tests.Entities.Transform
             Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_CompoundNegative, -point_seven), Is.EqualTo(new float3(1.75f, -1.75f, 2.47487378f)).Using<float3>(EqualityWithTolerance));
         }
 
-        // ----- ConvertLocalToWorldPointTest ----- //
+        // ----- ConvertLocalToWorldPoint ----- //
         [Test]
         public static void ConvertLocalToWorldPointTest_Identity()
         {
@@ -1001,7 +1000,6 @@ namespace Anvil.Unity.DOTS.Tests.Entities.Transform
             quaternion rotation_XZ_fortyFive = quaternion.Euler(math.radians(45), 0, math.radians(45));
             quaternion rotation_XZ_fortyFive_inverse = math.inverse(rotation_XZ_fortyFive);
             quaternion rotation_XZ_negativeFortyFive = quaternion.Euler(math.radians(-45), 0, math.radians(-45));
-            quaternion rotation_XZ_negativeFortyFive_inverse = math.inverse(rotation_XZ_negativeFortyFive);
 
 
             LocalToWorld localToWorld_compound = new LocalToWorld()
@@ -1479,7 +1477,7 @@ namespace Anvil.Unity.DOTS.Tests.Entities.Transform
 
             // // These follow the template of the asserts for uniform scale transforms. They may or may not result in correct values for
             // // non-uniform scaling.
-            // float3x3 localToWorld_compound_negativeYZScale = float3x3.Scale(TransformUtil.ConvertLocalToWorldScale(localToWorldMatrix_compound_negativeYZ, new float3(1f));
+            // float3x3 localToWorld_compound_negativeYZScale = float3x3.Scale(TransformUtil.ConvertLocalToWorldScale(localToWorldMatrix_compound_negativeYZ, new float3(1f)));
             // Assert.That(
             //     math.mul(new float3x3(TransformUtil.ConvertLocalToWorldRotation(localToWorld_compound_negativeYZ, quaternion.identity)), localToWorld_compound_negativeYZScale),
             //     Is.EqualTo(math.mul((float3x3)localToWorldMatrix_compound_negativeYZ, new float3x3(quaternion.identity))).Using<float3x3>(EqualityWithTolerance)
@@ -1908,6 +1906,7 @@ namespace Anvil.Unity.DOTS.Tests.Entities.Transform
             );
         }
 
+        // ----- ConvertLocalToWorldScale ----- //
         [Test]
         public static void ConvertLocalToWorldScaleTest_Scale()
         {

--- a/Scripts/Editor/Tests/Entities/Transform/TransformUtilTests.cs
+++ b/Scripts/Editor/Tests/Entities/Transform/TransformUtilTests.cs
@@ -1,5 +1,6 @@
 using System.Text.RegularExpressions;
 using Anvil.CSharp.Logging;
+using Anvil.Unity.Core;
 using Anvil.Unity.DOTS.Entities.Transform;
 using Anvil.Unity.DOTS.Mathematics;
 using NUnit.Framework;
@@ -38,6 +39,11 @@ namespace Anvil.Unity.DOTS.Tests.Entities.Transform
         private static int EqualityWithTolerance(quaternion a, quaternion b)
         {
             return EqualityWithTolerance(a.value, b.value);
+        }
+
+        private static int EquivalencyWithTolerance(Rect a, Rect b)
+        {
+            return RectUtil.AreEquivalent(a, b) ? 0 : 1;
         }
 
         // ----- ConvertWorldToLocalPointTest ----- //
@@ -897,32 +903,32 @@ namespace Anvil.Unity.DOTS.Tests.Entities.Transform
             quaternion rotation_fortyFive = quaternion.Euler(math.radians(45f), math.radians(45f), math.radians(45f));
             quaternion rotation_fortyFive_inverse = math.inverse(rotation_fortyFive);
 
-            quaternion rotation_nintey = quaternion.Euler(math.radians(90f), math.radians(90f), math.radians(90f));
-            quaternion rotation_nintey_inverse = math.inverse(rotation_nintey);
+            quaternion rotation_ninety = quaternion.Euler(math.radians(90f), math.radians(90f), math.radians(90f));
+            quaternion rotation_ninety_inverse = math.inverse(rotation_ninety);
 
             quaternion rotation_ZfortyFive = quaternion.Euler(0f, 0f, math.radians(45f));
             quaternion rotation_ZfortyFive_inverse = math.inverse(rotation_ZfortyFive);
 
-            quaternion rotation_Znintey = quaternion.Euler(0f, 0f, math.radians(90f));
-            quaternion rotation_Znintey_inverse = math.inverse(rotation_Znintey);
+            quaternion rotation_Zninety = quaternion.Euler(0f, 0f, math.radians(90f));
+            quaternion rotation_Zninety_inverse = math.inverse(rotation_Zninety);
 
 
-            LocalToWorld localToWorld_nintey = new LocalToWorld()
+            LocalToWorld localToWorld_ninety = new LocalToWorld()
             {
-                Value = float4x4.TRS(point_zero, rotation_nintey, point_one)
+                Value = float4x4.TRS(point_zero, rotation_ninety, point_one)
             };
-            float4x4 worldToLocal_nintey = math.inverse(localToWorld_nintey.Value);
-            Assert.That(TransformUtil.ConvertWorldToLocalRotation(localToWorld_nintey, quaternion.identity), Is.EqualTo(math.mul(rotation_nintey_inverse, quaternion.identity)).Using<quaternion>(EqualityWithTolerance));
-            Assert.That(TransformUtil.ConvertWorldToLocalRotation(localToWorld_nintey, rotation_nintey), Is.EqualTo(math.mul(rotation_nintey_inverse, rotation_nintey)).Using<quaternion>(EqualityWithTolerance));
-            Assert.That(TransformUtil.ConvertWorldToLocalRotation(localToWorld_nintey, rotation_Znintey), Is.EqualTo(math.mul(rotation_nintey_inverse, rotation_Znintey)).Using<quaternion>(EqualityWithTolerance));
-            Assert.That(TransformUtil.ConvertWorldToLocalRotation(localToWorld_nintey, rotation_fortyFive), Is.EqualTo(math.mul(rotation_nintey_inverse, rotation_fortyFive)).Using<quaternion>(EqualityWithTolerance));
-            Assert.That(TransformUtil.ConvertWorldToLocalRotation(localToWorld_nintey, rotation_ZfortyFive), Is.EqualTo(math.mul(rotation_nintey_inverse, rotation_ZfortyFive)).Using<quaternion>(EqualityWithTolerance));
+            float4x4 worldToLocal_ninety = math.inverse(localToWorld_ninety.Value);
+            Assert.That(TransformUtil.ConvertWorldToLocalRotation(localToWorld_ninety, quaternion.identity), Is.EqualTo(math.mul(rotation_ninety_inverse, quaternion.identity)).Using<quaternion>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalRotation(localToWorld_ninety, rotation_ninety), Is.EqualTo(math.mul(rotation_ninety_inverse, rotation_ninety)).Using<quaternion>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalRotation(localToWorld_ninety, rotation_Zninety), Is.EqualTo(math.mul(rotation_ninety_inverse, rotation_Zninety)).Using<quaternion>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalRotation(localToWorld_ninety, rotation_fortyFive), Is.EqualTo(math.mul(rotation_ninety_inverse, rotation_fortyFive)).Using<quaternion>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalRotation(localToWorld_ninety, rotation_ZfortyFive), Is.EqualTo(math.mul(rotation_ninety_inverse, rotation_ZfortyFive)).Using<quaternion>(EqualityWithTolerance));
 
-            Assert.That(TransformUtil.ConvertWorldToLocalRotation(worldToLocal_nintey, quaternion.identity), Is.EqualTo(math.mul(rotation_nintey_inverse, quaternion.identity)).Using<quaternion>(EqualityWithTolerance));
-            Assert.That(TransformUtil.ConvertWorldToLocalRotation(worldToLocal_nintey, rotation_nintey), Is.EqualTo(math.mul(rotation_nintey_inverse, rotation_nintey)).Using<quaternion>(EqualityWithTolerance));
-            Assert.That(TransformUtil.ConvertWorldToLocalRotation(worldToLocal_nintey, rotation_Znintey), Is.EqualTo(math.mul(rotation_nintey_inverse, rotation_Znintey)).Using<quaternion>(EqualityWithTolerance));
-            Assert.That(TransformUtil.ConvertWorldToLocalRotation(worldToLocal_nintey, rotation_fortyFive), Is.EqualTo(math.mul(rotation_nintey_inverse, rotation_fortyFive)).Using<quaternion>(EqualityWithTolerance));
-            Assert.That(TransformUtil.ConvertWorldToLocalRotation(worldToLocal_nintey, rotation_ZfortyFive), Is.EqualTo(math.mul(rotation_nintey_inverse, rotation_ZfortyFive)).Using<quaternion>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalRotation(worldToLocal_ninety, quaternion.identity), Is.EqualTo(math.mul(rotation_ninety_inverse, quaternion.identity)).Using<quaternion>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalRotation(worldToLocal_ninety, rotation_ninety), Is.EqualTo(math.mul(rotation_ninety_inverse, rotation_ninety)).Using<quaternion>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalRotation(worldToLocal_ninety, rotation_Zninety), Is.EqualTo(math.mul(rotation_ninety_inverse, rotation_Zninety)).Using<quaternion>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalRotation(worldToLocal_ninety, rotation_fortyFive), Is.EqualTo(math.mul(rotation_ninety_inverse, rotation_fortyFive)).Using<quaternion>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalRotation(worldToLocal_ninety, rotation_ZfortyFive), Is.EqualTo(math.mul(rotation_ninety_inverse, rotation_ZfortyFive)).Using<quaternion>(EqualityWithTolerance));
 
 
             LocalToWorld localToWorld_fortyFive = new LocalToWorld()
@@ -931,34 +937,34 @@ namespace Anvil.Unity.DOTS.Tests.Entities.Transform
             };
             float4x4 worldToLocal_fortyFive = math.inverse(localToWorld_fortyFive.Value);
             Assert.That(TransformUtil.ConvertWorldToLocalRotation(localToWorld_fortyFive, quaternion.identity), Is.EqualTo(math.mul(rotation_fortyFive_inverse, quaternion.identity)).Using<quaternion>(EqualityWithTolerance));
-            Assert.That(TransformUtil.ConvertWorldToLocalRotation(localToWorld_fortyFive, rotation_nintey), Is.EqualTo(math.mul(rotation_fortyFive_inverse, rotation_nintey)).Using<quaternion>(EqualityWithTolerance));
-            Assert.That(TransformUtil.ConvertWorldToLocalRotation(localToWorld_fortyFive, rotation_Znintey), Is.EqualTo(math.mul(rotation_fortyFive_inverse, rotation_Znintey)).Using<quaternion>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalRotation(localToWorld_fortyFive, rotation_ninety), Is.EqualTo(math.mul(rotation_fortyFive_inverse, rotation_ninety)).Using<quaternion>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalRotation(localToWorld_fortyFive, rotation_Zninety), Is.EqualTo(math.mul(rotation_fortyFive_inverse, rotation_Zninety)).Using<quaternion>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertWorldToLocalRotation(localToWorld_fortyFive, rotation_fortyFive), Is.EqualTo(math.mul(rotation_fortyFive_inverse, rotation_fortyFive)).Using<quaternion>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertWorldToLocalRotation(localToWorld_fortyFive, rotation_ZfortyFive), Is.EqualTo(math.mul(rotation_fortyFive_inverse, rotation_ZfortyFive)).Using<quaternion>(EqualityWithTolerance));
 
             Assert.That(TransformUtil.ConvertWorldToLocalRotation(worldToLocal_fortyFive, quaternion.identity), Is.EqualTo(math.mul(rotation_fortyFive_inverse, quaternion.identity)).Using<quaternion>(EqualityWithTolerance));
-            Assert.That(TransformUtil.ConvertWorldToLocalRotation(worldToLocal_fortyFive, rotation_nintey), Is.EqualTo(math.mul(rotation_fortyFive_inverse, rotation_nintey)).Using<quaternion>(EqualityWithTolerance));
-            Assert.That(TransformUtil.ConvertWorldToLocalRotation(worldToLocal_fortyFive, rotation_Znintey), Is.EqualTo(math.mul(rotation_fortyFive_inverse, rotation_Znintey)).Using<quaternion>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalRotation(worldToLocal_fortyFive, rotation_ninety), Is.EqualTo(math.mul(rotation_fortyFive_inverse, rotation_ninety)).Using<quaternion>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalRotation(worldToLocal_fortyFive, rotation_Zninety), Is.EqualTo(math.mul(rotation_fortyFive_inverse, rotation_Zninety)).Using<quaternion>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertWorldToLocalRotation(worldToLocal_fortyFive, rotation_fortyFive), Is.EqualTo(math.mul(rotation_fortyFive_inverse, rotation_fortyFive)).Using<quaternion>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertWorldToLocalRotation(worldToLocal_fortyFive, rotation_ZfortyFive), Is.EqualTo(math.mul(rotation_fortyFive_inverse, rotation_ZfortyFive)).Using<quaternion>(EqualityWithTolerance));
 
 
-            LocalToWorld localToWorld_Znintey = new LocalToWorld()
+            LocalToWorld localToWorld_Zninety = new LocalToWorld()
             {
-                Value = float4x4.TRS(point_zero, rotation_Znintey, point_one)
+                Value = float4x4.TRS(point_zero, rotation_Zninety, point_one)
             };
-            float4x4 worldToLocal_Znintey = math.inverse(localToWorld_Znintey.Value);
-            Assert.That(TransformUtil.ConvertWorldToLocalRotation(localToWorld_Znintey, quaternion.identity), Is.EqualTo(math.mul(rotation_Znintey_inverse, quaternion.identity)).Using<quaternion>(EqualityWithTolerance));
-            Assert.That(TransformUtil.ConvertWorldToLocalRotation(localToWorld_Znintey, rotation_nintey), Is.EqualTo(math.mul(rotation_Znintey_inverse, rotation_nintey)).Using<quaternion>(EqualityWithTolerance));
-            Assert.That(TransformUtil.ConvertWorldToLocalRotation(localToWorld_Znintey, rotation_Znintey), Is.EqualTo(math.mul(rotation_Znintey_inverse, rotation_Znintey)).Using<quaternion>(EqualityWithTolerance));
-            Assert.That(TransformUtil.ConvertWorldToLocalRotation(localToWorld_Znintey, rotation_fortyFive), Is.EqualTo(math.mul(rotation_Znintey_inverse, rotation_fortyFive)).Using<quaternion>(EqualityWithTolerance));
-            Assert.That(TransformUtil.ConvertWorldToLocalRotation(localToWorld_Znintey, rotation_ZfortyFive), Is.EqualTo(math.mul(rotation_Znintey_inverse, rotation_ZfortyFive)).Using<quaternion>(EqualityWithTolerance));
+            float4x4 worldToLocal_Zninety = math.inverse(localToWorld_Zninety.Value);
+            Assert.That(TransformUtil.ConvertWorldToLocalRotation(localToWorld_Zninety, quaternion.identity), Is.EqualTo(math.mul(rotation_Zninety_inverse, quaternion.identity)).Using<quaternion>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalRotation(localToWorld_Zninety, rotation_ninety), Is.EqualTo(math.mul(rotation_Zninety_inverse, rotation_ninety)).Using<quaternion>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalRotation(localToWorld_Zninety, rotation_Zninety), Is.EqualTo(math.mul(rotation_Zninety_inverse, rotation_Zninety)).Using<quaternion>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalRotation(localToWorld_Zninety, rotation_fortyFive), Is.EqualTo(math.mul(rotation_Zninety_inverse, rotation_fortyFive)).Using<quaternion>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalRotation(localToWorld_Zninety, rotation_ZfortyFive), Is.EqualTo(math.mul(rotation_Zninety_inverse, rotation_ZfortyFive)).Using<quaternion>(EqualityWithTolerance));
 
-            Assert.That(TransformUtil.ConvertWorldToLocalRotation(worldToLocal_Znintey, quaternion.identity), Is.EqualTo(math.mul(rotation_Znintey_inverse, quaternion.identity)).Using<quaternion>(EqualityWithTolerance));
-            Assert.That(TransformUtil.ConvertWorldToLocalRotation(worldToLocal_Znintey, rotation_nintey), Is.EqualTo(math.mul(rotation_Znintey_inverse, rotation_nintey)).Using<quaternion>(EqualityWithTolerance));
-            Assert.That(TransformUtil.ConvertWorldToLocalRotation(worldToLocal_Znintey, rotation_Znintey), Is.EqualTo(math.mul(rotation_Znintey_inverse, rotation_Znintey)).Using<quaternion>(EqualityWithTolerance));
-            Assert.That(TransformUtil.ConvertWorldToLocalRotation(worldToLocal_Znintey, rotation_fortyFive), Is.EqualTo(math.mul(rotation_Znintey_inverse, rotation_fortyFive)).Using<quaternion>(EqualityWithTolerance));
-            Assert.That(TransformUtil.ConvertWorldToLocalRotation(worldToLocal_Znintey, rotation_ZfortyFive), Is.EqualTo(math.mul(rotation_Znintey_inverse, rotation_ZfortyFive)).Using<quaternion>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalRotation(worldToLocal_Zninety, quaternion.identity), Is.EqualTo(math.mul(rotation_Zninety_inverse, quaternion.identity)).Using<quaternion>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalRotation(worldToLocal_Zninety, rotation_ninety), Is.EqualTo(math.mul(rotation_Zninety_inverse, rotation_ninety)).Using<quaternion>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalRotation(worldToLocal_Zninety, rotation_Zninety), Is.EqualTo(math.mul(rotation_Zninety_inverse, rotation_Zninety)).Using<quaternion>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalRotation(worldToLocal_Zninety, rotation_fortyFive), Is.EqualTo(math.mul(rotation_Zninety_inverse, rotation_fortyFive)).Using<quaternion>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalRotation(worldToLocal_Zninety, rotation_ZfortyFive), Is.EqualTo(math.mul(rotation_Zninety_inverse, rotation_ZfortyFive)).Using<quaternion>(EqualityWithTolerance));
 
 
             LocalToWorld localToWorld_ZfortyFive = new LocalToWorld()
@@ -967,14 +973,14 @@ namespace Anvil.Unity.DOTS.Tests.Entities.Transform
             };
             float4x4 worldToLocal_ZfortyFive = math.inverse(localToWorld_ZfortyFive.Value);
             Assert.That(TransformUtil.ConvertWorldToLocalRotation(localToWorld_ZfortyFive, quaternion.identity), Is.EqualTo(math.mul(rotation_ZfortyFive_inverse, quaternion.identity)).Using<quaternion>(EqualityWithTolerance));
-            Assert.That(TransformUtil.ConvertWorldToLocalRotation(localToWorld_ZfortyFive, rotation_nintey), Is.EqualTo(math.mul(rotation_ZfortyFive_inverse, rotation_nintey)).Using<quaternion>(EqualityWithTolerance));
-            Assert.That(TransformUtil.ConvertWorldToLocalRotation(localToWorld_ZfortyFive, rotation_Znintey), Is.EqualTo(math.mul(rotation_ZfortyFive_inverse, rotation_Znintey)).Using<quaternion>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalRotation(localToWorld_ZfortyFive, rotation_ninety), Is.EqualTo(math.mul(rotation_ZfortyFive_inverse, rotation_ninety)).Using<quaternion>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalRotation(localToWorld_ZfortyFive, rotation_Zninety), Is.EqualTo(math.mul(rotation_ZfortyFive_inverse, rotation_Zninety)).Using<quaternion>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertWorldToLocalRotation(localToWorld_ZfortyFive, rotation_fortyFive), Is.EqualTo(math.mul(rotation_ZfortyFive_inverse, rotation_fortyFive)).Using<quaternion>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertWorldToLocalRotation(localToWorld_ZfortyFive, rotation_ZfortyFive), Is.EqualTo(math.mul(rotation_ZfortyFive_inverse, rotation_ZfortyFive)).Using<quaternion>(EqualityWithTolerance));
 
             Assert.That(TransformUtil.ConvertWorldToLocalRotation(worldToLocal_ZfortyFive, quaternion.identity), Is.EqualTo(math.mul(rotation_ZfortyFive_inverse, quaternion.identity)).Using<quaternion>(EqualityWithTolerance));
-            Assert.That(TransformUtil.ConvertWorldToLocalRotation(worldToLocal_ZfortyFive, rotation_nintey), Is.EqualTo(math.mul(rotation_ZfortyFive_inverse, rotation_nintey)).Using<quaternion>(EqualityWithTolerance));
-            Assert.That(TransformUtil.ConvertWorldToLocalRotation(worldToLocal_ZfortyFive, rotation_Znintey), Is.EqualTo(math.mul(rotation_ZfortyFive_inverse, rotation_Znintey)).Using<quaternion>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalRotation(worldToLocal_ZfortyFive, rotation_ninety), Is.EqualTo(math.mul(rotation_ZfortyFive_inverse, rotation_ninety)).Using<quaternion>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalRotation(worldToLocal_ZfortyFive, rotation_Zninety), Is.EqualTo(math.mul(rotation_ZfortyFive_inverse, rotation_Zninety)).Using<quaternion>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertWorldToLocalRotation(worldToLocal_ZfortyFive, rotation_fortyFive), Is.EqualTo(math.mul(rotation_ZfortyFive_inverse, rotation_fortyFive)).Using<quaternion>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertWorldToLocalRotation(worldToLocal_ZfortyFive, rotation_ZfortyFive), Is.EqualTo(math.mul(rotation_ZfortyFive_inverse, rotation_ZfortyFive)).Using<quaternion>(EqualityWithTolerance));
         }
@@ -988,9 +994,9 @@ namespace Anvil.Unity.DOTS.Tests.Entities.Transform
             float3 point_one = new float3(1f, 1f, 1f);
             float3 point_sevenXY = new float3(7f, 7f, 0f);
             quaternion rotation_fortyFive = quaternion.Euler(math.radians(45f), math.radians(45f), math.radians(45f));
-            quaternion rotation_nintey = quaternion.Euler(math.radians(90f), math.radians(90f), math.radians(90f));
+            quaternion rotation_ninety = quaternion.Euler(math.radians(90f), math.radians(90f), math.radians(90f));
             quaternion rotation_ZfortyFive = quaternion.Euler(0f, 0f, math.radians(45f));
-            quaternion rotation_Znintey = quaternion.Euler(0f, 0f, math.radians(90f));
+            quaternion rotation_Zninety = quaternion.Euler(0f, 0f, math.radians(90f));
 
             quaternion rotation_XZ_fortyFive = quaternion.Euler(math.radians(45), 0, math.radians(45));
             quaternion rotation_XZ_fortyFive_inverse = math.inverse(rotation_XZ_fortyFive);
@@ -1009,12 +1015,12 @@ namespace Anvil.Unity.DOTS.Tests.Entities.Transform
                 Is.EqualTo(math.mul(rotation_XZ_fortyFive_inverse, quaternion.identity)).Using<quaternion>(EqualityWithTolerance)
                 );
             Assert.That(
-                TransformUtil.ConvertWorldToLocalRotation(localToWorld_compound, rotation_nintey),
-                Is.EqualTo(math.mul(rotation_XZ_fortyFive_inverse, rotation_nintey)).Using<quaternion>(EqualityWithTolerance)
+                TransformUtil.ConvertWorldToLocalRotation(localToWorld_compound, rotation_ninety),
+                Is.EqualTo(math.mul(rotation_XZ_fortyFive_inverse, rotation_ninety)).Using<quaternion>(EqualityWithTolerance)
                 );
             Assert.That(
-                TransformUtil.ConvertWorldToLocalRotation(localToWorld_compound, rotation_Znintey),
-                Is.EqualTo(math.mul(rotation_XZ_fortyFive_inverse, rotation_Znintey)).Using<quaternion>(EqualityWithTolerance)
+                TransformUtil.ConvertWorldToLocalRotation(localToWorld_compound, rotation_Zninety),
+                Is.EqualTo(math.mul(rotation_XZ_fortyFive_inverse, rotation_Zninety)).Using<quaternion>(EqualityWithTolerance)
                 );
             Assert.That(
                 TransformUtil.ConvertWorldToLocalRotation(localToWorld_compound, rotation_fortyFive),
@@ -1030,12 +1036,12 @@ namespace Anvil.Unity.DOTS.Tests.Entities.Transform
                 Is.EqualTo(math.mul(rotation_XZ_fortyFive_inverse, quaternion.identity)).Using<quaternion>(EqualityWithTolerance)
                 );
             Assert.That(
-                TransformUtil.ConvertWorldToLocalRotation(worldToLocal_compound, rotation_nintey),
-                Is.EqualTo(math.mul(rotation_XZ_fortyFive_inverse, rotation_nintey)).Using<quaternion>(EqualityWithTolerance)
+                TransformUtil.ConvertWorldToLocalRotation(worldToLocal_compound, rotation_ninety),
+                Is.EqualTo(math.mul(rotation_XZ_fortyFive_inverse, rotation_ninety)).Using<quaternion>(EqualityWithTolerance)
                 );
             Assert.That(
-                TransformUtil.ConvertWorldToLocalRotation(worldToLocal_compound, rotation_Znintey),
-                Is.EqualTo(math.mul(rotation_XZ_fortyFive_inverse, rotation_Znintey)).Using<quaternion>(EqualityWithTolerance)
+                TransformUtil.ConvertWorldToLocalRotation(worldToLocal_compound, rotation_Zninety),
+                Is.EqualTo(math.mul(rotation_XZ_fortyFive_inverse, rotation_Zninety)).Using<quaternion>(EqualityWithTolerance)
                 );
             Assert.That(
                 TransformUtil.ConvertWorldToLocalRotation(worldToLocal_compound, rotation_fortyFive),
@@ -1059,12 +1065,12 @@ namespace Anvil.Unity.DOTS.Tests.Entities.Transform
                 Is.EqualTo(math.mul((float3x3)worldToLocal_compound_negativeZ, new float3x3(quaternion.identity))).Using<float3x3>(EqualityWithTolerance)
                 );
             Assert.That(
-                math.mul(new float3x3(TransformUtil.ConvertWorldToLocalRotation(localToWorld_compound_negativeZ, rotation_nintey)), worldToLocal_compound_negativeZScale),
-                Is.EqualTo(math.mul((float3x3)worldToLocal_compound_negativeZ, new float3x3(rotation_nintey))).Using<float3x3>(EqualityWithTolerance)
+                math.mul(new float3x3(TransformUtil.ConvertWorldToLocalRotation(localToWorld_compound_negativeZ, rotation_ninety)), worldToLocal_compound_negativeZScale),
+                Is.EqualTo(math.mul((float3x3)worldToLocal_compound_negativeZ, new float3x3(rotation_ninety))).Using<float3x3>(EqualityWithTolerance)
             );
             Assert.That(
-                math.mul(new float3x3(TransformUtil.ConvertWorldToLocalRotation(localToWorld_compound_negativeZ, rotation_Znintey)), worldToLocal_compound_negativeZScale),
-                Is.EqualTo(math.mul((float3x3)worldToLocal_compound_negativeZ, new float3x3(rotation_Znintey))).Using<float3x3>(EqualityWithTolerance)
+                math.mul(new float3x3(TransformUtil.ConvertWorldToLocalRotation(localToWorld_compound_negativeZ, rotation_Zninety)), worldToLocal_compound_negativeZScale),
+                Is.EqualTo(math.mul((float3x3)worldToLocal_compound_negativeZ, new float3x3(rotation_Zninety))).Using<float3x3>(EqualityWithTolerance)
             );
             Assert.That(
                 math.mul(new float3x3(TransformUtil.ConvertWorldToLocalRotation(localToWorld_compound_negativeZ, rotation_fortyFive)), worldToLocal_compound_negativeZScale),
@@ -1080,12 +1086,12 @@ namespace Anvil.Unity.DOTS.Tests.Entities.Transform
                 Is.EqualTo(math.mul((float3x3)worldToLocal_compound_negativeZ, new float3x3(quaternion.identity))).Using<float3x3>(EqualityWithTolerance)
             );
             Assert.That(
-                math.mul(new float3x3(TransformUtil.ConvertWorldToLocalRotation(worldToLocal_compound_negativeZ, rotation_nintey)), worldToLocal_compound_negativeZScale),
-                Is.EqualTo(math.mul((float3x3)worldToLocal_compound_negativeZ, new float3x3(rotation_nintey))).Using<float3x3>(EqualityWithTolerance)
+                math.mul(new float3x3(TransformUtil.ConvertWorldToLocalRotation(worldToLocal_compound_negativeZ, rotation_ninety)), worldToLocal_compound_negativeZScale),
+                Is.EqualTo(math.mul((float3x3)worldToLocal_compound_negativeZ, new float3x3(rotation_ninety))).Using<float3x3>(EqualityWithTolerance)
             );
             Assert.That(
-                math.mul(new float3x3(TransformUtil.ConvertWorldToLocalRotation(worldToLocal_compound_negativeZ, rotation_Znintey)), worldToLocal_compound_negativeZScale),
-                Is.EqualTo(math.mul((float3x3)worldToLocal_compound_negativeZ, new float3x3(rotation_Znintey))).Using<float3x3>(EqualityWithTolerance)
+                math.mul(new float3x3(TransformUtil.ConvertWorldToLocalRotation(worldToLocal_compound_negativeZ, rotation_Zninety)), worldToLocal_compound_negativeZScale),
+                Is.EqualTo(math.mul((float3x3)worldToLocal_compound_negativeZ, new float3x3(rotation_Zninety))).Using<float3x3>(EqualityWithTolerance)
             );
             Assert.That(
                 math.mul(new float3x3(TransformUtil.ConvertWorldToLocalRotation(worldToLocal_compound_negativeZ, rotation_fortyFive)), worldToLocal_compound_negativeZScale),
@@ -1108,9 +1114,9 @@ namespace Anvil.Unity.DOTS.Tests.Entities.Transform
             LogAssert.Expect(LogType.Error, invalidMatrixError_rotate);
             Assert.That(TransformUtil.ConvertWorldToLocalRotation(localToWorld_compound_zeroScale, quaternion.identity), Is.EqualTo(quaternion.identity));
             LogAssert.Expect(LogType.Error, invalidMatrixError_rotate);
-            Assert.That(TransformUtil.ConvertWorldToLocalRotation(localToWorld_compound_zeroScale, rotation_nintey), Is.EqualTo(quaternion.identity));
+            Assert.That(TransformUtil.ConvertWorldToLocalRotation(localToWorld_compound_zeroScale, rotation_ninety), Is.EqualTo(quaternion.identity));
             LogAssert.Expect(LogType.Error, invalidMatrixError_rotate);
-            Assert.That(TransformUtil.ConvertWorldToLocalRotation(localToWorld_compound_zeroScale, rotation_Znintey), Is.EqualTo(quaternion.identity));
+            Assert.That(TransformUtil.ConvertWorldToLocalRotation(localToWorld_compound_zeroScale, rotation_Zninety), Is.EqualTo(quaternion.identity));
             LogAssert.Expect(LogType.Error, invalidMatrixError_rotate);
             Assert.That(TransformUtil.ConvertWorldToLocalRotation(localToWorld_compound_zeroScale, rotation_fortyFive), Is.EqualTo(quaternion.identity));
             LogAssert.Expect(LogType.Error, invalidMatrixError_rotate);
@@ -1119,9 +1125,9 @@ namespace Anvil.Unity.DOTS.Tests.Entities.Transform
             LogAssert.Expect(LogType.Error, invalidMatrixError_rotate);
             Assert.That(TransformUtil.ConvertWorldToLocalRotation(worldToLocal_compound_zeroScale, quaternion.identity), Is.EqualTo(quaternion.identity));
             LogAssert.Expect(LogType.Error, invalidMatrixError_rotate);
-            Assert.That(TransformUtil.ConvertWorldToLocalRotation(worldToLocal_compound_zeroScale, rotation_nintey), Is.EqualTo(quaternion.identity));
+            Assert.That(TransformUtil.ConvertWorldToLocalRotation(worldToLocal_compound_zeroScale, rotation_ninety), Is.EqualTo(quaternion.identity));
             LogAssert.Expect(LogType.Error, invalidMatrixError_rotate);
-            Assert.That(TransformUtil.ConvertWorldToLocalRotation(worldToLocal_compound_zeroScale, rotation_Znintey), Is.EqualTo(quaternion.identity));
+            Assert.That(TransformUtil.ConvertWorldToLocalRotation(worldToLocal_compound_zeroScale, rotation_Zninety), Is.EqualTo(quaternion.identity));
             LogAssert.Expect(LogType.Error, invalidMatrixError_rotate);
             Assert.That(TransformUtil.ConvertWorldToLocalRotation(worldToLocal_compound_zeroScale, rotation_fortyFive), Is.EqualTo(quaternion.identity));
             LogAssert.Expect(LogType.Error, invalidMatrixError_rotate);
@@ -1144,9 +1150,9 @@ namespace Anvil.Unity.DOTS.Tests.Entities.Transform
             TransformUtil.ConvertWorldToLocalRotation(localToWorld_compound_negativeYZ, quaternion.identity);
 
             LogAssert.Expect(LogType.Error, s_NonUniformScaleError);
-            TransformUtil.ConvertWorldToLocalRotation(localToWorld_compound_negativeYZ, rotation_nintey);
+            TransformUtil.ConvertWorldToLocalRotation(localToWorld_compound_negativeYZ, rotation_ninety);
             LogAssert.Expect(LogType.Error, s_NonUniformScaleError);
-            TransformUtil.ConvertWorldToLocalRotation(localToWorld_compound_negativeYZ, rotation_Znintey);
+            TransformUtil.ConvertWorldToLocalRotation(localToWorld_compound_negativeYZ, rotation_Zninety);
             LogAssert.Expect(LogType.Error, s_NonUniformScaleError);
             TransformUtil.ConvertWorldToLocalRotation(localToWorld_compound_negativeYZ, rotation_fortyFive);
             LogAssert.Expect(LogType.Error, s_NonUniformScaleError);
@@ -1155,9 +1161,9 @@ namespace Anvil.Unity.DOTS.Tests.Entities.Transform
             LogAssert.Expect(LogType.Error, s_NonUniformScaleError);
             TransformUtil.ConvertWorldToLocalRotation(worldToLocal_compound_negativeYZ, quaternion.identity);
             LogAssert.Expect(LogType.Error, s_NonUniformScaleError);
-            TransformUtil.ConvertWorldToLocalRotation(worldToLocal_compound_negativeYZ, rotation_nintey);
+            TransformUtil.ConvertWorldToLocalRotation(worldToLocal_compound_negativeYZ, rotation_ninety);
             LogAssert.Expect(LogType.Error, s_NonUniformScaleError);
-            TransformUtil.ConvertWorldToLocalRotation(worldToLocal_compound_negativeYZ, rotation_Znintey);
+            TransformUtil.ConvertWorldToLocalRotation(worldToLocal_compound_negativeYZ, rotation_Zninety);
             LogAssert.Expect(LogType.Error, s_NonUniformScaleError);
             TransformUtil.ConvertWorldToLocalRotation(worldToLocal_compound_negativeYZ, rotation_fortyFive);
             LogAssert.Expect(LogType.Error, s_NonUniformScaleError);
@@ -1173,12 +1179,12 @@ namespace Anvil.Unity.DOTS.Tests.Entities.Transform
             //     Is.EqualTo(math.mul((float3x3)worldToLocal_compound_negativeYZ, new float3x3(quaternion.identity))).Using<float3x3>(EqualityWithTolerance)
             //     );
             // Assert.That(
-            //     math.mul(new float3x3(TransformUtil.ConvertWorldToLocalRotation(localToWorld_compound_negativeYZ, rotation_nintey)), worldToLocal_compound_negativeYZScale),
-            //     Is.EqualTo(math.mul((float3x3)worldToLocal_compound_negativeYZ, new float3x3(rotation_nintey))).Using<float3x3>(EqualityWithTolerance)
+            //     math.mul(new float3x3(TransformUtil.ConvertWorldToLocalRotation(localToWorld_compound_negativeYZ, rotation_ninety)), worldToLocal_compound_negativeYZScale),
+            //     Is.EqualTo(math.mul((float3x3)worldToLocal_compound_negativeYZ, new float3x3(rotation_ninety))).Using<float3x3>(EqualityWithTolerance)
             // );
             // Assert.That(
-            //     math.mul(new float3x3(TransformUtil.ConvertWorldToLocalRotation(localToWorld_compound_negativeYZ, rotation_Znintey)), worldToLocal_compound_negativeYZScale),
-            //     Is.EqualTo(math.mul((float3x3)worldToLocal_compound_negativeYZ, new float3x3(rotation_Znintey))).Using<float3x3>(EqualityWithTolerance)
+            //     math.mul(new float3x3(TransformUtil.ConvertWorldToLocalRotation(localToWorld_compound_negativeYZ, rotation_Zninety)), worldToLocal_compound_negativeYZScale),
+            //     Is.EqualTo(math.mul((float3x3)worldToLocal_compound_negativeYZ, new float3x3(rotation_Zninety))).Using<float3x3>(EqualityWithTolerance)
             // );
             // Assert.That(
             //     math.mul(new float3x3(TransformUtil.ConvertWorldToLocalRotation(localToWorld_compound_negativeYZ, rotation_fortyFive)), worldToLocal_compound_negativeYZScale),
@@ -1194,12 +1200,12 @@ namespace Anvil.Unity.DOTS.Tests.Entities.Transform
             //     Is.EqualTo(math.mul((float3x3)worldToLocal_compound_negativeYZ, new float3x3(quaternion.identity))).Using<float3x3>(EqualityWithTolerance)
             // );
             // Assert.That(
-            //     math.mul(new float3x3(TransformUtil.ConvertWorldToLocalRotation(worldToLocal_compound_negativeYZ, rotation_nintey)), worldToLocal_compound_negativeYZScale),
-            //     Is.EqualTo(math.mul((float3x3)worldToLocal_compound_negativeYZ, new float3x3(rotation_nintey))).Using<float3x3>(EqualityWithTolerance)
+            //     math.mul(new float3x3(TransformUtil.ConvertWorldToLocalRotation(worldToLocal_compound_negativeYZ, rotation_ninety)), worldToLocal_compound_negativeYZScale),
+            //     Is.EqualTo(math.mul((float3x3)worldToLocal_compound_negativeYZ, new float3x3(rotation_ninety))).Using<float3x3>(EqualityWithTolerance)
             // );
             // Assert.That(
-            //     math.mul(new float3x3(TransformUtil.ConvertWorldToLocalRotation(worldToLocal_compound_negativeYZ, rotation_Znintey)), worldToLocal_compound_negativeYZScale),
-            //     Is.EqualTo(math.mul((float3x3)worldToLocal_compound_negativeYZ, new float3x3(rotation_Znintey))).Using<float3x3>(EqualityWithTolerance)
+            //     math.mul(new float3x3(TransformUtil.ConvertWorldToLocalRotation(worldToLocal_compound_negativeYZ, rotation_Zninety)), worldToLocal_compound_negativeYZScale),
+            //     Is.EqualTo(math.mul((float3x3)worldToLocal_compound_negativeYZ, new float3x3(rotation_Zninety))).Using<float3x3>(EqualityWithTolerance)
             // );
             // Assert.That(
             //     math.mul(new float3x3(TransformUtil.ConvertWorldToLocalRotation(worldToLocal_compound_negativeYZ, rotation_fortyFive)), worldToLocal_compound_negativeYZScale),
@@ -1218,26 +1224,26 @@ namespace Anvil.Unity.DOTS.Tests.Entities.Transform
             float3 point_zero = float3.zero;
             float3 point_one = new float3(1f, 1f, 1f);
             quaternion rotation_fortyFive = quaternion.Euler(math.radians(45f), math.radians(45f), math.radians(45f));
-            quaternion rotation_nintey = quaternion.Euler(math.radians(90f), math.radians(90f), math.radians(90f));
+            quaternion rotation_ninety = quaternion.Euler(math.radians(90f), math.radians(90f), math.radians(90f));
             quaternion rotation_ZfortyFive = quaternion.Euler(0f, 0f, math.radians(45f));
-            quaternion rotation_Znintey = quaternion.Euler(0f, 0f, math.radians(90f));
+            quaternion rotation_Zninety = quaternion.Euler(0f, 0f, math.radians(90f));
 
 
-            LocalToWorld localToWorld_nintey = new LocalToWorld()
+            LocalToWorld localToWorld_ninety = new LocalToWorld()
             {
-                Value = float4x4.TRS(point_zero, rotation_nintey, point_one)
+                Value = float4x4.TRS(point_zero, rotation_ninety, point_one)
             };
-            Assert.That(TransformUtil.ConvertLocalToWorldRotation(localToWorld_nintey, quaternion.identity), Is.EqualTo(math.mul(rotation_nintey, quaternion.identity)).Using<quaternion>(EqualityWithTolerance));
-            Assert.That(TransformUtil.ConvertLocalToWorldRotation(localToWorld_nintey, rotation_nintey), Is.EqualTo(math.mul(rotation_nintey, rotation_nintey)).Using<quaternion>(EqualityWithTolerance));
-            Assert.That(TransformUtil.ConvertLocalToWorldRotation(localToWorld_nintey, rotation_Znintey), Is.EqualTo(math.mul(rotation_nintey, rotation_Znintey)).Using<quaternion>(EqualityWithTolerance));
-            Assert.That(TransformUtil.ConvertLocalToWorldRotation(localToWorld_nintey, rotation_fortyFive), Is.EqualTo(math.mul(rotation_nintey, rotation_fortyFive)).Using<quaternion>(EqualityWithTolerance));
-            Assert.That(TransformUtil.ConvertLocalToWorldRotation(localToWorld_nintey, rotation_ZfortyFive), Is.EqualTo(math.mul(rotation_nintey, rotation_ZfortyFive)).Using<quaternion>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldRotation(localToWorld_ninety, quaternion.identity), Is.EqualTo(math.mul(rotation_ninety, quaternion.identity)).Using<quaternion>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldRotation(localToWorld_ninety, rotation_ninety), Is.EqualTo(math.mul(rotation_ninety, rotation_ninety)).Using<quaternion>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldRotation(localToWorld_ninety, rotation_Zninety), Is.EqualTo(math.mul(rotation_ninety, rotation_Zninety)).Using<quaternion>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldRotation(localToWorld_ninety, rotation_fortyFive), Is.EqualTo(math.mul(rotation_ninety, rotation_fortyFive)).Using<quaternion>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldRotation(localToWorld_ninety, rotation_ZfortyFive), Is.EqualTo(math.mul(rotation_ninety, rotation_ZfortyFive)).Using<quaternion>(EqualityWithTolerance));
 
-            Assert.That(TransformUtil.ConvertLocalToWorldRotation(localToWorld_nintey.Value, quaternion.identity), Is.EqualTo(math.mul(rotation_nintey, quaternion.identity)).Using<quaternion>(EqualityWithTolerance));
-            Assert.That(TransformUtil.ConvertLocalToWorldRotation(localToWorld_nintey.Value, rotation_nintey), Is.EqualTo(math.mul(rotation_nintey, rotation_nintey)).Using<quaternion>(EqualityWithTolerance));
-            Assert.That(TransformUtil.ConvertLocalToWorldRotation(localToWorld_nintey.Value, rotation_Znintey), Is.EqualTo(math.mul(rotation_nintey, rotation_Znintey)).Using<quaternion>(EqualityWithTolerance));
-            Assert.That(TransformUtil.ConvertLocalToWorldRotation(localToWorld_nintey.Value, rotation_fortyFive), Is.EqualTo(math.mul(rotation_nintey, rotation_fortyFive)).Using<quaternion>(EqualityWithTolerance));
-            Assert.That(TransformUtil.ConvertLocalToWorldRotation(localToWorld_nintey.Value, rotation_ZfortyFive), Is.EqualTo(math.mul(rotation_nintey, rotation_ZfortyFive)).Using<quaternion>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldRotation(localToWorld_ninety.Value, quaternion.identity), Is.EqualTo(math.mul(rotation_ninety, quaternion.identity)).Using<quaternion>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldRotation(localToWorld_ninety.Value, rotation_ninety), Is.EqualTo(math.mul(rotation_ninety, rotation_ninety)).Using<quaternion>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldRotation(localToWorld_ninety.Value, rotation_Zninety), Is.EqualTo(math.mul(rotation_ninety, rotation_Zninety)).Using<quaternion>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldRotation(localToWorld_ninety.Value, rotation_fortyFive), Is.EqualTo(math.mul(rotation_ninety, rotation_fortyFive)).Using<quaternion>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldRotation(localToWorld_ninety.Value, rotation_ZfortyFive), Is.EqualTo(math.mul(rotation_ninety, rotation_ZfortyFive)).Using<quaternion>(EqualityWithTolerance));
 
 
             LocalToWorld localToWorld_fortyFive = new LocalToWorld()
@@ -1245,33 +1251,33 @@ namespace Anvil.Unity.DOTS.Tests.Entities.Transform
                 Value = float4x4.TRS(point_zero, rotation_fortyFive, point_one)
             };
             Assert.That(TransformUtil.ConvertLocalToWorldRotation(localToWorld_fortyFive, quaternion.identity), Is.EqualTo(math.mul(rotation_fortyFive, quaternion.identity)).Using<quaternion>(EqualityWithTolerance));
-            Assert.That(TransformUtil.ConvertLocalToWorldRotation(localToWorld_fortyFive, rotation_nintey), Is.EqualTo(math.mul(rotation_fortyFive, rotation_nintey)).Using<quaternion>(EqualityWithTolerance));
-            Assert.That(TransformUtil.ConvertLocalToWorldRotation(localToWorld_fortyFive, rotation_Znintey), Is.EqualTo(math.mul(rotation_fortyFive, rotation_Znintey)).Using<quaternion>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldRotation(localToWorld_fortyFive, rotation_ninety), Is.EqualTo(math.mul(rotation_fortyFive, rotation_ninety)).Using<quaternion>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldRotation(localToWorld_fortyFive, rotation_Zninety), Is.EqualTo(math.mul(rotation_fortyFive, rotation_Zninety)).Using<quaternion>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertLocalToWorldRotation(localToWorld_fortyFive, rotation_fortyFive), Is.EqualTo(math.mul(rotation_fortyFive, rotation_fortyFive)).Using<quaternion>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertLocalToWorldRotation(localToWorld_fortyFive, rotation_ZfortyFive), Is.EqualTo(math.mul(rotation_fortyFive, rotation_ZfortyFive)).Using<quaternion>(EqualityWithTolerance));
 
             Assert.That(TransformUtil.ConvertLocalToWorldRotation(localToWorld_fortyFive.Value, quaternion.identity), Is.EqualTo(math.mul(rotation_fortyFive, quaternion.identity)).Using<quaternion>(EqualityWithTolerance));
-            Assert.That(TransformUtil.ConvertLocalToWorldRotation(localToWorld_fortyFive.Value, rotation_nintey), Is.EqualTo(math.mul(rotation_fortyFive, rotation_nintey)).Using<quaternion>(EqualityWithTolerance));
-            Assert.That(TransformUtil.ConvertLocalToWorldRotation(localToWorld_fortyFive.Value, rotation_Znintey), Is.EqualTo(math.mul(rotation_fortyFive, rotation_Znintey)).Using<quaternion>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldRotation(localToWorld_fortyFive.Value, rotation_ninety), Is.EqualTo(math.mul(rotation_fortyFive, rotation_ninety)).Using<quaternion>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldRotation(localToWorld_fortyFive.Value, rotation_Zninety), Is.EqualTo(math.mul(rotation_fortyFive, rotation_Zninety)).Using<quaternion>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertLocalToWorldRotation(localToWorld_fortyFive.Value, rotation_fortyFive), Is.EqualTo(math.mul(rotation_fortyFive, rotation_fortyFive)).Using<quaternion>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertLocalToWorldRotation(localToWorld_fortyFive.Value, rotation_ZfortyFive), Is.EqualTo(math.mul(rotation_fortyFive, rotation_ZfortyFive)).Using<quaternion>(EqualityWithTolerance));
 
 
-            LocalToWorld localToWorld_Znintey = new LocalToWorld()
+            LocalToWorld localToWorld_Zninety = new LocalToWorld()
             {
-                Value = float4x4.TRS(point_zero, rotation_Znintey, point_one)
+                Value = float4x4.TRS(point_zero, rotation_Zninety, point_one)
             };
-            Assert.That(TransformUtil.ConvertLocalToWorldRotation(localToWorld_Znintey, quaternion.identity), Is.EqualTo(math.mul(rotation_Znintey, quaternion.identity)).Using<quaternion>(EqualityWithTolerance));
-            Assert.That(TransformUtil.ConvertLocalToWorldRotation(localToWorld_Znintey, rotation_nintey), Is.EqualTo(math.mul(rotation_Znintey, rotation_nintey)).Using<quaternion>(EqualityWithTolerance));
-            Assert.That(TransformUtil.ConvertLocalToWorldRotation(localToWorld_Znintey, rotation_Znintey), Is.EqualTo(math.mul(rotation_Znintey, rotation_Znintey)).Using<quaternion>(EqualityWithTolerance));
-            Assert.That(TransformUtil.ConvertLocalToWorldRotation(localToWorld_Znintey, rotation_fortyFive), Is.EqualTo(math.mul(rotation_Znintey, rotation_fortyFive)).Using<quaternion>(EqualityWithTolerance));
-            Assert.That(TransformUtil.ConvertLocalToWorldRotation(localToWorld_Znintey, rotation_ZfortyFive), Is.EqualTo(math.mul(rotation_Znintey, rotation_ZfortyFive)).Using<quaternion>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldRotation(localToWorld_Zninety, quaternion.identity), Is.EqualTo(math.mul(rotation_Zninety, quaternion.identity)).Using<quaternion>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldRotation(localToWorld_Zninety, rotation_ninety), Is.EqualTo(math.mul(rotation_Zninety, rotation_ninety)).Using<quaternion>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldRotation(localToWorld_Zninety, rotation_Zninety), Is.EqualTo(math.mul(rotation_Zninety, rotation_Zninety)).Using<quaternion>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldRotation(localToWorld_Zninety, rotation_fortyFive), Is.EqualTo(math.mul(rotation_Zninety, rotation_fortyFive)).Using<quaternion>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldRotation(localToWorld_Zninety, rotation_ZfortyFive), Is.EqualTo(math.mul(rotation_Zninety, rotation_ZfortyFive)).Using<quaternion>(EqualityWithTolerance));
 
-            Assert.That(TransformUtil.ConvertLocalToWorldRotation(localToWorld_Znintey.Value, quaternion.identity), Is.EqualTo(math.mul(rotation_Znintey, quaternion.identity)).Using<quaternion>(EqualityWithTolerance));
-            Assert.That(TransformUtil.ConvertLocalToWorldRotation(localToWorld_Znintey.Value, rotation_nintey), Is.EqualTo(math.mul(rotation_Znintey, rotation_nintey)).Using<quaternion>(EqualityWithTolerance));
-            Assert.That(TransformUtil.ConvertLocalToWorldRotation(localToWorld_Znintey.Value, rotation_Znintey), Is.EqualTo(math.mul(rotation_Znintey, rotation_Znintey)).Using<quaternion>(EqualityWithTolerance));
-            Assert.That(TransformUtil.ConvertLocalToWorldRotation(localToWorld_Znintey.Value, rotation_fortyFive), Is.EqualTo(math.mul(rotation_Znintey, rotation_fortyFive)).Using<quaternion>(EqualityWithTolerance));
-            Assert.That(TransformUtil.ConvertLocalToWorldRotation(localToWorld_Znintey.Value, rotation_ZfortyFive), Is.EqualTo(math.mul(rotation_Znintey, rotation_ZfortyFive)).Using<quaternion>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldRotation(localToWorld_Zninety.Value, quaternion.identity), Is.EqualTo(math.mul(rotation_Zninety, quaternion.identity)).Using<quaternion>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldRotation(localToWorld_Zninety.Value, rotation_ninety), Is.EqualTo(math.mul(rotation_Zninety, rotation_ninety)).Using<quaternion>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldRotation(localToWorld_Zninety.Value, rotation_Zninety), Is.EqualTo(math.mul(rotation_Zninety, rotation_Zninety)).Using<quaternion>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldRotation(localToWorld_Zninety.Value, rotation_fortyFive), Is.EqualTo(math.mul(rotation_Zninety, rotation_fortyFive)).Using<quaternion>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldRotation(localToWorld_Zninety.Value, rotation_ZfortyFive), Is.EqualTo(math.mul(rotation_Zninety, rotation_ZfortyFive)).Using<quaternion>(EqualityWithTolerance));
 
 
             LocalToWorld localToWorld_ZfortyFive = new LocalToWorld()
@@ -1279,14 +1285,14 @@ namespace Anvil.Unity.DOTS.Tests.Entities.Transform
                 Value = float4x4.TRS(point_zero, rotation_ZfortyFive, point_one)
             };
             Assert.That(TransformUtil.ConvertLocalToWorldRotation(localToWorld_ZfortyFive, quaternion.identity), Is.EqualTo(math.mul(rotation_ZfortyFive, quaternion.identity)).Using<quaternion>(EqualityWithTolerance));
-            Assert.That(TransformUtil.ConvertLocalToWorldRotation(localToWorld_ZfortyFive, rotation_nintey), Is.EqualTo(math.mul(rotation_ZfortyFive, rotation_nintey)).Using<quaternion>(EqualityWithTolerance));
-            Assert.That(TransformUtil.ConvertLocalToWorldRotation(localToWorld_ZfortyFive, rotation_Znintey), Is.EqualTo(math.mul(rotation_ZfortyFive, rotation_Znintey)).Using<quaternion>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldRotation(localToWorld_ZfortyFive, rotation_ninety), Is.EqualTo(math.mul(rotation_ZfortyFive, rotation_ninety)).Using<quaternion>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldRotation(localToWorld_ZfortyFive, rotation_Zninety), Is.EqualTo(math.mul(rotation_ZfortyFive, rotation_Zninety)).Using<quaternion>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertLocalToWorldRotation(localToWorld_ZfortyFive, rotation_fortyFive), Is.EqualTo(math.mul(rotation_ZfortyFive, rotation_fortyFive)).Using<quaternion>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertLocalToWorldRotation(localToWorld_ZfortyFive, rotation_ZfortyFive), Is.EqualTo(math.mul(rotation_ZfortyFive, rotation_ZfortyFive)).Using<quaternion>(EqualityWithTolerance));
 
             Assert.That(TransformUtil.ConvertLocalToWorldRotation(localToWorld_ZfortyFive.Value, quaternion.identity), Is.EqualTo(math.mul(rotation_ZfortyFive, quaternion.identity)).Using<quaternion>(EqualityWithTolerance));
-            Assert.That(TransformUtil.ConvertLocalToWorldRotation(localToWorld_ZfortyFive.Value, rotation_nintey), Is.EqualTo(math.mul(rotation_ZfortyFive, rotation_nintey)).Using<quaternion>(EqualityWithTolerance));
-            Assert.That(TransformUtil.ConvertLocalToWorldRotation(localToWorld_ZfortyFive.Value, rotation_Znintey), Is.EqualTo(math.mul(rotation_ZfortyFive, rotation_Znintey)).Using<quaternion>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldRotation(localToWorld_ZfortyFive.Value, rotation_ninety), Is.EqualTo(math.mul(rotation_ZfortyFive, rotation_ninety)).Using<quaternion>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldRotation(localToWorld_ZfortyFive.Value, rotation_Zninety), Is.EqualTo(math.mul(rotation_ZfortyFive, rotation_Zninety)).Using<quaternion>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertLocalToWorldRotation(localToWorld_ZfortyFive.Value, rotation_fortyFive), Is.EqualTo(math.mul(rotation_ZfortyFive, rotation_fortyFive)).Using<quaternion>(EqualityWithTolerance));
             Assert.That(TransformUtil.ConvertLocalToWorldRotation(localToWorld_ZfortyFive.Value, rotation_ZfortyFive), Is.EqualTo(math.mul(rotation_ZfortyFive, rotation_ZfortyFive)).Using<quaternion>(EqualityWithTolerance));
         }
@@ -1300,9 +1306,9 @@ namespace Anvil.Unity.DOTS.Tests.Entities.Transform
             float3 point_one = new float3(1f, 1f, 1f);
             float3 point_sevenXY = new float3(7f, 7f, 0f);
             quaternion rotation_fortyFive = quaternion.Euler(math.radians(45f), math.radians(45f), math.radians(45f));
-            quaternion rotation_nintey = quaternion.Euler(math.radians(90f), math.radians(90f), math.radians(90f));
+            quaternion rotation_ninety = quaternion.Euler(math.radians(90f), math.radians(90f), math.radians(90f));
             quaternion rotation_ZfortyFive = quaternion.Euler(0f, 0f, math.radians(45f));
-            quaternion rotation_Znintey = quaternion.Euler(0f, 0f, math.radians(90f));
+            quaternion rotation_Zninety = quaternion.Euler(0f, 0f, math.radians(90f));
 
             quaternion rotation_XZ_fortyFive = quaternion.Euler(math.radians(45), 0, math.radians(45));
             quaternion rotation_XZ_fortyFive_inverse = math.inverse(rotation_XZ_fortyFive);
@@ -1319,12 +1325,12 @@ namespace Anvil.Unity.DOTS.Tests.Entities.Transform
                 Is.EqualTo(math.mul(rotation_XZ_fortyFive, quaternion.identity)).Using<quaternion>(EqualityWithTolerance)
                 );
             Assert.That(
-                TransformUtil.ConvertLocalToWorldRotation(localToWorld_compound, rotation_nintey),
-                Is.EqualTo(math.mul(rotation_XZ_fortyFive, rotation_nintey)).Using<quaternion>(EqualityWithTolerance)
+                TransformUtil.ConvertLocalToWorldRotation(localToWorld_compound, rotation_ninety),
+                Is.EqualTo(math.mul(rotation_XZ_fortyFive, rotation_ninety)).Using<quaternion>(EqualityWithTolerance)
                 );
             Assert.That(
-                TransformUtil.ConvertLocalToWorldRotation(localToWorld_compound, rotation_Znintey),
-                Is.EqualTo(math.mul(rotation_XZ_fortyFive, rotation_Znintey)).Using<quaternion>(EqualityWithTolerance)
+                TransformUtil.ConvertLocalToWorldRotation(localToWorld_compound, rotation_Zninety),
+                Is.EqualTo(math.mul(rotation_XZ_fortyFive, rotation_Zninety)).Using<quaternion>(EqualityWithTolerance)
                 );
             Assert.That(
                 TransformUtil.ConvertLocalToWorldRotation(localToWorld_compound, rotation_fortyFive),
@@ -1340,12 +1346,12 @@ namespace Anvil.Unity.DOTS.Tests.Entities.Transform
                 Is.EqualTo(math.mul(rotation_XZ_fortyFive, quaternion.identity)).Using<quaternion>(EqualityWithTolerance)
                 );
             Assert.That(
-                TransformUtil.ConvertLocalToWorldRotation(localToWorld_compound.Value, rotation_nintey),
-                Is.EqualTo(math.mul(rotation_XZ_fortyFive, rotation_nintey)).Using<quaternion>(EqualityWithTolerance)
+                TransformUtil.ConvertLocalToWorldRotation(localToWorld_compound.Value, rotation_ninety),
+                Is.EqualTo(math.mul(rotation_XZ_fortyFive, rotation_ninety)).Using<quaternion>(EqualityWithTolerance)
                 );
             Assert.That(
-                TransformUtil.ConvertLocalToWorldRotation(localToWorld_compound.Value, rotation_Znintey),
-                Is.EqualTo(math.mul(rotation_XZ_fortyFive, rotation_Znintey)).Using<quaternion>(EqualityWithTolerance)
+                TransformUtil.ConvertLocalToWorldRotation(localToWorld_compound.Value, rotation_Zninety),
+                Is.EqualTo(math.mul(rotation_XZ_fortyFive, rotation_Zninety)).Using<quaternion>(EqualityWithTolerance)
                 );
             Assert.That(
                 TransformUtil.ConvertLocalToWorldRotation(localToWorld_compound.Value, rotation_fortyFive),
@@ -1369,12 +1375,12 @@ namespace Anvil.Unity.DOTS.Tests.Entities.Transform
                 Is.EqualTo(math.mul((float3x3)localToWorldMatrix_compound_negativeZ, new float3x3(quaternion.identity))).Using<float3x3>(EqualityWithTolerance)
                 );
             Assert.That(
-                math.mul(new float3x3(TransformUtil.ConvertLocalToWorldRotation(localToWorld_compound_negativeZ, rotation_nintey)), localToWorld_compound_negativeZScale),
-                Is.EqualTo(math.mul((float3x3)localToWorldMatrix_compound_negativeZ, new float3x3(rotation_nintey))).Using<float3x3>(EqualityWithTolerance)
+                math.mul(new float3x3(TransformUtil.ConvertLocalToWorldRotation(localToWorld_compound_negativeZ, rotation_ninety)), localToWorld_compound_negativeZScale),
+                Is.EqualTo(math.mul((float3x3)localToWorldMatrix_compound_negativeZ, new float3x3(rotation_ninety))).Using<float3x3>(EqualityWithTolerance)
             );
             Assert.That(
-                math.mul(new float3x3(TransformUtil.ConvertLocalToWorldRotation(localToWorld_compound_negativeZ, rotation_Znintey)), localToWorld_compound_negativeZScale),
-                Is.EqualTo(math.mul((float3x3)localToWorldMatrix_compound_negativeZ, new float3x3(rotation_Znintey))).Using<float3x3>(EqualityWithTolerance)
+                math.mul(new float3x3(TransformUtil.ConvertLocalToWorldRotation(localToWorld_compound_negativeZ, rotation_Zninety)), localToWorld_compound_negativeZScale),
+                Is.EqualTo(math.mul((float3x3)localToWorldMatrix_compound_negativeZ, new float3x3(rotation_Zninety))).Using<float3x3>(EqualityWithTolerance)
             );
             Assert.That(
                 math.mul(new float3x3(TransformUtil.ConvertLocalToWorldRotation(localToWorld_compound_negativeZ, rotation_fortyFive)), localToWorld_compound_negativeZScale),
@@ -1390,12 +1396,12 @@ namespace Anvil.Unity.DOTS.Tests.Entities.Transform
                 Is.EqualTo(math.mul((float3x3)localToWorldMatrix_compound_negativeZ, new float3x3(quaternion.identity))).Using<float3x3>(EqualityWithTolerance)
             );
             Assert.That(
-                math.mul(new float3x3(TransformUtil.ConvertLocalToWorldRotation(localToWorldMatrix_compound_negativeZ, rotation_nintey)), localToWorld_compound_negativeZScale),
-                Is.EqualTo(math.mul((float3x3)localToWorldMatrix_compound_negativeZ, new float3x3(rotation_nintey))).Using<float3x3>(EqualityWithTolerance)
+                math.mul(new float3x3(TransformUtil.ConvertLocalToWorldRotation(localToWorldMatrix_compound_negativeZ, rotation_ninety)), localToWorld_compound_negativeZScale),
+                Is.EqualTo(math.mul((float3x3)localToWorldMatrix_compound_negativeZ, new float3x3(rotation_ninety))).Using<float3x3>(EqualityWithTolerance)
             );
             Assert.That(
-                math.mul(new float3x3(TransformUtil.ConvertLocalToWorldRotation(localToWorldMatrix_compound_negativeZ, rotation_Znintey)), localToWorld_compound_negativeZScale),
-                Is.EqualTo(math.mul((float3x3)localToWorldMatrix_compound_negativeZ, new float3x3(rotation_Znintey))).Using<float3x3>(EqualityWithTolerance)
+                math.mul(new float3x3(TransformUtil.ConvertLocalToWorldRotation(localToWorldMatrix_compound_negativeZ, rotation_Zninety)), localToWorld_compound_negativeZScale),
+                Is.EqualTo(math.mul((float3x3)localToWorldMatrix_compound_negativeZ, new float3x3(rotation_Zninety))).Using<float3x3>(EqualityWithTolerance)
             );
             Assert.That(
                 math.mul(new float3x3(TransformUtil.ConvertLocalToWorldRotation(localToWorldMatrix_compound_negativeZ, rotation_fortyFive)), localToWorld_compound_negativeZScale),
@@ -1416,9 +1422,9 @@ namespace Anvil.Unity.DOTS.Tests.Entities.Transform
             LogAssert.Expect(LogType.Error, invalidMatrixError_rotate);
             Assert.That(TransformUtil.ConvertLocalToWorldRotation(localToWorld_compound_zeroScale, quaternion.identity), Is.EqualTo(quaternion.identity));
             LogAssert.Expect(LogType.Error, invalidMatrixError_rotate);
-            Assert.That(TransformUtil.ConvertLocalToWorldRotation(localToWorld_compound_zeroScale, rotation_nintey), Is.EqualTo(quaternion.identity));
+            Assert.That(TransformUtil.ConvertLocalToWorldRotation(localToWorld_compound_zeroScale, rotation_ninety), Is.EqualTo(quaternion.identity));
             LogAssert.Expect(LogType.Error, invalidMatrixError_rotate);
-            Assert.That(TransformUtil.ConvertLocalToWorldRotation(localToWorld_compound_zeroScale, rotation_Znintey), Is.EqualTo(quaternion.identity));
+            Assert.That(TransformUtil.ConvertLocalToWorldRotation(localToWorld_compound_zeroScale, rotation_Zninety), Is.EqualTo(quaternion.identity));
             LogAssert.Expect(LogType.Error, invalidMatrixError_rotate);
             Assert.That(TransformUtil.ConvertLocalToWorldRotation(localToWorld_compound_zeroScale, rotation_fortyFive), Is.EqualTo(quaternion.identity));
             LogAssert.Expect(LogType.Error, invalidMatrixError_rotate);
@@ -1427,9 +1433,9 @@ namespace Anvil.Unity.DOTS.Tests.Entities.Transform
             LogAssert.Expect(LogType.Error, invalidMatrixError_rotate);
             Assert.That(TransformUtil.ConvertLocalToWorldRotation(localToWorld_compound_zeroScale.Value, quaternion.identity), Is.EqualTo(quaternion.identity));
             LogAssert.Expect(LogType.Error, invalidMatrixError_rotate);
-            Assert.That(TransformUtil.ConvertLocalToWorldRotation(localToWorld_compound_zeroScale.Value, rotation_nintey), Is.EqualTo(quaternion.identity));
+            Assert.That(TransformUtil.ConvertLocalToWorldRotation(localToWorld_compound_zeroScale.Value, rotation_ninety), Is.EqualTo(quaternion.identity));
             LogAssert.Expect(LogType.Error, invalidMatrixError_rotate);
-            Assert.That(TransformUtil.ConvertLocalToWorldRotation(localToWorld_compound_zeroScale.Value, rotation_Znintey), Is.EqualTo(quaternion.identity));
+            Assert.That(TransformUtil.ConvertLocalToWorldRotation(localToWorld_compound_zeroScale.Value, rotation_Zninety), Is.EqualTo(quaternion.identity));
             LogAssert.Expect(LogType.Error, invalidMatrixError_rotate);
             Assert.That(TransformUtil.ConvertLocalToWorldRotation(localToWorld_compound_zeroScale.Value, rotation_fortyFive), Is.EqualTo(quaternion.identity));
             LogAssert.Expect(LogType.Error, invalidMatrixError_rotate);
@@ -1450,9 +1456,9 @@ namespace Anvil.Unity.DOTS.Tests.Entities.Transform
             LogAssert.Expect(LogType.Error, s_NonUniformScaleError);
             TransformUtil.ConvertLocalToWorldRotation(localToWorld_compound_negativeYZ, quaternion.identity);
             LogAssert.Expect(LogType.Error, s_NonUniformScaleError);
-            TransformUtil.ConvertLocalToWorldRotation(localToWorld_compound_negativeYZ, rotation_nintey);
+            TransformUtil.ConvertLocalToWorldRotation(localToWorld_compound_negativeYZ, rotation_ninety);
             LogAssert.Expect(LogType.Error, s_NonUniformScaleError);
-            TransformUtil.ConvertLocalToWorldRotation(localToWorld_compound_negativeYZ, rotation_Znintey);
+            TransformUtil.ConvertLocalToWorldRotation(localToWorld_compound_negativeYZ, rotation_Zninety);
             LogAssert.Expect(LogType.Error, s_NonUniformScaleError);
             TransformUtil.ConvertLocalToWorldRotation(localToWorld_compound_negativeYZ, rotation_fortyFive);
             LogAssert.Expect(LogType.Error, s_NonUniformScaleError);
@@ -1461,9 +1467,9 @@ namespace Anvil.Unity.DOTS.Tests.Entities.Transform
             LogAssert.Expect(LogType.Error, s_NonUniformScaleError);
             TransformUtil.ConvertLocalToWorldRotation(localToWorldMatrix_compound_negativeYZ, quaternion.identity);
             LogAssert.Expect(LogType.Error, s_NonUniformScaleError);
-            TransformUtil.ConvertLocalToWorldRotation(localToWorldMatrix_compound_negativeYZ, rotation_nintey);
+            TransformUtil.ConvertLocalToWorldRotation(localToWorldMatrix_compound_negativeYZ, rotation_ninety);
             LogAssert.Expect(LogType.Error, s_NonUniformScaleError);
-            TransformUtil.ConvertLocalToWorldRotation(localToWorldMatrix_compound_negativeYZ, rotation_Znintey);
+            TransformUtil.ConvertLocalToWorldRotation(localToWorldMatrix_compound_negativeYZ, rotation_Zninety);
             LogAssert.Expect(LogType.Error, s_NonUniformScaleError);
             TransformUtil.ConvertLocalToWorldRotation(localToWorldMatrix_compound_negativeYZ, rotation_fortyFive);
             LogAssert.Expect(LogType.Error, s_NonUniformScaleError);
@@ -1479,12 +1485,12 @@ namespace Anvil.Unity.DOTS.Tests.Entities.Transform
             //     Is.EqualTo(math.mul((float3x3)localToWorldMatrix_compound_negativeYZ, new float3x3(quaternion.identity))).Using<float3x3>(EqualityWithTolerance)
             //     );
             // Assert.That(
-            //     math.mul(new float3x3(TransformUtil.ConvertLocalToWorldRotation(localToWorld_compound_negativeYZ, rotation_nintey)), localToWorld_compound_negativeYZScale),
-            //     Is.EqualTo(math.mul((float3x3)localToWorldMatrix_compound_negativeYZ, new float3x3(rotation_nintey))).Using<float3x3>(EqualityWithTolerance)
+            //     math.mul(new float3x3(TransformUtil.ConvertLocalToWorldRotation(localToWorld_compound_negativeYZ, rotation_ninety)), localToWorld_compound_negativeYZScale),
+            //     Is.EqualTo(math.mul((float3x3)localToWorldMatrix_compound_negativeYZ, new float3x3(rotation_ninety))).Using<float3x3>(EqualityWithTolerance)
             // );
             // Assert.That(
-            //     math.mul(new float3x3(TransformUtil.ConvertLocalToWorldRotation(localToWorld_compound_negativeYZ, rotation_Znintey)), localToWorld_compound_negativeYZScale),
-            //     Is.EqualTo(math.mul((float3x3)localToWorldMatrix_compound_negativeYZ, new float3x3(rotation_Znintey))).Using<float3x3>(EqualityWithTolerance)
+            //     math.mul(new float3x3(TransformUtil.ConvertLocalToWorldRotation(localToWorld_compound_negativeYZ, rotation_Zninety)), localToWorld_compound_negativeYZScale),
+            //     Is.EqualTo(math.mul((float3x3)localToWorldMatrix_compound_negativeYZ, new float3x3(rotation_Zninety))).Using<float3x3>(EqualityWithTolerance)
             // );
             // Assert.That(
             //     math.mul(new float3x3(TransformUtil.ConvertLocalToWorldRotation(localToWorld_compound_negativeYZ, rotation_fortyFive)), localToWorld_compound_negativeYZScale),
@@ -1500,12 +1506,12 @@ namespace Anvil.Unity.DOTS.Tests.Entities.Transform
             //     Is.EqualTo(math.mul((float3x3)localToWorldMatrix_compound_negativeYZ, new float3x3(quaternion.identity))).Using<float3x3>(EqualityWithTolerance)
             // );
             // Assert.That(
-            //     math.mul(new float3x3(TransformUtil.ConvertLocalToWorldRotation(localToWorldMatrix_compound_negativeYZ, rotation_nintey)), localToWorld_compound_negativeYZScale),
-            //     Is.EqualTo(math.mul((float3x3)localToWorldMatrix_compound_negativeYZ, new float3x3(rotation_nintey))).Using<float3x3>(EqualityWithTolerance)
+            //     math.mul(new float3x3(TransformUtil.ConvertLocalToWorldRotation(localToWorldMatrix_compound_negativeYZ, rotation_ninety)), localToWorld_compound_negativeYZScale),
+            //     Is.EqualTo(math.mul((float3x3)localToWorldMatrix_compound_negativeYZ, new float3x3(rotation_ninety))).Using<float3x3>(EqualityWithTolerance)
             // );
             // Assert.That(
-            //     math.mul(new float3x3(TransformUtil.ConvertLocalToWorldRotation(localToWorldMatrix_compound_negativeYZ, rotation_Znintey)), localToWorld_compound_negativeYZScale),
-            //     Is.EqualTo(math.mul((float3x3)localToWorldMatrix_compound_negativeYZ, new float3x3(rotation_Znintey))).Using<float3x3>(EqualityWithTolerance)
+            //     math.mul(new float3x3(TransformUtil.ConvertLocalToWorldRotation(localToWorldMatrix_compound_negativeYZ, rotation_Zninety)), localToWorld_compound_negativeYZScale),
+            //     Is.EqualTo(math.mul((float3x3)localToWorldMatrix_compound_negativeYZ, new float3x3(rotation_Zninety))).Using<float3x3>(EqualityWithTolerance)
             // );
             // Assert.That(
             //     math.mul(new float3x3(TransformUtil.ConvertLocalToWorldRotation(localToWorldMatrix_compound_negativeYZ, rotation_fortyFive)), localToWorld_compound_negativeYZScale),
@@ -2284,26 +2290,204 @@ namespace Anvil.Unity.DOTS.Tests.Entities.Transform
                 Is.EqualTo(math.mul((float3x3)localToWorldMatrix_compound_negativeZ, float3x3.Scale(point_zero))).Using<float3x3>(EqualityWithTolerance)
             );
         }
-        
-        // [Test]
-        // public static Rect ConvertWorldToLocalRectTest()
-        // {
-        //     //TODO: #321 - Optimize...
-        //     float4x4 worldToLocalMtx = math.inverse(localToWorld.Value);
-        //
-        //     float3 point1 = (Vector3)worldRect.min;
-        //     float3 point2 = (Vector3)worldRect.max;
-        //     float3 point3 = new float3(point1.x, point2.y, 0);
-        //     float3 point4 = new float3(point2.x, point1.y, 0);
-        //
-        //     return RectUtil.CreateFromPoints(
-        //         ConvertWorldToLocalPoint(worldToLocalMtx, point1).xy,
-        //         ConvertWorldToLocalPoint(worldToLocalMtx, point2).xy,
-        //         ConvertWorldToLocalPoint(worldToLocalMtx, point3).xy,
-        //         ConvertWorldToLocalPoint(worldToLocalMtx, point4).xy
-        //     );
-        // }
-        //
+
+        // ----- ConvertWorldToLocalRect ----- //
+        [Test]
+        public static void ConvertWorldToLocalRectTest_Identity()
+        {
+            float3 point_zero = float3.zero;
+            float3 point_one = new float3(1f);
+            float3 point_seven = new float3(7f);
+
+            Rect rect_zero_zero = Rect.zero;
+
+            Rect rect_zero_one = new Rect(0, 0, 1, 1);
+
+            Rect rect_seven_seven = new Rect(7, 7, 7, 7);
+            Rect rect_seven_negativeSeven = new Rect(7, 7, -7, -7);
+
+            Rect rect_zero_oneSeven = new Rect(0, 0, 1, 7);
+            Rect rect_zero_sevenOne = new Rect(0, 0, 7, 1);
+            Rect rect_zero_negativeOneSeven = new Rect(0, 0, -1, -7);
+            Rect rect_zero_negativeSevenOne = new Rect(0, 0, -7, -1);
+
+            Rect rect_negativeOffset_seven = new Rect(-14, -14, 7, 7);
+            Rect rect_negativeOffset_negativeSeven = new Rect(-14, -14, -7, -7);
+
+            Rect rect_centered_seven = new Rect(-3.5f, -3.5f, 7, 7);
+            Rect rect_centered_negativeSeven = new Rect(-3.5f, -3.5f, -7, -7);
+
+            Rect rect_centered_negativePositiveSeven = new Rect(-3.5f, -3.5f, -7, 7);
+
+
+            LocalToWorld localToWorld_identity = new LocalToWorld()
+            {
+                Value = float4x4.TRS(point_zero, quaternion.identity, point_one)
+            };
+
+            Assert.That(TransformUtil.ConvertWorldToLocalRect(localToWorld_identity, rect_zero_zero), Is.EqualTo(rect_zero_zero).Using<Rect>(EquivalencyWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalRect(localToWorld_identity, rect_zero_one), Is.EqualTo(rect_zero_one).Using<Rect>(EquivalencyWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalRect(localToWorld_identity, rect_seven_seven), Is.EqualTo(rect_seven_seven).Using<Rect>(EquivalencyWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalRect(localToWorld_identity, rect_seven_negativeSeven), Is.EqualTo(rect_seven_negativeSeven).Using<Rect>(EquivalencyWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalRect(localToWorld_identity, rect_zero_oneSeven), Is.EqualTo(rect_zero_oneSeven).Using<Rect>(EquivalencyWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalRect(localToWorld_identity, rect_zero_sevenOne), Is.EqualTo(rect_zero_sevenOne).Using<Rect>(EquivalencyWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalRect(localToWorld_identity, rect_zero_negativeOneSeven), Is.EqualTo(rect_zero_negativeOneSeven).Using<Rect>(EquivalencyWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalRect(localToWorld_identity, rect_zero_negativeSevenOne), Is.EqualTo(rect_zero_negativeSevenOne).Using<Rect>(EquivalencyWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalRect(localToWorld_identity, rect_negativeOffset_seven), Is.EqualTo(rect_negativeOffset_seven).Using<Rect>(EquivalencyWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalRect(localToWorld_identity, rect_negativeOffset_negativeSeven), Is.EqualTo(rect_negativeOffset_negativeSeven).Using<Rect>(EquivalencyWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalRect(localToWorld_identity, rect_centered_seven), Is.EqualTo(rect_centered_seven).Using<Rect>(EquivalencyWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalRect(localToWorld_identity, rect_centered_negativeSeven), Is.EqualTo(rect_centered_negativeSeven).Using<Rect>(EquivalencyWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalRect(localToWorld_identity, rect_centered_negativePositiveSeven), Is.EqualTo(rect_centered_negativePositiveSeven).Using<Rect>(EquivalencyWithTolerance));
+        }
+
+        [Test]
+        public static void ConvertWorldToLocalRectTest_Translate()
+        {
+            float3 point_zero = float3.zero;
+            float3 point_one = new float3(1f);
+            float3 point_seven = new float3(7f);
+
+            Rect rect_zero_zero = Rect.zero;
+
+            Rect rect_zero_one = new Rect(0, 0, 1, 1);
+
+            Rect rect_seven_seven = new Rect(7, 7, 7, 7);
+            Rect rect_seven_negativeSeven = new Rect(7, 7, -7, -7);
+
+            Rect rect_zero_oneSeven = new Rect(0, 0, 1, 7);
+            Rect rect_zero_sevenOne = new Rect(0, 0, 7, 1);
+            Rect rect_zero_negativeOneSeven = new Rect(0, 0, -1, -7);
+            Rect rect_zero_negativeSevenOne = new Rect(0, 0, -7, -1);
+
+            Rect rect_negativeOffset_seven = new Rect(-14, -14, 7, 7);
+            Rect rect_negativeOffset_negativeSeven = new Rect(-14, -14, -7, -7);
+
+            Rect rect_centered_seven = new Rect(-3.5f, -3.5f, 7, 7);
+            Rect rect_centered_negativeSeven = new Rect(-3.5f, -3.5f, -7, -7);
+
+            Rect rect_centered_negativePositiveSeven = new Rect(-3.5f, -3.5f, -7, 7);
+
+
+            LocalToWorld localToWorld_translate = new LocalToWorld()
+            {
+                Value = float4x4.TRS(point_seven, quaternion.identity, point_one)
+            };
+            Vector2 localToWorld_translateTranslation = point_seven.xy;
+
+            Assert.That(
+                TransformUtil.ConvertWorldToLocalRect(localToWorld_translate, rect_zero_zero),
+                Is.EqualTo(new Rect(rect_zero_zero.position - localToWorld_translateTranslation, rect_zero_zero.size)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertWorldToLocalRect(localToWorld_translate, rect_seven_seven),
+                Is.EqualTo(new Rect(rect_seven_seven.position - localToWorld_translateTranslation, rect_seven_seven.size)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertWorldToLocalRect(localToWorld_translate, rect_zero_one),
+                Is.EqualTo(new Rect(rect_zero_one.position - localToWorld_translateTranslation, rect_zero_one.size)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertWorldToLocalRect(localToWorld_translate, rect_seven_negativeSeven),
+                Is.EqualTo(new Rect(rect_seven_negativeSeven.position - localToWorld_translateTranslation, rect_seven_negativeSeven.size)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertWorldToLocalRect(localToWorld_translate, rect_zero_oneSeven),
+                Is.EqualTo(new Rect(rect_zero_oneSeven.position - localToWorld_translateTranslation, rect_zero_oneSeven.size)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertWorldToLocalRect(localToWorld_translate, rect_zero_sevenOne),
+                Is.EqualTo(new Rect(rect_zero_sevenOne.position - localToWorld_translateTranslation, rect_zero_sevenOne.size)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertWorldToLocalRect(localToWorld_translate, rect_zero_negativeOneSeven),
+                Is.EqualTo(new Rect(rect_zero_negativeOneSeven.position - localToWorld_translateTranslation, rect_zero_negativeOneSeven.size)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertWorldToLocalRect(localToWorld_translate, rect_zero_negativeSevenOne),
+                Is.EqualTo(new Rect(rect_zero_negativeSevenOne.position - localToWorld_translateTranslation, rect_zero_negativeSevenOne.size)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertWorldToLocalRect(localToWorld_translate, rect_negativeOffset_seven),
+                Is.EqualTo(new Rect(rect_negativeOffset_seven.position - localToWorld_translateTranslation, rect_negativeOffset_seven.size)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertWorldToLocalRect(localToWorld_translate, rect_negativeOffset_negativeSeven),
+                Is.EqualTo(new Rect(rect_negativeOffset_negativeSeven.position - localToWorld_translateTranslation, rect_negativeOffset_negativeSeven.size)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertWorldToLocalRect(localToWorld_translate, rect_centered_seven),
+                Is.EqualTo(new Rect(rect_centered_seven.position - localToWorld_translateTranslation, rect_centered_seven.size)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertWorldToLocalRect(localToWorld_translate, rect_centered_negativeSeven),
+                Is.EqualTo(new Rect(rect_centered_negativeSeven.position - localToWorld_translateTranslation, rect_centered_negativeSeven.size)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertWorldToLocalRect(localToWorld_translate, rect_centered_negativePositiveSeven),
+                Is.EqualTo(new Rect(rect_centered_negativePositiveSeven.position - localToWorld_translateTranslation, rect_centered_negativePositiveSeven.size)).Using<Rect>(EquivalencyWithTolerance)
+                );
+
+
+            LocalToWorld localToWorld_negativeTranslate = new LocalToWorld()
+            {
+                Value = float4x4.TRS(-point_seven, quaternion.identity, point_one)
+            };
+            Vector2 localToWorld_negativeTranslateTranslation = -point_seven.xy;
+
+            Assert.That(
+                TransformUtil.ConvertWorldToLocalRect(localToWorld_negativeTranslate, rect_zero_zero),
+                Is.EqualTo(new Rect(rect_zero_zero.position - localToWorld_negativeTranslateTranslation, rect_zero_zero.size)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertWorldToLocalRect(localToWorld_negativeTranslate, rect_seven_seven),
+                Is.EqualTo(new Rect(rect_seven_seven.position - localToWorld_negativeTranslateTranslation, rect_seven_seven.size)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertWorldToLocalRect(localToWorld_negativeTranslate, rect_zero_one),
+                Is.EqualTo(new Rect(rect_zero_one.position - localToWorld_negativeTranslateTranslation, rect_zero_one.size)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertWorldToLocalRect(localToWorld_negativeTranslate, rect_seven_negativeSeven),
+                Is.EqualTo(new Rect(rect_seven_negativeSeven.position - localToWorld_negativeTranslateTranslation, rect_seven_negativeSeven.size)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertWorldToLocalRect(localToWorld_negativeTranslate, rect_zero_oneSeven),
+                Is.EqualTo(new Rect(rect_zero_oneSeven.position - localToWorld_negativeTranslateTranslation, rect_zero_oneSeven.size)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertWorldToLocalRect(localToWorld_negativeTranslate, rect_zero_sevenOne),
+                Is.EqualTo(new Rect(rect_zero_sevenOne.position - localToWorld_negativeTranslateTranslation, rect_zero_sevenOne.size)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertWorldToLocalRect(localToWorld_negativeTranslate, rect_zero_negativeOneSeven),
+                Is.EqualTo(new Rect(rect_zero_negativeOneSeven.position - localToWorld_negativeTranslateTranslation, rect_zero_negativeOneSeven.size)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertWorldToLocalRect(localToWorld_negativeTranslate, rect_zero_negativeSevenOne),
+                Is.EqualTo(new Rect(rect_zero_negativeSevenOne.position - localToWorld_negativeTranslateTranslation, rect_zero_negativeSevenOne.size)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertWorldToLocalRect(localToWorld_negativeTranslate, rect_negativeOffset_seven),
+                Is.EqualTo(new Rect(rect_negativeOffset_seven.position - localToWorld_negativeTranslateTranslation, rect_negativeOffset_seven.size)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertWorldToLocalRect(localToWorld_negativeTranslate, rect_negativeOffset_negativeSeven),
+                Is.EqualTo(new Rect(rect_negativeOffset_negativeSeven.position - localToWorld_negativeTranslateTranslation, rect_negativeOffset_negativeSeven.size)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertWorldToLocalRect(localToWorld_negativeTranslate, rect_centered_seven),
+                Is.EqualTo(new Rect(rect_centered_seven.position - localToWorld_negativeTranslateTranslation, rect_centered_seven.size)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertWorldToLocalRect(localToWorld_negativeTranslate, rect_centered_negativeSeven),
+                Is.EqualTo(new Rect(rect_centered_negativeSeven.position - localToWorld_negativeTranslateTranslation, rect_centered_negativeSeven.size)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertWorldToLocalRect(localToWorld_negativeTranslate, rect_centered_negativePositiveSeven),
+                Is.EqualTo(new Rect(rect_centered_negativePositiveSeven.position - localToWorld_negativeTranslateTranslation, rect_centered_negativePositiveSeven.size)).Using<Rect>(EquivalencyWithTolerance)
+                );
+        }
+
         // [Test]
         // public static Rect ConvertLocalToWorldRectTest()
         // {

--- a/Scripts/Editor/Tests/Entities/Transform/TransformUtilTests.cs
+++ b/Scripts/Editor/Tests/Entities/Transform/TransformUtilTests.cs
@@ -49,6 +49,8 @@ namespace Anvil.Unity.DOTS.Tests.Entities.Transform
         [Test]
         public static void ConvertWorldToLocalPointTest_Identity()
         {
+            Assert.That(nameof(ConvertWorldToLocalPointTest_Identity), Does.StartWith(nameof(TransformUtil.ConvertWorldToLocalPoint)));
+
             float3 point_zero = float3.zero;
             float3 point_one = new float3(1, 1, 1);
             float3 point_seven = point_one * 7f;
@@ -76,6 +78,8 @@ namespace Anvil.Unity.DOTS.Tests.Entities.Transform
         [Test]
         public static void ConvertWorldToLocalPointTest_Translate()
         {
+            Assert.That(nameof(ConvertWorldToLocalPointTest_Translate), Does.StartWith(nameof(TransformUtil.ConvertWorldToLocalPoint)));
+
             float3 point_zero = float3.zero;
             float3 point_one = new float3(1, 1, 1);
             float3 point_seven = point_one * 7f;
@@ -195,6 +199,8 @@ namespace Anvil.Unity.DOTS.Tests.Entities.Transform
         [Test]
         public static void ConvertWorldToLocalPointTest_Rotate()
         {
+            Assert.That(nameof(ConvertWorldToLocalPointTest_Rotate), Does.StartWith(nameof(TransformUtil.ConvertWorldToLocalPoint)));
+
             float3 point_zero = float3.zero;
             float3 point_one = new float3(1, 1, 1);
             float3 point_seven = point_one * 7f;
@@ -292,6 +298,8 @@ namespace Anvil.Unity.DOTS.Tests.Entities.Transform
         [Test]
         public static void ConvertWorldToLocalPointTest_Scale()
         {
+            Assert.That(nameof(ConvertWorldToLocalPointTest_Scale), Does.StartWith(nameof(TransformUtil.ConvertWorldToLocalPoint)));
+
             Regex invalidMatrixError_point = new Regex(@"This transform is invalid\. Returning a signed infinite position\.");
 
             float3 point_infinity = new float3(float.PositiveInfinity);
@@ -436,6 +444,8 @@ namespace Anvil.Unity.DOTS.Tests.Entities.Transform
         [Test]
         public static void ConvertWorldToLocalPointTest_Compound()
         {
+            Assert.That(nameof(ConvertWorldToLocalPointTest_Compound), Does.StartWith(nameof(TransformUtil.ConvertWorldToLocalPoint)));
+
             float3 point_zero = float3.zero;
             float3 point_one = new float3(1f, 1f, 1f);
             float3 point_seven = point_one * 7f;
@@ -481,6 +491,8 @@ namespace Anvil.Unity.DOTS.Tests.Entities.Transform
         [Test]
         public static void ConvertLocalToWorldPointTest_Identity()
         {
+            Assert.That(nameof(ConvertLocalToWorldPointTest_Identity), Does.StartWith(nameof(TransformUtil.ConvertLocalToWorldPoint)));
+
             float3 point_zero = float3.zero;
             float3 point_one = new float3(1, 1, 1);
             float3 point_seven = point_one * 7f;
@@ -508,6 +520,8 @@ namespace Anvil.Unity.DOTS.Tests.Entities.Transform
         [Test]
         public static void ConvertLocalToWorldPointTest_Translate()
         {
+            Assert.That(nameof(ConvertLocalToWorldPointTest_Translate), Does.StartWith(nameof(TransformUtil.ConvertLocalToWorldPoint)));
+
             float3 point_zero = float3.zero;
             float3 point_one = new float3(1, 1, 1);
             float3 point_seven = point_one * 7f;
@@ -623,6 +637,8 @@ namespace Anvil.Unity.DOTS.Tests.Entities.Transform
         [Test]
         public static void ConvertLocalToWorldPointTest_Rotate()
         {
+            Assert.That(nameof(ConvertLocalToWorldPointTest_Rotate), Does.StartWith(nameof(TransformUtil.ConvertLocalToWorldPoint)));
+
             float3 point_zero = float3.zero;
             float3 point_one = new float3(1, 1, 1);
             float3 point_seven = point_one * 7f;
@@ -715,6 +731,8 @@ namespace Anvil.Unity.DOTS.Tests.Entities.Transform
         [Test]
         public static void ConvertLocalToWorldPointTest_Scale()
         {
+            Assert.That(nameof(ConvertLocalToWorldPointTest_Scale), Does.StartWith(nameof(TransformUtil.ConvertLocalToWorldPoint)));
+
             Regex invalidMatrixError_point = new Regex(@"This transform is invalid\. Returning a signed infinite position\.");
 
             float3 point_infinity = new float3(float.PositiveInfinity);
@@ -853,6 +871,8 @@ namespace Anvil.Unity.DOTS.Tests.Entities.Transform
         [Test]
         public static void ConvertLocalToWorldPointTest_Compound()
         {
+            Assert.That(nameof(ConvertLocalToWorldPointTest_Compound), Does.StartWith(nameof(TransformUtil.ConvertLocalToWorldPoint)));
+
             float3 point_zero = float3.zero;
             float3 point_one = new float3(1f, 1f, 1f);
             float3 point_seven = point_one * 7f;
@@ -896,6 +916,8 @@ namespace Anvil.Unity.DOTS.Tests.Entities.Transform
         [Test]
         public static void ConvertWorldToLocalRotationTest_Rotate()
         {
+            Assert.That(nameof(ConvertWorldToLocalRotationTest_Rotate), Does.StartWith(nameof(TransformUtil.ConvertWorldToLocalRotation)));
+
             float3 point_zero = float3.zero;
             float3 point_one = new float3(1f, 1f, 1f);
 
@@ -987,6 +1009,8 @@ namespace Anvil.Unity.DOTS.Tests.Entities.Transform
         [Test]
         public static void ConvertWorldToLocalRotationTest_Compound()
         {
+            Assert.That(nameof(ConvertWorldToLocalRotationTest_Compound), Does.StartWith(nameof(TransformUtil.ConvertWorldToLocalRotation)));
+
             Regex invalidMatrixError_rotate = new Regex(@"Transform is not valid\. Returning identity rotation\.");
 
             float3 point_zero = float3.zero;
@@ -1219,6 +1243,8 @@ namespace Anvil.Unity.DOTS.Tests.Entities.Transform
         [Test]
         public static void ConvertLocalToWorldRotationTest_Rotate()
         {
+            Assert.That(nameof(ConvertLocalToWorldRotationTest_Rotate), Does.StartWith(nameof(TransformUtil.ConvertLocalToWorldRotation)));
+
             float3 point_zero = float3.zero;
             float3 point_one = new float3(1f, 1f, 1f);
             quaternion rotation_fortyFive = quaternion.Euler(math.radians(45f), math.radians(45f), math.radians(45f));
@@ -1298,6 +1324,8 @@ namespace Anvil.Unity.DOTS.Tests.Entities.Transform
         [Test]
         public static void ConvertLocalToWorldRotationTest_Compound()
         {
+            Assert.That(nameof(ConvertLocalToWorldRotationTest_Compound), Does.StartWith(nameof(TransformUtil.ConvertLocalToWorldRotation)));
+
             Regex invalidMatrixError_rotate = new Regex(@"Transform is not valid\. Returning identity rotation\.");
 
             float3 point_zero = float3.zero;
@@ -1525,6 +1553,8 @@ namespace Anvil.Unity.DOTS.Tests.Entities.Transform
         [Test]
         public static void ConvertWorldToLocalScaleTest_Scale()
         {
+            Assert.That(nameof(ConvertWorldToLocalScaleTest_Scale), Does.StartWith(nameof(TransformUtil.ConvertWorldToLocalScale)));
+
             Regex invalidMatrixError_scale = new Regex(@"This transform is invalid\. Returning a signed infinite scale\.");
             float3 point_zero = float3.zero;
             float3 point_one = new float3(1f, 1f, 1f);
@@ -1797,6 +1827,8 @@ namespace Anvil.Unity.DOTS.Tests.Entities.Transform
         [Test]
         public static void ConvertWorldToLocalScaleTest_Compound()
         {
+            Assert.That(nameof(ConvertWorldToLocalScaleTest_Compound), Does.StartWith(nameof(TransformUtil.ConvertWorldToLocalScale)));
+
             float3 point_zero = float3.zero;
             float3 point_one = new float3(1f, 1f, 1f);
             float3 point_two = point_one * 2f;
@@ -1910,6 +1942,8 @@ namespace Anvil.Unity.DOTS.Tests.Entities.Transform
         [Test]
         public static void ConvertLocalToWorldScaleTest_Scale()
         {
+            Assert.That(nameof(ConvertLocalToWorldScaleTest_Scale), Does.StartWith(nameof(TransformUtil.ConvertLocalToWorldScale)));
+
             Regex invalidMatrixError_scale = new Regex(@"This transform is invalid\. Returning a signed infinite scale\.");
             float3 point_zero = float3.zero;
             float3 point_one = new float3(1f, 1f, 1f);
@@ -2181,6 +2215,8 @@ namespace Anvil.Unity.DOTS.Tests.Entities.Transform
         [Test]
         public static void ConvertLocalToWorldScaleTest_Compound()
         {
+            Assert.That(nameof(ConvertLocalToWorldScaleTest_Compound), Does.StartWith(nameof(TransformUtil.ConvertLocalToWorldScale)));
+
             float3 point_zero = float3.zero;
             float3 point_one = new float3(1f, 1f, 1f);
             float3 point_two = point_one * 2f;
@@ -2294,6 +2330,8 @@ namespace Anvil.Unity.DOTS.Tests.Entities.Transform
         [Test]
         public static void ConvertWorldToLocalRectTest_Identity()
         {
+            Assert.That(nameof(ConvertWorldToLocalRectTest_Identity), Does.StartWith(nameof(TransformUtil.ConvertWorldToLocalRect)));
+
             float3 point_zero = float3.zero;
             float3 point_one = new float3(1f);
             float3 point_seven = new float3(7f);
@@ -2342,6 +2380,8 @@ namespace Anvil.Unity.DOTS.Tests.Entities.Transform
         [Test]
         public static void ConvertWorldToLocalRectTest_Translate()
         {
+            Assert.That(nameof(ConvertWorldToLocalRectTest_Translate), Does.StartWith(nameof(TransformUtil.ConvertWorldToLocalRect)));
+
             float3 point_zero = float3.zero;
             float3 point_one = new float3(1f);
             float3 point_seven = new float3(7f);
@@ -2490,6 +2530,8 @@ namespace Anvil.Unity.DOTS.Tests.Entities.Transform
         [Test]
         public static void ConvertWorldToLocalRectTest_Rotate()
         {
+            Assert.That(nameof(ConvertWorldToLocalRectTest_Rotate), Does.StartWith(nameof(TransformUtil.ConvertWorldToLocalRect)));
+
             float3 point_zero = float3.zero;
             float3 point_one = new float3(1f);
 
@@ -2758,6 +2800,8 @@ namespace Anvil.Unity.DOTS.Tests.Entities.Transform
         [Test]
         public static void ConvertWorldToLocalRectTest_Scale()
         {
+            Assert.That(nameof(ConvertWorldToLocalRectTest_Scale), Does.StartWith(nameof(TransformUtil.ConvertWorldToLocalRect)));
+
             Regex invalidMatrixError_rect = new Regex(@"This transform is invalid\. Returning infinite min/max rect\.");
 
             float3 point_zero = float3.zero;
@@ -3168,6 +3212,8 @@ namespace Anvil.Unity.DOTS.Tests.Entities.Transform
         [Test]
         public static void ConvertWorldToLocalRectTest_Compound()
         {
+            Assert.That(nameof(ConvertWorldToLocalRectTest_Compound), Does.StartWith(nameof(TransformUtil.ConvertWorldToLocalRect)));
+
             Rect rect_zero_zero = Rect.zero;
 
             Rect rect_zero_one = new Rect(0, 0, 1, 1);
@@ -3315,6 +3361,8 @@ namespace Anvil.Unity.DOTS.Tests.Entities.Transform
         [Test]
         public static void ConvertLocalToWorldRectTest_Identity()
         {
+            Assert.That(nameof(ConvertLocalToWorldRectTest_Identity), Does.StartWith(nameof(TransformUtil.ConvertLocalToWorldRect)));
+
             float3 point_zero = float3.zero;
             float3 point_one = new float3(1f);
             float3 point_seven = new float3(7f);
@@ -3363,6 +3411,8 @@ namespace Anvil.Unity.DOTS.Tests.Entities.Transform
         [Test]
         public static void ConvertLocalToWorldRectTest_Translate()
         {
+            Assert.That(nameof(ConvertLocalToWorldRectTest_Translate), Does.StartWith(nameof(TransformUtil.ConvertLocalToWorldRect)));
+
             float3 point_zero = float3.zero;
             float3 point_one = new float3(1f);
             float3 point_seven = new float3(7f);
@@ -3511,6 +3561,8 @@ namespace Anvil.Unity.DOTS.Tests.Entities.Transform
         [Test]
         public static void ConvertLocalToWorldRectTest_Rotate()
         {
+            Assert.That(nameof(ConvertLocalToWorldRectTest_Rotate), Does.StartWith(nameof(TransformUtil.ConvertLocalToWorldRect)));
+
             float3 point_zero = float3.zero;
             float3 point_one = new float3(1f);
 
@@ -3779,6 +3831,8 @@ namespace Anvil.Unity.DOTS.Tests.Entities.Transform
         [Test]
         public static void ConvertLocalToWorldRectTest_Scale()
         {
+            Assert.That(nameof(ConvertLocalToWorldRectTest_Scale), Does.StartWith(nameof(TransformUtil.ConvertLocalToWorldRect)));
+
             Regex invalidMatrixError_rect = new Regex(@"This transform is invalid\. Returning infinite min/max rect\.");
 
             float3 point_zero = float3.zero;
@@ -4189,6 +4243,8 @@ namespace Anvil.Unity.DOTS.Tests.Entities.Transform
         [Test]
         public static void ConvertLocalToWorldRectTest_Compound()
         {
+            Assert.That(nameof(ConvertLocalToWorldRectTest_Compound), Does.StartWith(nameof(TransformUtil.ConvertLocalToWorldRect)));
+
             Rect rect_zero_zero = Rect.zero;
 
             Rect rect_zero_one = new Rect(0, 0, 1, 1);

--- a/Scripts/Editor/Tests/Entities/Transform/TransformUtilTests.cs
+++ b/Scripts/Editor/Tests/Entities/Transform/TransformUtilTests.cs
@@ -1,0 +1,1007 @@
+using Anvil.CSharp.Mathematics;
+using Anvil.Unity.DOTS.Entities.Transform;
+using Anvil.Unity.DOTS.Mathematics;
+using NUnit.Framework;
+using Unity.Mathematics;
+using Unity.Transforms;
+using UnityEngine;
+
+namespace Anvil.Unity.DOTS.Tests.Entities.Transform
+{
+    public static class TransformUtilTests
+    {
+        //TODO: Update to use [DefaultFloatingPointTolerance] when Unity uses NUnit >=3.7 and remove all .Using<float3>(EqualityWithTolerance) uses
+        // https://github.com/nunit/nunit/blob/master/src/NUnitFramework/framework/Attributes/DefaultFloatingPointToleranceAttribute.cs
+        private const float FLOATING_POINT_TOLERANCE = 0.00001f;
+
+        private static int EqualityWithTolerance(float3 a, float3 b)
+        {
+            return math.all(math.abs(a - b) < MathUtil.FLOATING_POINT_EQUALITY_TOLERANCE) ? 0 : 1;
+        }
+        private static int EqualityWithTolerance(float4 a, float4 b)
+        {
+            return math.all(math.abs(a - b) < MathUtil.FLOATING_POINT_EQUALITY_TOLERANCE) ? 0 : 1;
+        }
+        private static int EqualityWithTolerance(quaternion a, quaternion b)
+        {
+            return EqualityWithTolerance(a.value, b.value);
+        }
+
+        // ----- ConvertWorldToLocalPointTest ----- //
+        [Test]
+        public static void ConvertWorldToLocalPointTest_Identity()
+        {
+            float3 point_one = new float3(1, 1, 1);
+            float3 point_seven = point_one * 7f;
+            float3 point_sevenXY = new float3(point_seven.xy, 0);
+
+            LocalToWorld localToWorld_Identity = new LocalToWorld() { Value = float4x4.identity };
+            float4x4 worldToLocal_TranslatedOne = math.inverse(localToWorld_Identity.Value);
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_Identity, float3.zero), Is.EqualTo(float3.zero).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_Identity, point_one), Is.EqualTo(point_one).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_Identity, point_seven), Is.EqualTo(point_seven).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_Identity, point_sevenXY), Is.EqualTo(point_sevenXY).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_Identity, -point_one), Is.EqualTo(-point_one).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_Identity, -point_seven), Is.EqualTo(-point_seven).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_Identity, -point_sevenXY), Is.EqualTo(-point_sevenXY).Using<float3>(EqualityWithTolerance));
+
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_TranslatedOne, float3.zero), Is.EqualTo(float3.zero).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_TranslatedOne, point_one), Is.EqualTo(point_one).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_TranslatedOne, point_seven), Is.EqualTo(point_seven).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_TranslatedOne, point_sevenXY), Is.EqualTo(point_sevenXY).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_TranslatedOne, -point_one), Is.EqualTo(-point_one).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_TranslatedOne, -point_seven), Is.EqualTo(-point_seven).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_TranslatedOne, -point_sevenXY), Is.EqualTo(-point_sevenXY).Using<float3>(EqualityWithTolerance));
+        }
+
+        [Test]
+        public static void ConvertWorldToLocalPointTest_Translate()
+        {
+            float3 point_one = new float3(1, 1, 1);
+            float3 point_seven = point_one * 7f;
+            float3 point_oneXY = new float3(1, 1, 0);
+            float3 point_sevenXY = point_oneXY * 7f;
+
+            LocalToWorld localToWorld_TranslatedOne = new LocalToWorld()
+            {
+                Value = float4x4.TRS(point_one, quaternion.identity, point_one)
+            };
+            float4x4 worldToLocal_TranslatedOne = math.inverse(localToWorld_TranslatedOne.Value);
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_TranslatedOne, float3.zero), Is.EqualTo(-point_one).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_TranslatedOne, point_one), Is.EqualTo(float3.zero).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_TranslatedOne, point_seven), Is.EqualTo(point_seven-point_one).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_TranslatedOne, point_sevenXY), Is.EqualTo(point_sevenXY-point_one).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_TranslatedOne, -point_one), Is.EqualTo(-point_one-point_one).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_TranslatedOne, -point_seven), Is.EqualTo(-point_seven-point_one).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_TranslatedOne, -point_sevenXY), Is.EqualTo(-point_sevenXY-point_one).Using<float3>(EqualityWithTolerance));
+
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_TranslatedOne, float3.zero), Is.EqualTo(-point_one).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_TranslatedOne, point_one), Is.EqualTo(float3.zero).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_TranslatedOne, point_seven), Is.EqualTo(point_seven-point_one).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_TranslatedOne, point_sevenXY), Is.EqualTo(point_sevenXY-point_one).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_TranslatedOne, -point_one), Is.EqualTo(-point_one-point_one).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_TranslatedOne, -point_seven), Is.EqualTo(-point_seven-point_one).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_TranslatedOne, -point_sevenXY), Is.EqualTo(-point_sevenXY-point_one).Using<float3>(EqualityWithTolerance));
+
+
+            LocalToWorld localToWorld_TranslatedNegativeOne = new LocalToWorld()
+            {
+                Value = float4x4.TRS(-point_one, quaternion.identity, point_one)
+            };
+            float4x4 worldToLocal_TranslatedNegativeOne = math.inverse(localToWorld_TranslatedNegativeOne.Value);
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_TranslatedNegativeOne, float3.zero), Is.EqualTo(point_one).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_TranslatedNegativeOne, point_one), Is.EqualTo(point_one+point_one).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_TranslatedNegativeOne, point_seven), Is.EqualTo(point_seven+point_one).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_TranslatedNegativeOne, point_sevenXY), Is.EqualTo(point_sevenXY+point_one).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_TranslatedNegativeOne, -point_one), Is.EqualTo(float3.zero).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_TranslatedNegativeOne, -point_seven), Is.EqualTo(-point_seven+point_one).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_TranslatedNegativeOne, -point_sevenXY), Is.EqualTo(-point_sevenXY+point_one).Using<float3>(EqualityWithTolerance));
+
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_TranslatedNegativeOne, float3.zero), Is.EqualTo(point_one).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_TranslatedNegativeOne, point_one), Is.EqualTo(point_one+point_one).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_TranslatedNegativeOne, point_seven), Is.EqualTo(point_seven+point_one).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_TranslatedNegativeOne, point_sevenXY), Is.EqualTo(point_sevenXY+point_one).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_TranslatedNegativeOne, -point_one), Is.EqualTo(float3.zero).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_TranslatedNegativeOne, -point_seven), Is.EqualTo(-point_seven+point_one).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_TranslatedNegativeOne, -point_sevenXY), Is.EqualTo(-point_sevenXY+point_one).Using<float3>(EqualityWithTolerance));
+
+
+            LocalToWorld localToWorld_TranslatedSeven = new LocalToWorld()
+            {
+                Value = float4x4.TRS(point_seven, quaternion.identity, point_one)
+            };
+            float4x4 worldToLocal_TranslatedSeven = math.inverse(localToWorld_TranslatedSeven.Value);
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_TranslatedSeven, float3.zero), Is.EqualTo(-point_seven).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_TranslatedSeven, point_one), Is.EqualTo(-point_seven+point_one).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_TranslatedSeven, point_seven), Is.EqualTo(float3.zero).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_TranslatedSeven, point_sevenXY), Is.EqualTo(point_sevenXY - point_seven).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_TranslatedSeven, -point_one), Is.EqualTo(-point_seven-point_one).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_TranslatedSeven, -point_seven), Is.EqualTo(-point_seven-point_seven).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_TranslatedSeven, -point_sevenXY), Is.EqualTo(-point_sevenXY-point_seven).Using<float3>(EqualityWithTolerance));
+
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_TranslatedSeven, float3.zero), Is.EqualTo(-point_seven).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_TranslatedSeven, point_one), Is.EqualTo(-point_seven+point_one).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_TranslatedSeven, point_seven), Is.EqualTo(float3.zero).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_TranslatedSeven, point_sevenXY), Is.EqualTo(point_sevenXY - point_seven).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_TranslatedSeven, -point_one), Is.EqualTo(-point_seven-point_one).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_TranslatedSeven, -point_seven), Is.EqualTo(-point_seven-point_seven).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_TranslatedSeven, -point_sevenXY), Is.EqualTo(-point_sevenXY-point_seven).Using<float3>(EqualityWithTolerance));
+
+
+            LocalToWorld localToWorld_TranslatedNegativeSeven = new LocalToWorld()
+            {
+                Value = float4x4.TRS(-point_seven, quaternion.identity, point_one)
+            };
+            float4x4 worldToLocal_TranslatedNegativeSeven = math.inverse(localToWorld_TranslatedNegativeSeven.Value);
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_TranslatedNegativeSeven, float3.zero), Is.EqualTo(point_seven).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_TranslatedNegativeSeven, point_one), Is.EqualTo(point_seven+point_one).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_TranslatedNegativeSeven, point_seven), Is.EqualTo(point_seven+point_seven).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_TranslatedNegativeSeven, point_sevenXY), Is.EqualTo(point_sevenXY+point_seven).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_TranslatedNegativeSeven, -point_one), Is.EqualTo(point_seven-point_one).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_TranslatedNegativeSeven, -point_seven), Is.EqualTo(float3.zero).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_TranslatedNegativeSeven, -point_sevenXY), Is.EqualTo(point_seven-point_sevenXY).Using<float3>(EqualityWithTolerance));
+
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_TranslatedNegativeSeven, float3.zero), Is.EqualTo(point_seven).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_TranslatedNegativeSeven, point_one), Is.EqualTo(point_seven+point_one).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_TranslatedNegativeSeven, point_seven), Is.EqualTo(point_seven+point_seven).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_TranslatedNegativeSeven, point_sevenXY), Is.EqualTo(point_sevenXY+point_seven).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_TranslatedNegativeSeven, -point_one), Is.EqualTo(point_seven-point_one).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_TranslatedNegativeSeven, -point_seven), Is.EqualTo(float3.zero).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_TranslatedNegativeSeven, -point_sevenXY), Is.EqualTo(point_seven-point_sevenXY).Using<float3>(EqualityWithTolerance));
+
+
+            LocalToWorld localToWorld_TranslatedSevenXY = new LocalToWorld()
+            {
+                Value = float4x4.TRS(point_sevenXY, quaternion.identity, point_one)
+            };
+            float4x4 worldToLocal_TranslatedSevenXY = math.inverse(localToWorld_TranslatedSevenXY.Value);
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_TranslatedSevenXY, float3.zero), Is.EqualTo(-point_sevenXY).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_TranslatedSevenXY, point_one), Is.EqualTo(-point_sevenXY+point_one).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_TranslatedSevenXY, point_seven), Is.EqualTo(point_seven-point_sevenXY).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_TranslatedSevenXY, point_sevenXY), Is.EqualTo(float3.zero).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_TranslatedSevenXY, -point_one), Is.EqualTo(-point_sevenXY-point_one).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_TranslatedSevenXY, -point_seven), Is.EqualTo(-point_seven-point_sevenXY).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_TranslatedSevenXY, -point_sevenXY), Is.EqualTo(-point_sevenXY-point_sevenXY).Using<float3>(EqualityWithTolerance));
+
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_TranslatedSevenXY, float3.zero), Is.EqualTo(-point_sevenXY).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_TranslatedSevenXY, point_one), Is.EqualTo(-point_sevenXY+point_one).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_TranslatedSevenXY, point_seven), Is.EqualTo(point_seven-point_sevenXY).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_TranslatedSevenXY, point_sevenXY), Is.EqualTo(float3.zero).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_TranslatedSevenXY, -point_one), Is.EqualTo(-point_sevenXY-point_one).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_TranslatedSevenXY, -point_seven), Is.EqualTo(-point_seven-point_sevenXY).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_TranslatedSevenXY, -point_sevenXY), Is.EqualTo(-point_sevenXY-point_sevenXY).Using<float3>(EqualityWithTolerance));
+        }
+
+        [Test]
+        public static void ConvertWorldToLocalPointTest_Rotate()
+        {
+            float3 point_one = new float3(1, 1, 1);
+            float3 point_seven = point_one * 7f;
+
+            LocalToWorld localToWorld_RotatedZ90 = new LocalToWorld()
+            {
+                Value = float4x4.TRS(float3.zero, quaternion.Euler(0, 0, math.radians(90)), point_one)
+            };
+            float4x4 worldToLocal_RotatedZ90 = math.inverse(localToWorld_RotatedZ90.Value);
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_RotatedZ90, float3.zero), Is.EqualTo(float3.zero).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_RotatedZ90, point_one), Is.EqualTo(new float3(1f, -1f, 1f)).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_RotatedZ90, point_seven), Is.EqualTo(new float3(7f, -7f, 7f)).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_RotatedZ90, -point_one), Is.EqualTo(new float3(-1f, 1f, -1f)).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_RotatedZ90, -point_seven), Is.EqualTo(new float3(-7f, 7f, -7f)).Using<float3>(EqualityWithTolerance));
+
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_RotatedZ90, float3.zero), Is.EqualTo(float3.zero).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_RotatedZ90, point_one), Is.EqualTo(new float3(1f, -1f, 1f)).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_RotatedZ90, point_seven), Is.EqualTo(new float3(7f, -7f, 7f)).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_RotatedZ90, -point_one), Is.EqualTo(new float3(-1f, 1f, -1f)).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_RotatedZ90, -point_seven), Is.EqualTo(new float3(-7f, 7f, -7f)).Using<float3>(EqualityWithTolerance));
+
+
+            LocalToWorld localToWorld_RotatedZNegative90 = new LocalToWorld()
+            {
+                Value = float4x4.TRS(float3.zero, quaternion.Euler(0, 0, math.radians(-90)), point_one)
+            };
+            float4x4 worldToLocal_RotatedNegative90 = math.inverse(localToWorld_RotatedZNegative90.Value);
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_RotatedZNegative90, float3.zero), Is.EqualTo(float3.zero).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_RotatedZNegative90, point_one), Is.EqualTo(new float3(-1f, 1f, 1f)).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_RotatedZNegative90, point_seven), Is.EqualTo(new float3(-7f, 7f, 7f)).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_RotatedZNegative90, -point_one), Is.EqualTo(new float3(1f, -1f, -1f)).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_RotatedZNegative90, -point_seven), Is.EqualTo(new float3(7f, -7f, -7f)).Using<float3>(EqualityWithTolerance));
+
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_RotatedNegative90, float3.zero), Is.EqualTo(float3.zero).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_RotatedNegative90, point_one), Is.EqualTo(new float3(-1f, 1f, 1f)).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_RotatedNegative90, point_seven), Is.EqualTo(new float3(-7f, 7f, 7f)).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_RotatedNegative90, -point_one), Is.EqualTo(new float3(1f, -1f, -1f)).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_RotatedNegative90, -point_seven), Is.EqualTo(new float3(7f, -7f, -7f)).Using<float3>(EqualityWithTolerance));
+
+
+            LocalToWorld localToWorld_RotatedZX90 = new LocalToWorld()
+            {
+                Value = float4x4.TRS(float3.zero, quaternion.Euler(math.radians(90), 0, math.radians(90)), point_one)
+            };
+            float4x4 worldToLocal_RotatedZX90 = math.inverse(localToWorld_RotatedZX90.Value);
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_RotatedZX90, float3.zero), Is.EqualTo(float3.zero).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_RotatedZX90, point_one), Is.EqualTo(new float3(1f, -1f, -1f)).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_RotatedZX90, point_seven), Is.EqualTo(new float3(7f, -7f, -7f)).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_RotatedZX90, -point_one), Is.EqualTo(new float3(-1f, 1f, 1f)).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_RotatedZX90, -point_seven), Is.EqualTo(new float3(-7f, 7f, 7f)).Using<float3>(EqualityWithTolerance));
+
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_RotatedZX90, float3.zero), Is.EqualTo(float3.zero).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_RotatedZX90, point_one), Is.EqualTo(new float3(1f, -1f, -1f)).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_RotatedZX90, point_seven), Is.EqualTo(new float3(7f, -7f, -7f)).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_RotatedZX90, -point_one), Is.EqualTo(new float3(-1f, 1f, 1f)).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_RotatedZX90, -point_seven), Is.EqualTo(new float3(-7f, 7f, 7f)).Using<float3>(EqualityWithTolerance));
+
+
+            LocalToWorld localToWorld_RotatedZXNegative90 = new LocalToWorld()
+            {
+                Value = float4x4.TRS(float3.zero, quaternion.Euler(math.radians(-90), 0, math.radians(-90)), point_one)
+            };
+            float4x4 worldToLocal_RotatedZXNegative90 = math.inverse(localToWorld_RotatedZXNegative90.Value);
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_RotatedZXNegative90, float3.zero), Is.EqualTo(float3.zero));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_RotatedZXNegative90, point_one), Is.EqualTo(point_one).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_RotatedZXNegative90, point_seven), Is.EqualTo(point_seven).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_RotatedZXNegative90, -point_one), Is.EqualTo(-point_one).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_RotatedZXNegative90, -point_seven), Is.EqualTo(-point_seven).Using<float3>(EqualityWithTolerance));
+
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_RotatedZXNegative90, float3.zero), Is.EqualTo(float3.zero).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_RotatedZXNegative90, point_one), Is.EqualTo(point_one).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_RotatedZXNegative90, point_seven), Is.EqualTo(point_seven).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_RotatedZXNegative90, -point_one), Is.EqualTo(-point_one).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_RotatedZXNegative90, -point_seven), Is.EqualTo(-point_seven).Using<float3>(EqualityWithTolerance));
+
+
+            LocalToWorld localToWorld_RotatedZX45 = new LocalToWorld()
+            {
+                Value = float4x4.TRS(float3.zero, quaternion.Euler(math.radians(45), 0, math.radians(45)), point_one)
+            };
+            float4x4 worldToLocal_RotatedZX45 = math.inverse(localToWorld_RotatedZX45.Value);
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_RotatedZX45, float3.zero), Is.EqualTo(float3.zero).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_RotatedZX45, point_one), Is.EqualTo(new float3(1.70710683f,0.292893201f,0f)).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_RotatedZX45, point_seven), Is.EqualTo(new float3(11.9497471f,2.0502522f,0f)).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_RotatedZX45, -point_one), Is.EqualTo(new float3(-1.70710683f,-0.292893201f,0f)).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_RotatedZX45, -point_seven), Is.EqualTo(new float3(-11.9497471f,-2.0502522f,0f)).Using<float3>(EqualityWithTolerance));
+
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_RotatedZX45, float3.zero), Is.EqualTo(float3.zero).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_RotatedZX45, point_one), Is.EqualTo(new float3(1.70710683f,0.292893201f,0f)).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_RotatedZX45, point_seven), Is.EqualTo(new float3(11.9497471f,2.0502522f,0f)).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_RotatedZX45, -point_one), Is.EqualTo(new float3(-1.70710683f,-0.292893201f,0f)).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_RotatedZX45, -point_seven), Is.EqualTo(new float3(-11.9497471f,-2.0502522f,0f)).Using<float3>(EqualityWithTolerance));
+        }
+
+        [Test]
+        public static void ConvertWorldToLocalPointTest_Scale()
+        {
+            float3 point_one = new float3(1, 1, 1);
+            float3 point_seven = point_one * 7f;
+
+            LocalToWorld localToWorld_Scaled2 = new LocalToWorld()
+            {
+                Value = float4x4.TRS(float3.zero, quaternion.identity, point_one*2f)
+            };
+            float4x4 worldToLocal_Scaled2 = math.inverse(localToWorld_Scaled2.Value);
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_Scaled2, float3.zero), Is.EqualTo(float3.zero).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_Scaled2, point_one), Is.EqualTo(point_one/2f).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_Scaled2, point_seven), Is.EqualTo(point_seven/2f).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_Scaled2, -point_one), Is.EqualTo(-point_one/2f).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_Scaled2, -point_seven), Is.EqualTo(-point_seven/2f).Using<float3>(EqualityWithTolerance));
+
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_Scaled2, float3.zero), Is.EqualTo(float3.zero).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_Scaled2, point_one), Is.EqualTo(point_one/2f).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_Scaled2, point_seven), Is.EqualTo(point_seven/2f).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_Scaled2, -point_one), Is.EqualTo(-point_one/2f).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_Scaled2, -point_seven), Is.EqualTo(-point_seven/2f).Using<float3>(EqualityWithTolerance));
+
+
+            LocalToWorld localToWorld_ScaledNegative2 = new LocalToWorld()
+            {
+                Value = float4x4.TRS(float3.zero, quaternion.identity, point_one*-2f)
+            };
+            float4x4 worldToLocal_ScaledNegative2 = math.inverse(localToWorld_ScaledNegative2.Value);
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_ScaledNegative2, float3.zero), Is.EqualTo(float3.zero).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_ScaledNegative2, point_one), Is.EqualTo(-point_one/2f).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_ScaledNegative2, point_seven), Is.EqualTo(-point_seven/2f).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_ScaledNegative2, -point_one), Is.EqualTo(point_one/2f).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_ScaledNegative2, -point_seven), Is.EqualTo(point_seven/2f).Using<float3>(EqualityWithTolerance));
+
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_ScaledNegative2, float3.zero), Is.EqualTo(float3.zero).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_ScaledNegative2, point_one), Is.EqualTo(-point_one/2f).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_ScaledNegative2, point_seven), Is.EqualTo(-point_seven/2f).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_ScaledNegative2, -point_one), Is.EqualTo(point_one/2f).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_ScaledNegative2, -point_seven), Is.EqualTo(point_seven/2f).Using<float3>(EqualityWithTolerance));
+
+
+            float3 scaleZ2 = new float3(point_one.xy, 2f);
+            LocalToWorld localToWorld_ScaledZ2 = new LocalToWorld()
+            {
+                Value = float4x4.TRS(float3.zero, quaternion.identity, scaleZ2)
+            };
+            float4x4 worldToLocal_ScaledZ2 = math.inverse(localToWorld_ScaledZ2.Value);
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_ScaledZ2, float3.zero), Is.EqualTo(float3.zero).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_ScaledZ2, point_one), Is.EqualTo(point_one/scaleZ2).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_ScaledZ2, point_seven), Is.EqualTo(point_seven/scaleZ2).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_ScaledZ2, -point_one), Is.EqualTo(-point_one/scaleZ2).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_ScaledZ2, -point_seven), Is.EqualTo(-point_seven/scaleZ2).Using<float3>(EqualityWithTolerance));
+
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_ScaledZ2, float3.zero), Is.EqualTo(float3.zero).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_ScaledZ2, point_one), Is.EqualTo(point_one/scaleZ2).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_ScaledZ2, point_seven), Is.EqualTo(point_seven/scaleZ2).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_ScaledZ2, -point_one), Is.EqualTo(-point_one/scaleZ2).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_ScaledZ2, -point_seven), Is.EqualTo(-point_seven/scaleZ2).Using<float3>(EqualityWithTolerance));
+
+
+            float3 scaleZNegative2 = new float3(point_one.xy, -2f);
+            LocalToWorld localToWorld_ScaledZNegative2 = new LocalToWorld()
+            {
+                Value = float4x4.TRS(float3.zero, quaternion.identity, scaleZNegative2)
+            };
+            float4x4 worldToLocal_ScaledZNegative2 = math.inverse(localToWorld_ScaledZNegative2.Value);
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_ScaledZNegative2, float3.zero), Is.EqualTo(float3.zero).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_ScaledZNegative2, point_one), Is.EqualTo(point_one/scaleZNegative2).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_ScaledZNegative2, point_seven), Is.EqualTo(point_seven/scaleZNegative2).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_ScaledZNegative2, -point_one), Is.EqualTo(-point_one/scaleZNegative2).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_ScaledZNegative2, -point_seven), Is.EqualTo(-point_seven/scaleZNegative2).Using<float3>(EqualityWithTolerance));
+
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_ScaledZNegative2, float3.zero), Is.EqualTo(float3.zero).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_ScaledZNegative2, point_one), Is.EqualTo(point_one/scaleZNegative2).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_ScaledZNegative2, point_seven), Is.EqualTo(point_seven/scaleZNegative2).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_ScaledZNegative2, -point_one), Is.EqualTo(-point_one/scaleZNegative2).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_ScaledZNegative2, -point_seven), Is.EqualTo(-point_seven/scaleZNegative2).Using<float3>(EqualityWithTolerance));
+
+
+            float3 scaleZXOnePointFive = new float3(1.5f, 1f, 1.5f);
+            LocalToWorld localToWorld_ScaledZXOnePointFive = new LocalToWorld()
+            {
+                Value = float4x4.TRS(float3.zero, quaternion.identity, scaleZXOnePointFive)
+            };
+            float4x4 worldToLocal_ScaledZXOnePointFive = math.inverse(localToWorld_ScaledZXOnePointFive.Value);
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_ScaledZXOnePointFive, float3.zero), Is.EqualTo(float3.zero).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_ScaledZXOnePointFive, point_one), Is.EqualTo(point_one/scaleZXOnePointFive).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_ScaledZXOnePointFive, point_seven), Is.EqualTo(point_seven/scaleZXOnePointFive).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_ScaledZXOnePointFive, -point_one), Is.EqualTo(-point_one/scaleZXOnePointFive).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_ScaledZXOnePointFive, -point_seven), Is.EqualTo(-point_seven/scaleZXOnePointFive).Using<float3>(EqualityWithTolerance));
+
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_ScaledZXOnePointFive, float3.zero), Is.EqualTo(float3.zero).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_ScaledZXOnePointFive, point_one), Is.EqualTo(point_one/scaleZXOnePointFive).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_ScaledZXOnePointFive, point_seven), Is.EqualTo(point_seven/scaleZXOnePointFive).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_ScaledZXOnePointFive, -point_one), Is.EqualTo(-point_one/scaleZXOnePointFive).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_ScaledZXOnePointFive, -point_seven), Is.EqualTo(-point_seven/scaleZXOnePointFive).Using<float3>(EqualityWithTolerance));
+        }
+
+        [Test]
+        public static void ConvertWorldToLocalPointTest_Compound()
+        {
+            float3 point_one = new float3(1f, 1f, 1f);
+            float3 point_seven = point_one * 7f;
+            float3 point_sevenXY = new float3(point_seven.xy, 0f);
+
+            LocalToWorld localToWorld_Compound = new LocalToWorld()
+            {
+                Value = float4x4.TRS(point_sevenXY, quaternion.Euler(math.radians(45), 0, math.radians(45)), point_one*2f)
+            };
+            float4x4 worldToLocal_Compound = math.inverse(localToWorld_Compound.Value);
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_Compound, float3.zero), Is.EqualTo(new float3(-4.22487354f, 0.7248739f, 2.47487402f)).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_Compound, point_one), Is.EqualTo(new float3(-3.37132025f, 0.871320367f, 2.47487402f)).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_Compound, point_seven), Is.EqualTo(new float3(1.75f, 1.75f, 2.47487378f)).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_Compound, -point_one), Is.EqualTo(new float3(-5.07842731f, 0.578427196f, 2.47487402f)).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_Compound, -point_seven), Is.EqualTo(new float3(-10.1997471f, -0.300252199f, 2.4748745f)).Using<float3>(EqualityWithTolerance));
+
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_Compound, float3.zero), Is.EqualTo(new float3(-4.22487354f, 0.7248739f, 2.47487402f)).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_Compound, point_one), Is.EqualTo(new float3(-3.37132025f, 0.871320367f, 2.47487402f)).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_Compound, point_seven), Is.EqualTo(new float3(1.75f, 1.75f, 2.47487378f)).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_Compound, -point_one), Is.EqualTo(new float3(-5.07842731f, 0.578427196f, 2.47487402f)).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_Compound, -point_seven), Is.EqualTo(new float3(-10.1997471f, -0.300252199f, 2.4748745f)).Using<float3>(EqualityWithTolerance));
+
+
+            LocalToWorld localToWorld_CompoundNegative = new LocalToWorld()
+            {
+                Value = float4x4.TRS(-point_sevenXY, quaternion.Euler(math.radians(-45), 0, math.radians(-45)), point_one*-2f)
+            };
+            float4x4 worldToLocal_CompoundNegative = math.inverse(localToWorld_CompoundNegative.Value);
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_CompoundNegative, float3.zero), Is.EqualTo(new float3(-0.724873781f, -4.22487402f, -2.47487402f)).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_CompoundNegative, point_one), Is.EqualTo(new float3(-1.07842731f, -4.57842731f, -3.18198061f)).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_CompoundNegative, point_seven), Is.EqualTo(new float3(-3.19974756f,-6.69974804f,-7.42462158f)).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_CompoundNegative, -point_one), Is.EqualTo(new float3(-0.371320248f, -3.87132072f, -1.76776719f)).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_CompoundNegative, -point_seven), Is.EqualTo(new float3(1.75f, -1.75f, 2.47487378f)).Using<float3>(EqualityWithTolerance));
+
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_CompoundNegative, float3.zero), Is.EqualTo(new float3(-0.724873781f, -4.22487402f, -2.47487402f)).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_CompoundNegative, point_one), Is.EqualTo(new float3(-1.07842731f, -4.57842731f, -3.18198061f)).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_CompoundNegative, point_seven), Is.EqualTo(new float3(-3.19974756f,-6.69974804f,-7.42462158f)).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_CompoundNegative, -point_one), Is.EqualTo(new float3(-0.371320248f, -3.87132072f, -1.76776719f)).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(worldToLocal_CompoundNegative, -point_seven), Is.EqualTo(new float3(1.75f, -1.75f, 2.47487378f)).Using<float3>(EqualityWithTolerance));
+        }
+
+        // ----- ConvertLocalToWorldPointTest ----- //
+        [Test]
+        public static void ConvertLocalToWorldPointTest_Identity()
+        {
+            float3 point_one = new float3(1, 1, 1);
+            float3 point_seven = point_one * 7f;
+            float3 point_oneXY = new float3(1, 1, 0);
+            float3 point_sevenXY = point_oneXY * 7f;
+
+            LocalToWorld localToWorld_Identity = new LocalToWorld() { Value = float4x4.identity };
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_Identity, float3.zero), Is.EqualTo(float3.zero).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_Identity, point_one), Is.EqualTo(point_one).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_Identity, point_seven), Is.EqualTo(point_seven).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_Identity, point_sevenXY), Is.EqualTo(point_sevenXY).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_Identity, -point_one), Is.EqualTo(-point_one).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_Identity, -point_seven), Is.EqualTo(-point_seven).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_Identity, -point_sevenXY), Is.EqualTo(-point_sevenXY).Using<float3>(EqualityWithTolerance));
+
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_Identity.Value, float3.zero), Is.EqualTo(float3.zero).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_Identity.Value, point_one), Is.EqualTo(point_one).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_Identity.Value, point_seven), Is.EqualTo(point_seven).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_Identity.Value, point_sevenXY), Is.EqualTo(point_sevenXY).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_Identity.Value, -point_one), Is.EqualTo(-point_one).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_Identity.Value, -point_seven), Is.EqualTo(-point_seven).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_Identity.Value, -point_sevenXY), Is.EqualTo(-point_sevenXY).Using<float3>(EqualityWithTolerance));
+        }
+
+        [Test]
+        public static void ConvertLocalToWorldPointTest_Translate()
+        {
+            float3 point_one = new float3(1, 1, 1);
+            float3 point_seven = point_one * 7f;
+            float3 point_oneXY = new float3(1, 1, 0);
+            float3 point_sevenXY = point_oneXY * 7f;
+
+
+            LocalToWorld localToWorld_TranslatedOne = new LocalToWorld()
+            {
+                Value = float4x4.TRS(point_one, quaternion.identity, point_one)
+            };
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_TranslatedOne, float3.zero), Is.EqualTo(point_one).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_TranslatedOne, point_one), Is.EqualTo(point_one+point_one).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_TranslatedOne, point_seven), Is.EqualTo(point_seven+point_one).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_TranslatedOne, point_sevenXY), Is.EqualTo(point_sevenXY+point_one).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_TranslatedOne, -point_one), Is.EqualTo(float3.zero).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_TranslatedOne, -point_seven), Is.EqualTo(-point_seven+point_one).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_TranslatedOne, -point_sevenXY), Is.EqualTo(-point_sevenXY+point_one).Using<float3>(EqualityWithTolerance));
+
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_TranslatedOne.Value, float3.zero), Is.EqualTo(point_one).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_TranslatedOne.Value, point_one), Is.EqualTo(point_one+point_one).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_TranslatedOne.Value, point_seven), Is.EqualTo(point_seven+point_one).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_TranslatedOne.Value, point_sevenXY), Is.EqualTo(point_sevenXY+point_one).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_TranslatedOne.Value, -point_one), Is.EqualTo(float3.zero).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_TranslatedOne.Value, -point_seven), Is.EqualTo(-point_seven+point_one).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_TranslatedOne.Value, -point_sevenXY), Is.EqualTo(-point_sevenXY+point_one).Using<float3>(EqualityWithTolerance));
+
+
+            LocalToWorld localToWorld_TranslatedNegativeOne = new LocalToWorld()
+            {
+                Value = float4x4.TRS(-point_one, quaternion.identity, point_one)
+            };
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_TranslatedNegativeOne, float3.zero), Is.EqualTo(-point_one).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_TranslatedNegativeOne, point_one), Is.EqualTo(float3.zero).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_TranslatedNegativeOne, point_seven), Is.EqualTo(point_seven-point_one).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_TranslatedNegativeOne, point_sevenXY), Is.EqualTo(point_sevenXY-point_one).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_TranslatedNegativeOne, -point_one), Is.EqualTo(-point_one-point_one).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_TranslatedNegativeOne, -point_seven), Is.EqualTo(-point_seven-point_one).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_TranslatedNegativeOne, -point_sevenXY), Is.EqualTo(-point_sevenXY-point_one).Using<float3>(EqualityWithTolerance));
+
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_TranslatedNegativeOne.Value, float3.zero), Is.EqualTo(-point_one).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_TranslatedNegativeOne.Value, point_one), Is.EqualTo(float3.zero).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_TranslatedNegativeOne.Value, point_seven), Is.EqualTo(point_seven-point_one).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_TranslatedNegativeOne.Value, point_sevenXY), Is.EqualTo(point_sevenXY-point_one).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_TranslatedNegativeOne.Value, -point_one), Is.EqualTo(-point_one-point_one).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_TranslatedNegativeOne.Value, -point_seven), Is.EqualTo(-point_seven-point_one).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_TranslatedNegativeOne.Value, -point_sevenXY), Is.EqualTo(-point_sevenXY-point_one).Using<float3>(EqualityWithTolerance));
+
+
+            LocalToWorld localToWorld_TranslatedSeven = new LocalToWorld()
+            {
+                Value = float4x4.TRS(point_seven, quaternion.identity, point_one)
+            };
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_TranslatedSeven, float3.zero), Is.EqualTo(point_seven).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_TranslatedSeven, point_one), Is.EqualTo(point_seven+point_one).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_TranslatedSeven, point_seven), Is.EqualTo(point_seven+point_seven).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_TranslatedSeven, point_sevenXY), Is.EqualTo(point_sevenXY+point_seven).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_TranslatedSeven, -point_one), Is.EqualTo(point_seven-point_one).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_TranslatedSeven, -point_seven), Is.EqualTo(float3.zero).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_TranslatedSeven, -point_sevenXY), Is.EqualTo(-point_sevenXY+point_seven).Using<float3>(EqualityWithTolerance));
+
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_TranslatedSeven.Value, float3.zero), Is.EqualTo(point_seven).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_TranslatedSeven.Value, point_one), Is.EqualTo(point_seven+point_one).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_TranslatedSeven.Value, point_seven), Is.EqualTo(point_seven+point_seven).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_TranslatedSeven.Value, point_sevenXY), Is.EqualTo(point_sevenXY+point_seven).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_TranslatedSeven.Value, -point_one), Is.EqualTo(point_seven-point_one).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_TranslatedSeven.Value, -point_seven), Is.EqualTo(float3.zero).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalPoint(localToWorld_TranslatedSeven.Value, -point_sevenXY), Is.EqualTo(-point_sevenXY+point_seven).Using<float3>(EqualityWithTolerance));
+
+
+            LocalToWorld localToWorld_TranslatedNegativeSeven = new LocalToWorld()
+            {
+                Value = float4x4.TRS(-point_seven, quaternion.identity, point_one)
+            };
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_TranslatedNegativeSeven, float3.zero), Is.EqualTo(-point_seven).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_TranslatedNegativeSeven, point_one), Is.EqualTo(-point_seven+point_one).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_TranslatedNegativeSeven, point_seven), Is.EqualTo(float3.zero).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_TranslatedNegativeSeven, point_sevenXY), Is.EqualTo(point_sevenXY-point_seven).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_TranslatedNegativeSeven, -point_one), Is.EqualTo(-point_seven-point_one).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_TranslatedNegativeSeven, -point_seven), Is.EqualTo(-point_seven-point_seven).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_TranslatedNegativeSeven, -point_sevenXY), Is.EqualTo(-point_sevenXY-point_seven).Using<float3>(EqualityWithTolerance));
+
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_TranslatedNegativeSeven.Value, float3.zero), Is.EqualTo(-point_seven).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_TranslatedNegativeSeven.Value, point_one), Is.EqualTo(-point_seven+point_one).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_TranslatedNegativeSeven.Value, point_seven), Is.EqualTo(float3.zero).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_TranslatedNegativeSeven.Value, point_sevenXY), Is.EqualTo(point_sevenXY-point_seven).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_TranslatedNegativeSeven.Value, -point_one), Is.EqualTo(-point_seven-point_one).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_TranslatedNegativeSeven.Value, -point_seven), Is.EqualTo(-point_seven-point_seven).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_TranslatedNegativeSeven.Value, -point_sevenXY), Is.EqualTo(-point_sevenXY-point_seven).Using<float3>(EqualityWithTolerance));
+
+
+            LocalToWorld localToWorld_TranslatedSevenXY = new LocalToWorld()
+            {
+                Value = float4x4.TRS(point_sevenXY, quaternion.identity, point_one)
+            };
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_TranslatedSevenXY, float3.zero), Is.EqualTo(point_sevenXY).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_TranslatedSevenXY, point_one), Is.EqualTo(point_one+point_sevenXY).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_TranslatedSevenXY, point_seven), Is.EqualTo(point_seven+point_sevenXY).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_TranslatedSevenXY, point_sevenXY), Is.EqualTo(point_sevenXY+point_sevenXY).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_TranslatedSevenXY, -point_one), Is.EqualTo(point_sevenXY-point_one).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_TranslatedSevenXY, -point_seven), Is.EqualTo(point_sevenXY-point_seven).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_TranslatedSevenXY, -point_sevenXY), Is.EqualTo(float3.zero).Using<float3>(EqualityWithTolerance));
+
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_TranslatedSevenXY.Value, float3.zero), Is.EqualTo(point_sevenXY).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_TranslatedSevenXY.Value, point_one), Is.EqualTo(point_one+point_sevenXY).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_TranslatedSevenXY.Value, point_seven), Is.EqualTo(point_seven+point_sevenXY).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_TranslatedSevenXY.Value, point_sevenXY), Is.EqualTo(point_sevenXY+point_sevenXY).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_TranslatedSevenXY.Value, -point_one), Is.EqualTo(point_sevenXY-point_one).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_TranslatedSevenXY.Value, -point_seven), Is.EqualTo(point_sevenXY-point_seven).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_TranslatedSevenXY.Value, -point_sevenXY), Is.EqualTo(float3.zero).Using<float3>(EqualityWithTolerance));
+        }
+
+        [Test]
+        public static void ConvertLocalToWorldPointTest_Rotate()
+        {
+            float3 point_one = new float3(1, 1, 1);
+            float3 point_seven = point_one * 7f;
+
+            LocalToWorld localToWorld_RotatedZ90 = new LocalToWorld()
+            {
+                Value = float4x4.TRS(float3.zero, quaternion.Euler(0, 0, math.radians(90)), point_one)
+            };
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_RotatedZ90, float3.zero), Is.EqualTo(float3.zero).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_RotatedZ90, point_one), Is.EqualTo(new float3(-1f, 1f, 1f)).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_RotatedZ90, point_seven), Is.EqualTo(new float3(-7f, 7f, 7f)).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_RotatedZ90, -point_one), Is.EqualTo(new float3(1f, -1f, -1f)).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_RotatedZ90, -point_seven), Is.EqualTo(new float3(7f, -7f, -7f)).Using<float3>(EqualityWithTolerance));
+
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_RotatedZ90.Value, float3.zero), Is.EqualTo(float3.zero).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_RotatedZ90.Value, point_one), Is.EqualTo(new float3(-1f, 1f, 1f)).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_RotatedZ90.Value, point_seven), Is.EqualTo(new float3(-7f, 7f, 7f)).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_RotatedZ90.Value, -point_one), Is.EqualTo(new float3(1f, -1f, -1f)).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_RotatedZ90.Value, -point_seven), Is.EqualTo(new float3(7f, -7f, -7f)).Using<float3>(EqualityWithTolerance));
+
+
+            LocalToWorld localToWorld_RotatedZNegative90 = new LocalToWorld()
+            {
+                Value = float4x4.TRS(float3.zero, quaternion.Euler(0, 0, math.radians(-90)), point_one)
+            };
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_RotatedZNegative90, float3.zero), Is.EqualTo(float3.zero).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_RotatedZNegative90, point_one), Is.EqualTo(new float3(1f, -1f, 1f)).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_RotatedZNegative90, point_seven), Is.EqualTo(new float3(7f, -7f, 7f)).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_RotatedZNegative90, -point_one), Is.EqualTo(new float3(-1f, 1f, -1f)).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_RotatedZNegative90, -point_seven), Is.EqualTo(new float3(-7f, 7f, -7f)).Using<float3>(EqualityWithTolerance));
+
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_RotatedZNegative90.Value, float3.zero), Is.EqualTo(float3.zero).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_RotatedZNegative90.Value, point_one), Is.EqualTo(new float3(1f, -1f, 1f)).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_RotatedZNegative90.Value, point_seven), Is.EqualTo(new float3(7f, -7f, 7f)).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_RotatedZNegative90.Value, -point_one), Is.EqualTo(new float3(-1f, 1f, -1f)).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_RotatedZNegative90.Value, -point_seven), Is.EqualTo(new float3(-7f, 7f, -7f)).Using<float3>(EqualityWithTolerance));
+
+
+            LocalToWorld localToWorld_RotatedZX90 = new LocalToWorld()
+            {
+                Value = float4x4.TRS(float3.zero, quaternion.Euler(math.radians(90), 0, math.radians(90)), point_one)
+            };
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_RotatedZX90, float3.zero), Is.EqualTo(float3.zero).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_RotatedZX90, point_one), Is.EqualTo(new float3(-1f, -1f, 1f)).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_RotatedZX90, point_seven), Is.EqualTo(new float3(-7f, -7f, 7f)).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_RotatedZX90, -point_one), Is.EqualTo(new float3(1f, 1f, -1f)).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_RotatedZX90, -point_seven), Is.EqualTo(new float3(7f, 7f, -7f)).Using<float3>(EqualityWithTolerance));
+
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_RotatedZX90.Value, float3.zero), Is.EqualTo(float3.zero).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_RotatedZX90.Value, point_one), Is.EqualTo(new float3(-1f, -1f, 1f)).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_RotatedZX90.Value, point_seven), Is.EqualTo(new float3(-7f, -7f, 7f)).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_RotatedZX90.Value, -point_one), Is.EqualTo(new float3(1f, 1f, -1f)).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_RotatedZX90.Value, -point_seven), Is.EqualTo(new float3(7f, 7f, -7f)).Using<float3>(EqualityWithTolerance));
+
+
+            LocalToWorld localToWorld_RotatedZXNegative90 = new LocalToWorld()
+            {
+                Value = float4x4.TRS(float3.zero, quaternion.Euler(math.radians(-90), 0, math.radians(-90)), point_one)
+            };
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_RotatedZXNegative90, float3.zero), Is.EqualTo(float3.zero).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_RotatedZXNegative90, point_one), Is.EqualTo(point_one).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_RotatedZXNegative90, point_seven), Is.EqualTo(point_seven).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_RotatedZXNegative90, -point_one), Is.EqualTo(-point_one).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_RotatedZXNegative90, -point_seven), Is.EqualTo(-point_seven).Using<float3>(EqualityWithTolerance));
+
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_RotatedZXNegative90.Value, float3.zero), Is.EqualTo(float3.zero).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_RotatedZXNegative90.Value, point_one), Is.EqualTo(point_one).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_RotatedZXNegative90.Value, point_seven), Is.EqualTo(point_seven).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_RotatedZXNegative90.Value, -point_one), Is.EqualTo(-point_one).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_RotatedZXNegative90.Value, -point_seven), Is.EqualTo(-point_seven).Using<float3>(EqualityWithTolerance));
+
+
+            LocalToWorld localToWorld_RotatedZX45 = new LocalToWorld()
+            {
+                Value = float4x4.TRS(float3.zero, quaternion.Euler(math.radians(45), 0, math.radians(45)), point_one)
+            };
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_RotatedZX45, float3.zero), Is.EqualTo(float3.zero).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_RotatedZX45, point_one), Is.EqualTo(new float3(0f,0.292893201f,1.70710683f)).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_RotatedZX45, point_seven), Is.EqualTo(new float3(0f,2.0502522f,11.9497471f)).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_RotatedZX45, -point_one), Is.EqualTo(new float3(0f,-0.292893201f,-1.70710683f)).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_RotatedZX45, -point_seven), Is.EqualTo(new float3(0f,-2.0502522f,-11.9497471f)).Using<float3>(EqualityWithTolerance));
+
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_RotatedZX45.Value, float3.zero), Is.EqualTo(float3.zero).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_RotatedZX45.Value, point_one), Is.EqualTo(new float3(0f,0.292893201f,1.70710683f)).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_RotatedZX45.Value, point_seven), Is.EqualTo(new float3(0f,2.0502522f,11.9497471f)).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_RotatedZX45.Value, -point_one), Is.EqualTo(new float3(0f,-0.292893201f,-1.70710683f)).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_RotatedZX45.Value, -point_seven), Is.EqualTo(new float3(0f,-2.0502522f,-11.9497471f)).Using<float3>(EqualityWithTolerance));
+        }
+
+        [Test]
+        public static void ConvertLocalToWorldPointTest_Scale()
+        {
+            float3 point_one = new float3(1, 1, 1);
+            float3 point_seven = point_one * 7f;
+
+            LocalToWorld localToWorld_Scaled2 = new LocalToWorld()
+            {
+                Value = float4x4.TRS(float3.zero, quaternion.identity, point_one*2f)
+            };
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_Scaled2, float3.zero), Is.EqualTo(float3.zero).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_Scaled2, point_one), Is.EqualTo(point_one*2f).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_Scaled2, point_seven), Is.EqualTo(point_seven*2f).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_Scaled2, -point_one), Is.EqualTo(-point_one*2f).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_Scaled2, -point_seven), Is.EqualTo(-point_seven*2f).Using<float3>(EqualityWithTolerance));
+
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_Scaled2.Value, float3.zero), Is.EqualTo(float3.zero).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_Scaled2.Value, point_one), Is.EqualTo(point_one*2f).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_Scaled2.Value, point_seven), Is.EqualTo(point_seven*2f).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_Scaled2.Value, -point_one), Is.EqualTo(-point_one*2f).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_Scaled2.Value, -point_seven), Is.EqualTo(-point_seven*2f).Using<float3>(EqualityWithTolerance));
+
+
+            LocalToWorld localToWorld_ScaledNegative2 = new LocalToWorld()
+            {
+                Value = float4x4.TRS(float3.zero, quaternion.identity, point_one*-2f)
+            };
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_ScaledNegative2, float3.zero), Is.EqualTo(float3.zero).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_ScaledNegative2, point_one), Is.EqualTo(-point_one*2f).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_ScaledNegative2, point_seven), Is.EqualTo(-point_seven*2f).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_ScaledNegative2, -point_one), Is.EqualTo(point_one*2f).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_ScaledNegative2, -point_seven), Is.EqualTo(point_seven*2f).Using<float3>(EqualityWithTolerance));
+
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_ScaledNegative2.Value, float3.zero), Is.EqualTo(float3.zero).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_ScaledNegative2.Value, point_one), Is.EqualTo(-point_one*2f).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_ScaledNegative2.Value, point_seven), Is.EqualTo(-point_seven*2f).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_ScaledNegative2.Value, -point_one), Is.EqualTo(point_one*2f).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_ScaledNegative2.Value, -point_seven), Is.EqualTo(point_seven*2f).Using<float3>(EqualityWithTolerance));
+
+
+            float3 scaleZ2 = new float3(point_one.xy, 2f);
+            LocalToWorld localToWorld_ScaledZ2 = new LocalToWorld()
+            {
+                Value = float4x4.TRS(float3.zero, quaternion.identity, scaleZ2)
+            };
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_ScaledZ2, float3.zero), Is.EqualTo(float3.zero).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_ScaledZ2, point_one), Is.EqualTo(point_one*scaleZ2).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_ScaledZ2, point_seven), Is.EqualTo(point_seven*scaleZ2).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_ScaledZ2, -point_one), Is.EqualTo(-point_one*scaleZ2).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_ScaledZ2, -point_seven), Is.EqualTo(-point_seven*scaleZ2).Using<float3>(EqualityWithTolerance));
+
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_ScaledZ2.Value, float3.zero), Is.EqualTo(float3.zero).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_ScaledZ2.Value, point_one), Is.EqualTo(point_one*scaleZ2).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_ScaledZ2.Value, point_seven), Is.EqualTo(point_seven*scaleZ2).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_ScaledZ2.Value, -point_one), Is.EqualTo(-point_one*scaleZ2).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_ScaledZ2.Value, -point_seven), Is.EqualTo(-point_seven*scaleZ2).Using<float3>(EqualityWithTolerance));
+
+
+            float3 scaleZNegative2 = new float3(point_one.xy, -2f);
+            LocalToWorld localToWorld_ScaledZNegative2 = new LocalToWorld()
+            {
+                Value = float4x4.TRS(float3.zero, quaternion.identity, scaleZNegative2)
+            };
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_ScaledZNegative2, float3.zero), Is.EqualTo(float3.zero).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_ScaledZNegative2, point_one), Is.EqualTo(point_one*scaleZNegative2).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_ScaledZNegative2, point_seven), Is.EqualTo(point_seven*scaleZNegative2).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_ScaledZNegative2, -point_one), Is.EqualTo(-point_one*scaleZNegative2).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_ScaledZNegative2, -point_seven), Is.EqualTo(-point_seven*scaleZNegative2).Using<float3>(EqualityWithTolerance));
+
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_ScaledZNegative2.Value, float3.zero), Is.EqualTo(float3.zero).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_ScaledZNegative2.Value, point_one), Is.EqualTo(point_one*scaleZNegative2).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_ScaledZNegative2.Value, point_seven), Is.EqualTo(point_seven*scaleZNegative2).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_ScaledZNegative2.Value, -point_one), Is.EqualTo(-point_one*scaleZNegative2).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_ScaledZNegative2.Value, -point_seven), Is.EqualTo(-point_seven*scaleZNegative2).Using<float3>(EqualityWithTolerance));
+
+
+            float3 scaleZXOnePointFive = new float3(1.5f, 1f, 1.5f);
+            LocalToWorld localToWorld_ScaledZXOnePointFive = new LocalToWorld()
+            {
+                Value = float4x4.TRS(float3.zero, quaternion.identity, scaleZXOnePointFive)
+            };
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_ScaledZXOnePointFive, float3.zero), Is.EqualTo(float3.zero).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_ScaledZXOnePointFive, point_one), Is.EqualTo(point_one*scaleZXOnePointFive).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_ScaledZXOnePointFive, point_seven), Is.EqualTo(point_seven*scaleZXOnePointFive).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_ScaledZXOnePointFive, -point_one), Is.EqualTo(-point_one*scaleZXOnePointFive).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_ScaledZXOnePointFive, -point_seven), Is.EqualTo(-point_seven*scaleZXOnePointFive).Using<float3>(EqualityWithTolerance));
+
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_ScaledZXOnePointFive.Value, float3.zero), Is.EqualTo(float3.zero).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_ScaledZXOnePointFive.Value, point_one), Is.EqualTo(point_one*scaleZXOnePointFive).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_ScaledZXOnePointFive.Value, point_seven), Is.EqualTo(point_seven*scaleZXOnePointFive).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_ScaledZXOnePointFive.Value, -point_one), Is.EqualTo(-point_one*scaleZXOnePointFive).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_ScaledZXOnePointFive.Value, -point_seven), Is.EqualTo(-point_seven*scaleZXOnePointFive).Using<float3>(EqualityWithTolerance));
+        }
+
+        [Test]
+        public static void ConvertLocalToWorldPointTest_Compound()
+        {
+            float3 point_one = new float3(1f, 1f, 1f);
+            float3 point_seven = point_one * 7f;
+            float3 point_sevenXY = new float3(point_seven.xy, 0f);
+
+            LocalToWorld localToWorld_Compound = new LocalToWorld()
+            {
+                Value = float4x4.TRS(point_sevenXY, quaternion.Euler(math.radians(45), 0, math.radians(45)), point_one*2f)
+            };
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_Compound, float3.zero), Is.EqualTo(point_sevenXY).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_Compound, point_one), Is.EqualTo(new float3(7f, 7.58578634f, 3.41421366f)).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_Compound, point_seven), Is.EqualTo(new float3(7f, 11.1005039f, 23.8994942f)).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_Compound, -point_one), Is.EqualTo(new float3(7f,6.41421366f, -3.41421366f)).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_Compound, -point_seven), Is.EqualTo(new float3(7f, 2.89949608f, -23.8994942f)).Using<float3>(EqualityWithTolerance));
+
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_Compound.Value, float3.zero), Is.EqualTo(point_sevenXY).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_Compound.Value, point_one), Is.EqualTo(new float3(7 ,7.58578634f, 3.41421366f)).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_Compound.Value, point_seven), Is.EqualTo(new float3(7 ,11.1005039f, 23.8994942f)).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_Compound.Value, -point_one), Is.EqualTo(new float3(7 ,6.41421366f, -3.41421366f)).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_Compound.Value, -point_seven), Is.EqualTo(new float3(7 ,2.89949608f, -23.8994942f)).Using<float3>(EqualityWithTolerance));
+
+
+            LocalToWorld localToWorld_CompoundNegative = new LocalToWorld()
+            {
+                Value = float4x4.TRS(-point_sevenXY, quaternion.Euler(math.radians(-45), 0, math.radians(-45)), point_one*-2f)
+            };
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_CompoundNegative, float3.zero), Is.EqualTo(-point_sevenXY).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_CompoundNegative, point_one), Is.EqualTo(new float3(-9.82842731f, -8.41421318f, -1.41421366f)).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_CompoundNegative, point_seven), Is.EqualTo(new float3(-26.7989922f, -16.8994961f, -9.89949512f)).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_CompoundNegative, -point_one), Is.EqualTo(new float3(-4.17157269f, -5.58578634f, 1.41421366f)).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_CompoundNegative, -point_seven), Is.EqualTo(new float3(12.7989922f, 2.89949608f, 9.89949512f)).Using<float3>(EqualityWithTolerance));
+
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_CompoundNegative.Value, float3.zero), Is.EqualTo(-point_sevenXY).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_CompoundNegative.Value, point_one), Is.EqualTo(new float3(-9.82842731f, -8.41421318f, -1.41421366f)).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_CompoundNegative.Value, point_seven), Is.EqualTo(new float3(-26.7989922f, -16.8994961f, -9.89949512f)).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_CompoundNegative.Value, -point_one), Is.EqualTo(new float3(-4.17157269f, -5.58578634f, 1.41421366f)).Using<float3>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldPoint(localToWorld_CompoundNegative.Value, -point_seven), Is.EqualTo(new float3(12.7989922f, 2.89949608f, 9.89949512f)).Using<float3>(EqualityWithTolerance));
+        }
+
+        // ----- ConvertWorldToLocalRotation ----- //
+        [Test]
+        public static void ConvertWorldToLocalRotation_Rotate()
+        {
+            float3 point_one = new float3(1f, 1f, 1f);
+            quaternion rotation_fortyFive = quaternion.Euler(math.radians(45f), math.radians(45f), math.radians(45f));
+            quaternion rotation_fortyFive_inverse = math.inverse(rotation_fortyFive);
+
+            quaternion rotation_nintey = quaternion.Euler(math.radians(90f), math.radians(90f), math.radians(90f));
+            quaternion rotation_nintey_inverse = math.inverse(rotation_nintey);
+
+            quaternion rotation_ZfortyFive = quaternion.Euler(0f, 0f, math.radians(45f));
+            quaternion rotation_ZfortyFive_inverse = math.inverse(rotation_ZfortyFive);
+
+            quaternion rotation_Znintey = quaternion.Euler(0f, 0f, math.radians(90f));
+            quaternion rotation_Znintey_inverse = math.inverse(rotation_Znintey);
+
+
+            LocalToWorld localToWorld_nintey = new LocalToWorld()
+            {
+                Value = float4x4.TRS(float3.zero, rotation_nintey, point_one)
+            };
+            float4x4 worldToLocal_nintey = math.inverse(localToWorld_nintey.Value);
+            Assert.That(TransformUtil.ConvertWorldToLocalRotation(localToWorld_nintey, quaternion.identity), Is.EqualTo(math.mul(rotation_nintey_inverse, quaternion.identity)).Using<quaternion>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalRotation(localToWorld_nintey, rotation_nintey), Is.EqualTo(math.mul(rotation_nintey_inverse, rotation_nintey)).Using<quaternion>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalRotation(localToWorld_nintey, rotation_Znintey), Is.EqualTo(math.mul(rotation_nintey_inverse, rotation_Znintey)).Using<quaternion>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalRotation(localToWorld_nintey, rotation_fortyFive), Is.EqualTo(math.mul(rotation_nintey_inverse, rotation_fortyFive)).Using<quaternion>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalRotation(localToWorld_nintey, rotation_ZfortyFive), Is.EqualTo(math.mul(rotation_nintey_inverse, rotation_ZfortyFive)).Using<quaternion>(EqualityWithTolerance));
+
+            Assert.That(TransformUtil.ConvertWorldToLocalRotation(worldToLocal_nintey, quaternion.identity), Is.EqualTo(math.mul(rotation_nintey_inverse, quaternion.identity)).Using<quaternion>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalRotation(worldToLocal_nintey, rotation_nintey), Is.EqualTo(math.mul(rotation_nintey_inverse, rotation_nintey)).Using<quaternion>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalRotation(worldToLocal_nintey, rotation_Znintey), Is.EqualTo(math.mul(rotation_nintey_inverse, rotation_Znintey)).Using<quaternion>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalRotation(worldToLocal_nintey, rotation_fortyFive), Is.EqualTo(math.mul(rotation_nintey_inverse, rotation_fortyFive)).Using<quaternion>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalRotation(worldToLocal_nintey, rotation_ZfortyFive), Is.EqualTo(math.mul(rotation_nintey_inverse, rotation_ZfortyFive)).Using<quaternion>(EqualityWithTolerance));
+
+
+            LocalToWorld localToWorld_fortyFive = new LocalToWorld()
+            {
+                Value = float4x4.TRS(float3.zero, rotation_fortyFive, point_one)
+            };
+            float4x4 worldToLocal_fortyFive = math.inverse(localToWorld_fortyFive.Value);
+            Assert.That(TransformUtil.ConvertWorldToLocalRotation(localToWorld_fortyFive, quaternion.identity), Is.EqualTo(math.mul(rotation_fortyFive_inverse, quaternion.identity)).Using<quaternion>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalRotation(localToWorld_fortyFive, rotation_nintey), Is.EqualTo(math.mul(rotation_fortyFive_inverse, rotation_nintey)).Using<quaternion>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalRotation(localToWorld_fortyFive, rotation_Znintey), Is.EqualTo(math.mul(rotation_fortyFive_inverse, rotation_Znintey)).Using<quaternion>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalRotation(localToWorld_fortyFive, rotation_fortyFive), Is.EqualTo(math.mul(rotation_fortyFive_inverse, rotation_fortyFive)).Using<quaternion>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalRotation(localToWorld_fortyFive, rotation_ZfortyFive), Is.EqualTo(math.mul(rotation_fortyFive_inverse, rotation_ZfortyFive)).Using<quaternion>(EqualityWithTolerance));
+
+            Assert.That(TransformUtil.ConvertWorldToLocalRotation(worldToLocal_fortyFive, quaternion.identity), Is.EqualTo(math.mul(rotation_fortyFive_inverse, quaternion.identity)).Using<quaternion>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalRotation(worldToLocal_fortyFive, rotation_nintey), Is.EqualTo(math.mul(rotation_fortyFive_inverse, rotation_nintey)).Using<quaternion>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalRotation(worldToLocal_fortyFive, rotation_Znintey), Is.EqualTo(math.mul(rotation_fortyFive_inverse, rotation_Znintey)).Using<quaternion>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalRotation(worldToLocal_fortyFive, rotation_fortyFive), Is.EqualTo(math.mul(rotation_fortyFive_inverse, rotation_fortyFive)).Using<quaternion>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalRotation(worldToLocal_fortyFive, rotation_ZfortyFive), Is.EqualTo(math.mul(rotation_fortyFive_inverse, rotation_ZfortyFive)).Using<quaternion>(EqualityWithTolerance));
+
+
+            LocalToWorld localToWorld_Znintey = new LocalToWorld()
+            {
+                Value = float4x4.TRS(float3.zero, rotation_Znintey, point_one)
+            };
+            float4x4 worldToLocal_Znintey = math.inverse(localToWorld_Znintey.Value);
+            Assert.That(TransformUtil.ConvertWorldToLocalRotation(localToWorld_Znintey, quaternion.identity), Is.EqualTo(math.mul(rotation_Znintey_inverse, quaternion.identity)).Using<quaternion>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalRotation(localToWorld_Znintey, rotation_nintey), Is.EqualTo(math.mul(rotation_Znintey_inverse, rotation_nintey)).Using<quaternion>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalRotation(localToWorld_Znintey, rotation_Znintey), Is.EqualTo(math.mul(rotation_Znintey_inverse, rotation_Znintey)).Using<quaternion>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalRotation(localToWorld_Znintey, rotation_fortyFive), Is.EqualTo(math.mul(rotation_Znintey_inverse, rotation_fortyFive)).Using<quaternion>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalRotation(localToWorld_Znintey, rotation_ZfortyFive), Is.EqualTo(math.mul(rotation_Znintey_inverse, rotation_ZfortyFive)).Using<quaternion>(EqualityWithTolerance));
+
+            Assert.That(TransformUtil.ConvertWorldToLocalRotation(worldToLocal_Znintey, quaternion.identity), Is.EqualTo(math.mul(rotation_Znintey_inverse, quaternion.identity)).Using<quaternion>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalRotation(worldToLocal_Znintey, rotation_nintey), Is.EqualTo(math.mul(rotation_Znintey_inverse, rotation_nintey)).Using<quaternion>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalRotation(worldToLocal_Znintey, rotation_Znintey), Is.EqualTo(math.mul(rotation_Znintey_inverse, rotation_Znintey)).Using<quaternion>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalRotation(worldToLocal_Znintey, rotation_fortyFive), Is.EqualTo(math.mul(rotation_Znintey_inverse, rotation_fortyFive)).Using<quaternion>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalRotation(worldToLocal_Znintey, rotation_ZfortyFive), Is.EqualTo(math.mul(rotation_Znintey_inverse, rotation_ZfortyFive)).Using<quaternion>(EqualityWithTolerance));
+
+
+            LocalToWorld localToWorld_ZfortyFive = new LocalToWorld()
+            {
+                Value = float4x4.TRS(float3.zero, rotation_ZfortyFive, point_one)
+            };
+            float4x4 worldToLocal_ZfortyFive = math.inverse(localToWorld_ZfortyFive.Value);
+            Assert.That(TransformUtil.ConvertWorldToLocalRotation(localToWorld_ZfortyFive, quaternion.identity), Is.EqualTo(math.mul(rotation_ZfortyFive_inverse, quaternion.identity)).Using<quaternion>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalRotation(localToWorld_ZfortyFive, rotation_nintey), Is.EqualTo(math.mul(rotation_ZfortyFive_inverse, rotation_nintey)).Using<quaternion>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalRotation(localToWorld_ZfortyFive, rotation_Znintey), Is.EqualTo(math.mul(rotation_ZfortyFive_inverse, rotation_Znintey)).Using<quaternion>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalRotation(localToWorld_ZfortyFive, rotation_fortyFive), Is.EqualTo(math.mul(rotation_ZfortyFive_inverse, rotation_fortyFive)).Using<quaternion>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalRotation(localToWorld_ZfortyFive, rotation_ZfortyFive), Is.EqualTo(math.mul(rotation_ZfortyFive_inverse, rotation_ZfortyFive)).Using<quaternion>(EqualityWithTolerance));
+
+            Assert.That(TransformUtil.ConvertWorldToLocalRotation(worldToLocal_ZfortyFive, quaternion.identity), Is.EqualTo(math.mul(rotation_ZfortyFive_inverse, quaternion.identity)).Using<quaternion>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalRotation(worldToLocal_ZfortyFive, rotation_nintey), Is.EqualTo(math.mul(rotation_ZfortyFive_inverse, rotation_nintey)).Using<quaternion>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalRotation(worldToLocal_ZfortyFive, rotation_Znintey), Is.EqualTo(math.mul(rotation_ZfortyFive_inverse, rotation_Znintey)).Using<quaternion>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalRotation(worldToLocal_ZfortyFive, rotation_fortyFive), Is.EqualTo(math.mul(rotation_ZfortyFive_inverse, rotation_fortyFive)).Using<quaternion>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalRotation(worldToLocal_ZfortyFive, rotation_ZfortyFive), Is.EqualTo(math.mul(rotation_ZfortyFive_inverse, rotation_ZfortyFive)).Using<quaternion>(EqualityWithTolerance));
+        }
+
+        [Test]
+        public static void ConvertWorldToLocalRotation_Compound()
+        {
+            float3 point_one = new float3(1f, 1f, 1f);
+            float3 point_sevenXY = new float3(7f, 7f, 0f);
+            quaternion rotation_fortyFive = quaternion.Euler(math.radians(45f), math.radians(45f), math.radians(45f));
+            quaternion rotation_nintey = quaternion.Euler(math.radians(90f), math.radians(90f), math.radians(90f));
+            quaternion rotation_ZfortyFive = quaternion.Euler(0f, 0f, math.radians(45f));
+            quaternion rotation_Znintey = quaternion.Euler(0f, 0f, math.radians(90f));
+
+            quaternion rotation_XZ_fortyFive = quaternion.Euler(math.radians(45), 0, math.radians(45));
+            quaternion rotation_XZ_fortyFive_inverse = math.inverse(rotation_XZ_fortyFive);
+            quaternion rotation_XZ_negativeFortyFive = quaternion.Euler(math.radians(-45), 0, math.radians(-45));
+            quaternion rotation_XZ_negativeFortyFive_inverse = math.inverse(rotation_XZ_negativeFortyFive);
+
+
+            LocalToWorld localToWorld_compound = new LocalToWorld()
+            {
+                Value = float4x4.TRS(point_sevenXY, rotation_XZ_fortyFive, point_one*2f)
+            };
+
+            float4x4 worldToLocal_compound = math.inverse(localToWorld_compound.Value);
+            // Assert.That(math.degrees(toEuler(localToWorld_compound.Value.GetRotation())), Is.EqualTo(math.degrees(toEuler(rotation_XZ_fortyFive))).Using<quaternion>(EqualityWithTolerance));
+
+            // Assert.That(math.degrees(toEuler(TransformUtil.ConvertWorldToLocalRotation(localToWorld_compound, quaternion.identity))), Is.EqualTo(math.degrees(toEuler(math.mul(rotation_XZ_fortyFive_inverse, quaternion.identity)))).Using<quaternion>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalRotation(localToWorld_compound, quaternion.identity), Is.EqualTo(math.mul(rotation_XZ_fortyFive_inverse, quaternion.identity)).Using<quaternion>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalRotation(localToWorld_compound, rotation_nintey), Is.EqualTo(math.mul(rotation_XZ_fortyFive_inverse, rotation_nintey)).Using<quaternion>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalRotation(localToWorld_compound, rotation_Znintey), Is.EqualTo(math.mul(rotation_XZ_fortyFive_inverse, rotation_Znintey)).Using<quaternion>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalRotation(localToWorld_compound, rotation_fortyFive), Is.EqualTo(math.mul(rotation_XZ_fortyFive_inverse, rotation_fortyFive)).Using<quaternion>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalRotation(localToWorld_compound, rotation_ZfortyFive), Is.EqualTo(math.mul(rotation_XZ_fortyFive_inverse, rotation_ZfortyFive)).Using<quaternion>(EqualityWithTolerance));
+
+            Assert.That(TransformUtil.ConvertWorldToLocalRotation(worldToLocal_compound, quaternion.identity), Is.EqualTo(math.mul(rotation_XZ_fortyFive_inverse, quaternion.identity)).Using<quaternion>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalRotation(worldToLocal_compound, rotation_nintey), Is.EqualTo(math.mul(rotation_XZ_fortyFive_inverse, rotation_nintey)).Using<quaternion>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalRotation(worldToLocal_compound, rotation_Znintey), Is.EqualTo(math.mul(rotation_XZ_fortyFive_inverse, rotation_Znintey)).Using<quaternion>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalRotation(worldToLocal_compound, rotation_fortyFive), Is.EqualTo(math.mul(rotation_XZ_fortyFive_inverse, rotation_fortyFive)).Using<quaternion>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalRotation(worldToLocal_compound, rotation_ZfortyFive), Is.EqualTo(math.mul(rotation_XZ_fortyFive_inverse, rotation_ZfortyFive)).Using<quaternion>(EqualityWithTolerance));
+
+
+            //TODO: HERE - ///Negative scale is the issue here. Issue decomposing negative scale since there are ambiguities.
+            LocalToWorld localToWorld_compound_negative = new LocalToWorld()
+            {
+                // Value = float4x4.TRS(-point_sevenXY, rotation_XZ_negativeFortyFive, point_one*-2f)
+                Value = float4x4.TRS(-point_sevenXY, rotation_XZ_negativeFortyFive, new float3(2f, 2f, -2f))
+            };
+            float4x4 worldToLocal_compound_negative = math.inverse(localToWorld_compound_negative.Value);
+
+            Debug.Log("LTW Rot: " + math.degrees(localToWorld_compound_negative.Value.GetRotation().ToEuler()));
+            Debug.Log("WTL Rot: " + math.degrees(worldToLocal_compound_negative.GetRotation().ToEuler()));
+
+            Debug.Log("Component Direct: " + math.degrees(math.mul(rotation_XZ_negativeFortyFive_inverse, quaternion.identity).ToEuler()));
+            Debug.Log("WTL Matrix: " + math.degrees(math.mul(worldToLocal_compound_negative.GetRotation(), quaternion.identity).ToEuler()));
+            Debug.Log("WTL Matrix Scale: " + worldToLocal_compound_negative.GetScale());
+
+
+            float4x4 trsComponentWise = float4x4.TRS(float3.zero, rotation_XZ_negativeFortyFive_inverse, 1f / (new float3(2f, 2f, -2f)));
+            float4x4 trsUtil = float4x4.TRS(float3.zero, worldToLocal_compound_negative.GetRotation(), worldToLocal_compound_negative.GetScaleMagnitude());
+            Debug.Log("-------------------");
+            Debug.Log("TRS Component Wise: " + trsComponentWise);
+            Debug.Log("TRS Util: " + trsUtil);
+            Debug.Log("-");
+            Debug.Log("TRS Component Wise Point: " + (math.transform(trsComponentWise, 5f)));
+            Debug.Log("TRS Util Point: " + (math.transform(trsUtil, 5f)));
+            Debug.Log("-------------------");
+
+            Assert.That(math.degrees(TransformUtil.ConvertWorldToLocalRotation(localToWorld_compound_negative, quaternion.identity).ToEuler()),
+                Is.EqualTo(math.degrees(math.mul(rotation_XZ_negativeFortyFive_inverse, quaternion.identity).ToEuler())).Using<quaternion>(EqualityWithTolerance));
+
+            Assert.That(TransformUtil.ConvertWorldToLocalRotation(localToWorld_compound_negative, quaternion.identity), Is.EqualTo(math.mul(rotation_XZ_negativeFortyFive_inverse, quaternion.identity)).Using<quaternion>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalRotation(localToWorld_compound_negative, rotation_nintey), Is.EqualTo(math.mul(rotation_XZ_negativeFortyFive_inverse, rotation_nintey)).Using<quaternion>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalRotation(localToWorld_compound_negative, rotation_Znintey), Is.EqualTo(math.mul(rotation_XZ_negativeFortyFive_inverse, rotation_Znintey)).Using<quaternion>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalRotation(localToWorld_compound_negative, rotation_fortyFive), Is.EqualTo(math.mul(rotation_XZ_negativeFortyFive_inverse, rotation_fortyFive)).Using<quaternion>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalRotation(localToWorld_compound_negative, rotation_ZfortyFive), Is.EqualTo(math.mul(rotation_XZ_negativeFortyFive_inverse, rotation_ZfortyFive)).Using<quaternion>(EqualityWithTolerance));
+
+            Assert.That(TransformUtil.ConvertWorldToLocalRotation(worldToLocal_compound_negative, quaternion.identity), Is.EqualTo(math.mul(rotation_XZ_negativeFortyFive_inverse, quaternion.identity)).Using<quaternion>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalRotation(worldToLocal_compound_negative, rotation_nintey), Is.EqualTo(math.mul(rotation_XZ_negativeFortyFive_inverse, rotation_nintey)).Using<quaternion>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalRotation(worldToLocal_compound_negative, rotation_Znintey), Is.EqualTo(math.mul(rotation_XZ_negativeFortyFive_inverse, rotation_Znintey)).Using<quaternion>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalRotation(worldToLocal_compound_negative, rotation_fortyFive), Is.EqualTo(math.mul(rotation_XZ_negativeFortyFive_inverse, rotation_fortyFive)).Using<quaternion>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertWorldToLocalRotation(worldToLocal_compound_negative, rotation_ZfortyFive), Is.EqualTo(math.mul(rotation_XZ_negativeFortyFive_inverse, rotation_ZfortyFive)).Using<quaternion>(EqualityWithTolerance));
+        }
+
+        // ----- ConvertLocalToWorldRotation ----- //
+        [Test]
+        public static void ConvertLocalToWorldRotation()
+        {
+
+        }
+
+        // [Test]
+        // public static quaternion ConvertLocalToWorldRotationTest()
+        // {
+        //     return ConvertLocalToWorldRotation(localToWorld.Value, rotation);
+        // }
+        //
+        // [Test]
+        // public static float3 ConvertLocalToWorldScaleTest()
+        // {
+        //     return ConvertLocalToWorldScale(localToWorld.Value, scale);
+        // }
+        //
+        // [Test]
+        // public static Rect ConvertWorldToLocalRectTest()
+        // {
+        //     //TODO: #321 - Optimize...
+        //     float4x4 worldToLocalMtx = math.inverse(localToWorld.Value);
+        //
+        //     float3 point1 = (Vector3)worldRect.min;
+        //     float3 point2 = (Vector3)worldRect.max;
+        //     float3 point3 = new float3(point1.x, point2.y, 0);
+        //     float3 point4 = new float3(point2.x, point1.y, 0);
+        //
+        //     return RectUtil.CreateFromPoints(
+        //         ConvertWorldToLocalPoint(worldToLocalMtx, point1).xy,
+        //         ConvertWorldToLocalPoint(worldToLocalMtx, point2).xy,
+        //         ConvertWorldToLocalPoint(worldToLocalMtx, point3).xy,
+        //         ConvertWorldToLocalPoint(worldToLocalMtx, point4).xy
+        //     );
+        // }
+        //
+        // [Test]
+        // public static Rect ConvertLocalToWorldRectTest()
+        // {
+        //     //TODO: #321 - Optimize...
+        //     float4x4 worldToLocalMtx = math.inverse(localToWorld.Value);
+        //
+        //     float3 point1 = (Vector3)localRect.min;
+        //     float3 point2 = (Vector3)localRect.max;
+        //     float3 point3 = new float3(point1.x, point2.y, 0);
+        //     float3 point4 = new float3(point2.x, point1.y, 0);
+        //
+        //     return RectUtil.CreateFromPoints(
+        //         ConvertLocalToWorldPoint(worldToLocalMtx, point1).xy,
+        //         ConvertLocalToWorldPoint(worldToLocalMtx, point2).xy,
+        //         ConvertLocalToWorldPoint(worldToLocalMtx, point3).xy,
+        //         ConvertLocalToWorldPoint(worldToLocalMtx, point4).xy
+        //     );
+        // }
+    }
+}

--- a/Scripts/Editor/Tests/Entities/Transform/TransformUtilTests.cs
+++ b/Scripts/Editor/Tests/Entities/Transform/TransformUtilTests.cs
@@ -2488,23 +2488,1849 @@ namespace Anvil.Unity.DOTS.Tests.Entities.Transform
                 );
         }
 
-        // [Test]
-        // public static Rect ConvertLocalToWorldRectTest()
-        // {
-        //     //TODO: #321 - Optimize...
-        //     float4x4 worldToLocalMtx = math.inverse(localToWorld.Value);
-        //
-        //     float3 point1 = (Vector3)localRect.min;
-        //     float3 point2 = (Vector3)localRect.max;
-        //     float3 point3 = new float3(point1.x, point2.y, 0);
-        //     float3 point4 = new float3(point2.x, point1.y, 0);
-        //
-        //     return RectUtil.CreateFromPoints(
-        //         ConvertLocalToWorldPoint(worldToLocalMtx, point1).xy,
-        //         ConvertLocalToWorldPoint(worldToLocalMtx, point2).xy,
-        //         ConvertLocalToWorldPoint(worldToLocalMtx, point3).xy,
-        //         ConvertLocalToWorldPoint(worldToLocalMtx, point4).xy
-        //     );
-        // }
+        [Test]
+        public static void ConvertWorldToLocalRectTest_Rotate()
+        {
+            float3 point_zero = float3.zero;
+            float3 point_one = new float3(1f);
+
+            Rect rect_zero_zero = Rect.zero;
+
+            Rect rect_zero_one = new Rect(0, 0, 1, 1);
+
+            Rect rect_seven_seven = new Rect(7, 7, 7, 7);
+            Rect rect_seven_negativeSeven = new Rect(7, 7, -7, -7);
+
+            Rect rect_zero_oneSeven = new Rect(0, 0, 1, 7);
+            Rect rect_zero_sevenOne = new Rect(0, 0, 7, 1);
+            Rect rect_zero_negativeOneSeven = new Rect(0, 0, -1, -7);
+            Rect rect_zero_negativeSevenOne = new Rect(0, 0, -7, -1);
+
+            Rect rect_negativeOffset_seven = new Rect(-14, -14, 7, 7);
+            Rect rect_negativeOffset_negativeSeven = new Rect(-14, -14, -7, -7);
+
+            Rect rect_centered_seven = new Rect(-3.5f, -3.5f, 7, 7);
+            Rect rect_centered_negativeSeven = new Rect(-3.5f, -3.5f, -7, -7);
+
+            Rect rect_centered_negativePositiveSeven = new Rect(-3.5f, -3.5f, -7, 7);
+
+            quaternion rotation_ninety = quaternion.Euler(math.radians(90f), math.radians(90f), math.radians(90f));
+            quaternion rotation_fortyFive = quaternion.Euler(math.radians(45f), math.radians(45f), math.radians(45f));
+            quaternion rotation_Xninety = quaternion.Euler(math.radians(90f), math.radians(0f), math.radians(0f));
+            quaternion rotation_Zninety = quaternion.Euler(math.radians(0f), math.radians(0f), math.radians(90f));
+
+
+            LocalToWorld localToWorld_rotate_ninety = new LocalToWorld
+            {
+                Value = float4x4.TRS(point_zero, rotation_ninety, point_one)
+            };
+
+            Assert.That(
+                TransformUtil.ConvertWorldToLocalRect(localToWorld_rotate_ninety, rect_zero_zero),
+                Is.EqualTo(new Rect(0f, 0f, 0f, 0f)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertWorldToLocalRect(localToWorld_rotate_ninety, rect_seven_seven),
+                Is.EqualTo(new Rect(7f, 0f, 7f, 0f)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertWorldToLocalRect(localToWorld_rotate_ninety, rect_zero_one),
+                Is.EqualTo(new Rect(0f, 0f, 1f, 0f)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertWorldToLocalRect(localToWorld_rotate_ninety, rect_seven_negativeSeven),
+                Is.EqualTo(new Rect(0f, 0f, 7f, 0f)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertWorldToLocalRect(localToWorld_rotate_ninety, rect_zero_oneSeven),
+                Is.EqualTo(new Rect(0f, 0f, 1f, 0f)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertWorldToLocalRect(localToWorld_rotate_ninety, rect_zero_sevenOne),
+                Is.EqualTo(new Rect(0f, 0f, 7f, 0f)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertWorldToLocalRect(localToWorld_rotate_ninety, rect_zero_negativeOneSeven),
+                Is.EqualTo(new Rect(-1f, 0f, 1f, 0f)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertWorldToLocalRect(localToWorld_rotate_ninety, rect_zero_negativeSevenOne),
+                Is.EqualTo(new Rect(-7f, 0f, 7f, 0f)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertWorldToLocalRect(localToWorld_rotate_ninety, rect_negativeOffset_seven),
+                Is.EqualTo(new Rect(-14f, 0f, 7f, 0f)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertWorldToLocalRect(localToWorld_rotate_ninety, rect_negativeOffset_negativeSeven),
+                Is.EqualTo(new Rect(-21f, 0f, 7f, 0f)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertWorldToLocalRect(localToWorld_rotate_ninety, rect_centered_seven),
+                Is.EqualTo(new Rect(-3.5f, 0f, 7f, 0f)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertWorldToLocalRect(localToWorld_rotate_ninety, rect_centered_negativeSeven),
+                Is.EqualTo(new Rect(-10.5f, 0f, 7f, 0f)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertWorldToLocalRect(localToWorld_rotate_ninety, rect_centered_negativePositiveSeven),
+                Is.EqualTo(new Rect(-10.5f, 0f, 7f, 0f)).Using<Rect>(EquivalencyWithTolerance)
+                );
+
+
+            LocalToWorld localToWorld_rotate_fortyFive = new LocalToWorld
+            {
+                Value = float4x4.TRS(point_zero, rotation_fortyFive, point_one)
+            };
+
+            Assert.That(
+                TransformUtil.ConvertWorldToLocalRect(localToWorld_rotate_fortyFive, rect_zero_zero),
+                Is.EqualTo(new Rect(0f, 0f, 0f, 0f)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertWorldToLocalRect(localToWorld_rotate_fortyFive, rect_seven_seven),
+                Is.EqualTo(new Rect(9.474874f, 1.449748f, 9.474874f, 4.525125f)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertWorldToLocalRect(localToWorld_rotate_fortyFive, rect_zero_one),
+                Is.EqualTo(new Rect(0f, -0.1464466f, 1.353553f, 0.6464465f)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertWorldToLocalRect(localToWorld_rotate_fortyFive, rect_seven_negativeSeven),
+                Is.EqualTo(new Rect(0f, -1.025126f, 9.474874f, 4.525126f)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertWorldToLocalRect(localToWorld_rotate_fortyFive, rect_zero_oneSeven),
+                Is.EqualTo(new Rect(0f, -0.1464466f, 4.353553f, 3.646446f)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertWorldToLocalRect(localToWorld_rotate_fortyFive, rect_zero_sevenOne),
+                Is.EqualTo(new Rect(0f, -1.025126f, 6.474874f, 1.525126f)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertWorldToLocalRect(localToWorld_rotate_fortyFive, rect_zero_negativeOneSeven),
+                Is.EqualTo(new Rect(-4.353553f, -3.5f, 4.353553f, 3.646446f)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertWorldToLocalRect(localToWorld_rotate_fortyFive, rect_zero_negativeSevenOne),
+                Is.EqualTo(new Rect(-6.474874f, -0.4999999f, 6.474874f, 1.525126f)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertWorldToLocalRect(localToWorld_rotate_fortyFive, rect_negativeOffset_seven),
+                Is.EqualTo(new Rect(-18.94975f, -5.974873f, 9.474874f, 4.525125f)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertWorldToLocalRect(localToWorld_rotate_fortyFive, rect_negativeOffset_negativeSeven),
+                Is.EqualTo(new Rect(-28.42462f, -8.449746f, 9.474874f, 4.525126f)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertWorldToLocalRect(localToWorld_rotate_fortyFive, rect_centered_seven),
+                Is.EqualTo(new Rect(-4.737437f, -2.262563f, 9.474874f, 4.525126f)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertWorldToLocalRect(localToWorld_rotate_fortyFive, rect_centered_negativeSeven),
+                Is.EqualTo(new Rect(-14.21231f, -4.737437f, 9.474874f, 4.525126f)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertWorldToLocalRect(localToWorld_rotate_fortyFive, rect_centered_negativePositiveSeven),
+                Is.EqualTo(new Rect(-10.71231f, -1.237437f, 9.474874f, 4.525126f)).Using<Rect>(EquivalencyWithTolerance)
+                );
+
+
+            LocalToWorld localToWorld_rotate_Xninety = new LocalToWorld
+            {
+                Value = float4x4.TRS(point_zero, rotation_Xninety, point_one)
+            };
+
+            Assert.That(
+                TransformUtil.ConvertWorldToLocalRect(localToWorld_rotate_Xninety, rect_zero_zero),
+                Is.EqualTo(new Rect(0f, 0f, 0f, 0f)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertWorldToLocalRect(localToWorld_rotate_Xninety, rect_seven_seven),
+                Is.EqualTo(new Rect(7f, 0f, 7f, 0f)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertWorldToLocalRect(localToWorld_rotate_Xninety, rect_zero_one),
+                Is.EqualTo(new Rect(0f, 0f, 1f, 0f)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertWorldToLocalRect(localToWorld_rotate_Xninety, rect_seven_negativeSeven),
+                Is.EqualTo(new Rect(0f, 0f, 7f, 0f)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertWorldToLocalRect(localToWorld_rotate_Xninety, rect_zero_oneSeven),
+                Is.EqualTo(new Rect(0f, 0f, 1f, 0f)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertWorldToLocalRect(localToWorld_rotate_Xninety, rect_zero_sevenOne),
+                Is.EqualTo(new Rect(0f, 0f, 7f, 0f)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertWorldToLocalRect(localToWorld_rotate_Xninety, rect_zero_negativeOneSeven),
+                Is.EqualTo(new Rect(-1f, 0f, 1f, 0f)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertWorldToLocalRect(localToWorld_rotate_Xninety, rect_zero_negativeSevenOne),
+                Is.EqualTo(new Rect(-7f, 0f, 7f, 0f)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertWorldToLocalRect(localToWorld_rotate_Xninety, rect_negativeOffset_seven),
+                Is.EqualTo(new Rect(-14f, 0f, 7f, 0f)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertWorldToLocalRect(localToWorld_rotate_Xninety, rect_negativeOffset_negativeSeven),
+                Is.EqualTo(new Rect(-21f, 0f, 7f, 0f)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertWorldToLocalRect(localToWorld_rotate_Xninety, rect_centered_seven),
+                Is.EqualTo(new Rect(-3.5f, 0f, 7f, 0f)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertWorldToLocalRect(localToWorld_rotate_Xninety, rect_centered_negativeSeven),
+                Is.EqualTo(new Rect(-10.5f, 0f, 7f, 0f)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertWorldToLocalRect(localToWorld_rotate_Xninety, rect_centered_negativePositiveSeven),
+                Is.EqualTo(new Rect(-10.5f, 0f, 7f, 0f)).Using<Rect>(EquivalencyWithTolerance)
+                );
+
+
+            LocalToWorld localToWorld_rotate_Zninety = new LocalToWorld
+            {
+                Value = float4x4.TRS(point_zero, rotation_Zninety, point_one)
+            };
+
+            Assert.That(
+                TransformUtil.ConvertWorldToLocalRect(localToWorld_rotate_Zninety, rect_zero_zero),
+                Is.EqualTo(new Rect(0f, 0f, 0f, 0f)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertWorldToLocalRect(localToWorld_rotate_Zninety, rect_seven_seven),
+                Is.EqualTo(new Rect(6.999999f, -14f, 7.000002f, 7.000002f)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertWorldToLocalRect(localToWorld_rotate_Zninety, rect_zero_one),
+                Is.EqualTo(new Rect(0f, -1f, 1f, 1f)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertWorldToLocalRect(localToWorld_rotate_Zninety, rect_seven_negativeSeven),
+                Is.EqualTo(new Rect(0f, -7.000002f, 7.000002f, 7.000002f)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertWorldToLocalRect(localToWorld_rotate_Zninety, rect_zero_oneSeven),
+                Is.EqualTo(new Rect(0f, -1.000001f, 7.000001f, 1.000001f)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertWorldToLocalRect(localToWorld_rotate_Zninety, rect_zero_sevenOne),
+                Is.EqualTo(new Rect(0f, -7.000001f, 1.000001f, 7.000001f)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertWorldToLocalRect(localToWorld_rotate_Zninety, rect_zero_negativeOneSeven),
+                Is.EqualTo(new Rect(-7.000001f, 0f, 7.000001f, 1.000001f)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertWorldToLocalRect(localToWorld_rotate_Zninety, rect_zero_negativeSevenOne),
+                Is.EqualTo(new Rect(-1f, 0f, 1.000001f, 7.000001f)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertWorldToLocalRect(localToWorld_rotate_Zninety, rect_negativeOffset_seven),
+                Is.EqualTo(new Rect(-14f, 7.000002f, 7.000002f, 7.000002f)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertWorldToLocalRect(localToWorld_rotate_Zninety, rect_negativeOffset_negativeSeven),
+                Is.EqualTo(new Rect(-21f, 14f, 7f, 7f)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertWorldToLocalRect(localToWorld_rotate_Zninety, rect_centered_seven),
+                Is.EqualTo(new Rect(-3.500001f, -3.500001f, 7.000002f, 7.000002f)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertWorldToLocalRect(localToWorld_rotate_Zninety, rect_centered_negativeSeven),
+                Is.EqualTo(new Rect(-10.5f, 3.500001f, 7f, 7.000001f)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertWorldToLocalRect(localToWorld_rotate_Zninety, rect_centered_negativePositiveSeven),
+                Is.EqualTo(new Rect(-3.5f, 3.5f, 7.000001f, 7.000002f)).Using<Rect>(EquivalencyWithTolerance)
+                );
+        }
+
+        [Test]
+        public static void ConvertWorldToLocalRectTest_Scale()
+        {
+            Regex invalidMatrixError_rect = new Regex(@"This transform is invalid\. Returning infinite min/max rect\.");
+
+            float3 point_zero = float3.zero;
+            float3 point_one = new float3(1f);
+
+            Rect rect_zero_zero = Rect.zero;
+
+            Rect rect_zero_one = new Rect(0, 0, 1, 1);
+
+            Rect rect_seven_seven = new Rect(7, 7, 7, 7);
+            Rect rect_seven_negativeSeven = new Rect(7, 7, -7, -7);
+
+            Rect rect_zero_oneSeven = new Rect(0, 0, 1, 7);
+            Rect rect_zero_sevenOne = new Rect(0, 0, 7, 1);
+            Rect rect_zero_negativeOneSeven = new Rect(0, 0, -1, -7);
+            Rect rect_zero_negativeSevenOne = new Rect(0, 0, -7, -1);
+
+            Rect rect_negativeOffset_seven = new Rect(-14, -14, 7, 7);
+            Rect rect_negativeOffset_negativeSeven = new Rect(-14, -14, -7, -7);
+
+            Rect rect_centered_seven = new Rect(-3.5f, -3.5f, 7, 7);
+            Rect rect_centered_negativeSeven = new Rect(-3.5f, -3.5f, -7, -7);
+
+            Rect rect_centered_negativePositiveSeven = new Rect(-3.5f, -3.5f, -7, 7);
+
+            float3 scale_two = new float3(2f);
+            float3 scale_negativeTwo = -scale_two;
+            float3 scale_twoNegativeZ = new float3(2f,2f,-2f);
+            float3 scale_ZnegativeTwo = new float3(point_one.xy, -2f);
+            float3 scale_ZXonePointFive = new float3(1.5f, 1f, 1.5f);
+            float3 scale_zero = float3.zero;
+
+
+            LocalToWorld localToWorld_scale_two = new LocalToWorld()
+            {
+                Value = float4x4.TRS(point_zero, quaternion.identity, scale_two)
+            };
+
+            Assert.That(
+                 TransformUtil.ConvertWorldToLocalRect(localToWorld_scale_two, rect_zero_zero),
+                 Is.EqualTo(new Rect(0f, 0f, 0f, 0f)).Using<Rect>(EquivalencyWithTolerance)
+                 );
+             Assert.That(
+                 TransformUtil.ConvertWorldToLocalRect(localToWorld_scale_two, rect_seven_seven),
+                 Is.EqualTo(new Rect(3.5f, 3.5f, 3.5f, 3.5f)).Using<Rect>(EquivalencyWithTolerance)
+                 );
+             Assert.That(
+                 TransformUtil.ConvertWorldToLocalRect(localToWorld_scale_two, rect_zero_one),
+                 Is.EqualTo(new Rect(0f, 0f, 0.5f, 0.5f)).Using<Rect>(EquivalencyWithTolerance)
+                 );
+             Assert.That(
+                 TransformUtil.ConvertWorldToLocalRect(localToWorld_scale_two, rect_seven_negativeSeven),
+                 Is.EqualTo(new Rect(0f, 0f, 3.5f, 3.5f)).Using<Rect>(EquivalencyWithTolerance)
+                 );
+             Assert.That(
+                 TransformUtil.ConvertWorldToLocalRect(localToWorld_scale_two, rect_zero_oneSeven),
+                 Is.EqualTo(new Rect(0f, 0f, 0.5f, 3.5f)).Using<Rect>(EquivalencyWithTolerance)
+                 );
+             Assert.That(
+                 TransformUtil.ConvertWorldToLocalRect(localToWorld_scale_two, rect_zero_sevenOne),
+                 Is.EqualTo(new Rect(0f, 0f, 3.5f, 0.5f)).Using<Rect>(EquivalencyWithTolerance)
+                 );
+             Assert.That(
+                 TransformUtil.ConvertWorldToLocalRect(localToWorld_scale_two, rect_zero_negativeOneSeven),
+                 Is.EqualTo(new Rect(-0.5f, -3.5f, 0.5f, 3.5f)).Using<Rect>(EquivalencyWithTolerance)
+                 );
+             Assert.That(
+                 TransformUtil.ConvertWorldToLocalRect(localToWorld_scale_two, rect_zero_negativeSevenOne),
+                 Is.EqualTo(new Rect(-3.5f, -0.5f, 3.5f, 0.5f)).Using<Rect>(EquivalencyWithTolerance)
+                 );
+             Assert.That(
+                 TransformUtil.ConvertWorldToLocalRect(localToWorld_scale_two, rect_negativeOffset_seven),
+                 Is.EqualTo(new Rect(-7f, -7f, 3.5f, 3.5f)).Using<Rect>(EquivalencyWithTolerance)
+                 );
+             Assert.That(
+                 TransformUtil.ConvertWorldToLocalRect(localToWorld_scale_two, rect_negativeOffset_negativeSeven),
+                 Is.EqualTo(new Rect(-10.5f, -10.5f, 3.5f, 3.5f)).Using<Rect>(EquivalencyWithTolerance)
+                 );
+             Assert.That(
+                 TransformUtil.ConvertWorldToLocalRect(localToWorld_scale_two, rect_centered_seven),
+                 Is.EqualTo(new Rect(-1.75f, -1.75f, 3.5f, 3.5f)).Using<Rect>(EquivalencyWithTolerance)
+                 );
+             Assert.That(
+                 TransformUtil.ConvertWorldToLocalRect(localToWorld_scale_two, rect_centered_negativeSeven),
+                 Is.EqualTo(new Rect(-5.25f, -5.25f, 3.5f, 3.5f)).Using<Rect>(EquivalencyWithTolerance)
+                 );
+             Assert.That(
+                 TransformUtil.ConvertWorldToLocalRect(localToWorld_scale_two, rect_centered_negativePositiveSeven),
+                 Is.EqualTo(new Rect(-5.25f, -1.75f, 3.5f, 3.5f)).Using<Rect>(EquivalencyWithTolerance)
+                 );
+
+
+            LocalToWorld localToWorld_scale_negativeTwo = new LocalToWorld()
+            {
+                Value = float4x4.TRS(point_zero, quaternion.identity, scale_negativeTwo)
+            };
+
+            Assert.That(
+                 TransformUtil.ConvertWorldToLocalRect(localToWorld_scale_negativeTwo, rect_zero_zero),
+                 Is.EqualTo(new Rect(0f, 0f, 0f, 0f)).Using<Rect>(EquivalencyWithTolerance)
+                 );
+             Assert.That(
+                 TransformUtil.ConvertWorldToLocalRect(localToWorld_scale_negativeTwo, rect_seven_seven),
+                 Is.EqualTo(new Rect(-7f, -7f, 3.5f, 3.5f)).Using<Rect>(EquivalencyWithTolerance)
+                 );
+             Assert.That(
+                 TransformUtil.ConvertWorldToLocalRect(localToWorld_scale_negativeTwo, rect_zero_one),
+                 Is.EqualTo(new Rect(-0.5f, -0.5f, 0.5f, 0.5f)).Using<Rect>(EquivalencyWithTolerance)
+                 );
+             Assert.That(
+                 TransformUtil.ConvertWorldToLocalRect(localToWorld_scale_negativeTwo, rect_seven_negativeSeven),
+                 Is.EqualTo(new Rect(-3.5f, -3.5f, 3.5f, 3.5f)).Using<Rect>(EquivalencyWithTolerance)
+                 );
+             Assert.That(
+                 TransformUtil.ConvertWorldToLocalRect(localToWorld_scale_negativeTwo, rect_zero_oneSeven),
+                 Is.EqualTo(new Rect(-0.5f, -3.5f, 0.5f, 3.5f)).Using<Rect>(EquivalencyWithTolerance)
+                 );
+             Assert.That(
+                 TransformUtil.ConvertWorldToLocalRect(localToWorld_scale_negativeTwo, rect_zero_sevenOne),
+                 Is.EqualTo(new Rect(-3.5f, -0.5f, 3.5f, 0.5f)).Using<Rect>(EquivalencyWithTolerance)
+                 );
+             Assert.That(
+                 TransformUtil.ConvertWorldToLocalRect(localToWorld_scale_negativeTwo, rect_zero_negativeOneSeven),
+                 Is.EqualTo(new Rect(0f, 0f, 0.5f, 3.5f)).Using<Rect>(EquivalencyWithTolerance)
+                 );
+             Assert.That(
+                 TransformUtil.ConvertWorldToLocalRect(localToWorld_scale_negativeTwo, rect_zero_negativeSevenOne),
+                 Is.EqualTo(new Rect(0f, 0f, 3.5f, 0.5f)).Using<Rect>(EquivalencyWithTolerance)
+                 );
+             Assert.That(
+                 TransformUtil.ConvertWorldToLocalRect(localToWorld_scale_negativeTwo, rect_negativeOffset_seven),
+                 Is.EqualTo(new Rect(3.5f, 3.5f, 3.5f, 3.5f)).Using<Rect>(EquivalencyWithTolerance)
+                 );
+             Assert.That(
+                 TransformUtil.ConvertWorldToLocalRect(localToWorld_scale_negativeTwo, rect_negativeOffset_negativeSeven),
+                 Is.EqualTo(new Rect(7f, 7f, 3.5f, 3.5f)).Using<Rect>(EquivalencyWithTolerance)
+                 );
+             Assert.That(
+                 TransformUtil.ConvertWorldToLocalRect(localToWorld_scale_negativeTwo, rect_centered_seven),
+                 Is.EqualTo(new Rect(-1.75f, -1.75f, 3.5f, 3.5f)).Using<Rect>(EquivalencyWithTolerance)
+                 );
+             Assert.That(
+                 TransformUtil.ConvertWorldToLocalRect(localToWorld_scale_negativeTwo, rect_centered_negativeSeven),
+                 Is.EqualTo(new Rect(1.75f, 1.75f, 3.5f, 3.5f)).Using<Rect>(EquivalencyWithTolerance)
+                 );
+             Assert.That(
+                 TransformUtil.ConvertWorldToLocalRect(localToWorld_scale_negativeTwo, rect_centered_negativePositiveSeven),
+                 Is.EqualTo(new Rect(1.75f, -1.75f, 3.5f, 3.5f)).Using<Rect>(EquivalencyWithTolerance)
+                 );
+
+
+            LocalToWorld localToWorld_scale_twoNegativeZ = new LocalToWorld()
+            {
+                Value = float4x4.TRS(point_zero, quaternion.identity, scale_twoNegativeZ)
+            };
+
+            Assert.That(
+                 TransformUtil.ConvertWorldToLocalRect(localToWorld_scale_twoNegativeZ, rect_zero_zero),
+                 Is.EqualTo(new Rect(0f, 0f, 0f, 0f)).Using<Rect>(EquivalencyWithTolerance)
+                 );
+             Assert.That(
+                 TransformUtil.ConvertWorldToLocalRect(localToWorld_scale_twoNegativeZ, rect_seven_seven),
+                 Is.EqualTo(new Rect(3.5f, 3.5f, 3.5f, 3.5f)).Using<Rect>(EquivalencyWithTolerance)
+                 );
+             Assert.That(
+                 TransformUtil.ConvertWorldToLocalRect(localToWorld_scale_twoNegativeZ, rect_zero_one),
+                 Is.EqualTo(new Rect(0f, 0f, 0.5f, 0.5f)).Using<Rect>(EquivalencyWithTolerance)
+                 );
+             Assert.That(
+                 TransformUtil.ConvertWorldToLocalRect(localToWorld_scale_twoNegativeZ, rect_seven_negativeSeven),
+                 Is.EqualTo(new Rect(0f, 0f, 3.5f, 3.5f)).Using<Rect>(EquivalencyWithTolerance)
+                 );
+             Assert.That(
+                 TransformUtil.ConvertWorldToLocalRect(localToWorld_scale_twoNegativeZ, rect_zero_oneSeven),
+                 Is.EqualTo(new Rect(0f, 0f, 0.5f, 3.5f)).Using<Rect>(EquivalencyWithTolerance)
+                 );
+             Assert.That(
+                 TransformUtil.ConvertWorldToLocalRect(localToWorld_scale_twoNegativeZ, rect_zero_sevenOne),
+                 Is.EqualTo(new Rect(0f, 0f, 3.5f, 0.5f)).Using<Rect>(EquivalencyWithTolerance)
+                 );
+             Assert.That(
+                 TransformUtil.ConvertWorldToLocalRect(localToWorld_scale_twoNegativeZ, rect_zero_negativeOneSeven),
+                 Is.EqualTo(new Rect(-0.5f, -3.5f, 0.5f, 3.5f)).Using<Rect>(EquivalencyWithTolerance)
+                 );
+             Assert.That(
+                 TransformUtil.ConvertWorldToLocalRect(localToWorld_scale_twoNegativeZ, rect_zero_negativeSevenOne),
+                 Is.EqualTo(new Rect(-3.5f, -0.5f, 3.5f, 0.5f)).Using<Rect>(EquivalencyWithTolerance)
+                 );
+             Assert.That(
+                 TransformUtil.ConvertWorldToLocalRect(localToWorld_scale_twoNegativeZ, rect_negativeOffset_seven),
+                 Is.EqualTo(new Rect(-7f, -7f, 3.5f, 3.5f)).Using<Rect>(EquivalencyWithTolerance)
+                 );
+             Assert.That(
+                 TransformUtil.ConvertWorldToLocalRect(localToWorld_scale_twoNegativeZ, rect_negativeOffset_negativeSeven),
+                 Is.EqualTo(new Rect(-10.5f, -10.5f, 3.5f, 3.5f)).Using<Rect>(EquivalencyWithTolerance)
+                 );
+             Assert.That(
+                 TransformUtil.ConvertWorldToLocalRect(localToWorld_scale_twoNegativeZ, rect_centered_seven),
+                 Is.EqualTo(new Rect(-1.75f, -1.75f, 3.5f, 3.5f)).Using<Rect>(EquivalencyWithTolerance)
+                 );
+             Assert.That(
+                 TransformUtil.ConvertWorldToLocalRect(localToWorld_scale_twoNegativeZ, rect_centered_negativeSeven),
+                 Is.EqualTo(new Rect(-5.25f, -5.25f, 3.5f, 3.5f)).Using<Rect>(EquivalencyWithTolerance)
+                 );
+             Assert.That(
+                 TransformUtil.ConvertWorldToLocalRect(localToWorld_scale_twoNegativeZ, rect_centered_negativePositiveSeven),
+                 Is.EqualTo(new Rect(-5.25f, -1.75f, 3.5f, 3.5f)).Using<Rect>(EquivalencyWithTolerance)
+                 );
+
+
+            LocalToWorld localToWorld_scale_ZnegativeTwo = new LocalToWorld()
+            {
+                Value = float4x4.TRS(point_zero, quaternion.identity, scale_ZnegativeTwo)
+            };
+
+            Assert.That(
+                 TransformUtil.ConvertWorldToLocalRect(localToWorld_scale_ZnegativeTwo, rect_zero_zero),
+                 Is.EqualTo(new Rect(0f, 0f, 0f, 0f)).Using<Rect>(EquivalencyWithTolerance)
+                 );
+             Assert.That(
+                 TransformUtil.ConvertWorldToLocalRect(localToWorld_scale_ZnegativeTwo, rect_seven_seven),
+                 Is.EqualTo(new Rect(7f, 7f, 7f, 7f)).Using<Rect>(EquivalencyWithTolerance)
+                 );
+             Assert.That(
+                 TransformUtil.ConvertWorldToLocalRect(localToWorld_scale_ZnegativeTwo, rect_zero_one),
+                 Is.EqualTo(new Rect(0f, 0f, 1f, 1f)).Using<Rect>(EquivalencyWithTolerance)
+                 );
+             Assert.That(
+                 TransformUtil.ConvertWorldToLocalRect(localToWorld_scale_ZnegativeTwo, rect_seven_negativeSeven),
+                 Is.EqualTo(new Rect(0f, 0f, 7f, 7f)).Using<Rect>(EquivalencyWithTolerance)
+                 );
+             Assert.That(
+                 TransformUtil.ConvertWorldToLocalRect(localToWorld_scale_ZnegativeTwo, rect_zero_oneSeven),
+                 Is.EqualTo(new Rect(0f, 0f, 1f, 7f)).Using<Rect>(EquivalencyWithTolerance)
+                 );
+             Assert.That(
+                 TransformUtil.ConvertWorldToLocalRect(localToWorld_scale_ZnegativeTwo, rect_zero_sevenOne),
+                 Is.EqualTo(new Rect(0f, 0f, 7f, 1f)).Using<Rect>(EquivalencyWithTolerance)
+                 );
+             Assert.That(
+                 TransformUtil.ConvertWorldToLocalRect(localToWorld_scale_ZnegativeTwo, rect_zero_negativeOneSeven),
+                 Is.EqualTo(new Rect(-1f, -7f, 1f, 7f)).Using<Rect>(EquivalencyWithTolerance)
+                 );
+             Assert.That(
+                 TransformUtil.ConvertWorldToLocalRect(localToWorld_scale_ZnegativeTwo, rect_zero_negativeSevenOne),
+                 Is.EqualTo(new Rect(-7f, -1f, 7f, 1f)).Using<Rect>(EquivalencyWithTolerance)
+                 );
+             Assert.That(
+                 TransformUtil.ConvertWorldToLocalRect(localToWorld_scale_ZnegativeTwo, rect_negativeOffset_seven),
+                 Is.EqualTo(new Rect(-14f, -14f, 7f, 7f)).Using<Rect>(EquivalencyWithTolerance)
+                 );
+             Assert.That(
+                 TransformUtil.ConvertWorldToLocalRect(localToWorld_scale_ZnegativeTwo, rect_negativeOffset_negativeSeven),
+                 Is.EqualTo(new Rect(-21f, -21f, 7f, 7f)).Using<Rect>(EquivalencyWithTolerance)
+                 );
+             Assert.That(
+                 TransformUtil.ConvertWorldToLocalRect(localToWorld_scale_ZnegativeTwo, rect_centered_seven),
+                 Is.EqualTo(new Rect(-3.5f, -3.5f, 7f, 7f)).Using<Rect>(EquivalencyWithTolerance)
+                 );
+             Assert.That(
+                 TransformUtil.ConvertWorldToLocalRect(localToWorld_scale_ZnegativeTwo, rect_centered_negativeSeven),
+                 Is.EqualTo(new Rect(-10.5f, -10.5f, 7f, 7f)).Using<Rect>(EquivalencyWithTolerance)
+                 );
+             Assert.That(
+                 TransformUtil.ConvertWorldToLocalRect(localToWorld_scale_ZnegativeTwo, rect_centered_negativePositiveSeven),
+                 Is.EqualTo(new Rect(-10.5f, -3.5f, 7f, 7f)).Using<Rect>(EquivalencyWithTolerance)
+                 );
+
+
+            LocalToWorld localToWorld_scale_ZXonePointFive = new LocalToWorld()
+            {
+                Value = float4x4.TRS(point_zero, quaternion.identity, scale_ZXonePointFive)
+            };
+
+            Assert.That(
+                 TransformUtil.ConvertWorldToLocalRect(localToWorld_scale_ZXonePointFive, rect_zero_zero),
+                 Is.EqualTo(new Rect(0f, 0f, 0f, 0f)).Using<Rect>(EquivalencyWithTolerance)
+                 );
+             Assert.That(
+                 TransformUtil.ConvertWorldToLocalRect(localToWorld_scale_ZXonePointFive, rect_seven_seven),
+                 Is.EqualTo(new Rect(4.666667f, 7f, 4.666667f, 7f)).Using<Rect>(EquivalencyWithTolerance)
+                 );
+             Assert.That(
+                 TransformUtil.ConvertWorldToLocalRect(localToWorld_scale_ZXonePointFive, rect_zero_one),
+                 Is.EqualTo(new Rect(0f, 0f, 0.6666667f, 1f)).Using<Rect>(EquivalencyWithTolerance)
+                 );
+             Assert.That(
+                 TransformUtil.ConvertWorldToLocalRect(localToWorld_scale_ZXonePointFive, rect_seven_negativeSeven),
+                 Is.EqualTo(new Rect(0f, 0f, 4.666667f, 7f)).Using<Rect>(EquivalencyWithTolerance)
+                 );
+             Assert.That(
+                 TransformUtil.ConvertWorldToLocalRect(localToWorld_scale_ZXonePointFive, rect_zero_oneSeven),
+                 Is.EqualTo(new Rect(0f, 0f, 0.6666667f, 7f)).Using<Rect>(EquivalencyWithTolerance)
+                 );
+             Assert.That(
+                 TransformUtil.ConvertWorldToLocalRect(localToWorld_scale_ZXonePointFive, rect_zero_sevenOne),
+                 Is.EqualTo(new Rect(0f, 0f, 4.666667f, 1f)).Using<Rect>(EquivalencyWithTolerance)
+                 );
+             Assert.That(
+                 TransformUtil.ConvertWorldToLocalRect(localToWorld_scale_ZXonePointFive, rect_zero_negativeOneSeven),
+                 Is.EqualTo(new Rect(-0.6666667f, -7f, 0.6666667f, 7f)).Using<Rect>(EquivalencyWithTolerance)
+                 );
+             Assert.That(
+                 TransformUtil.ConvertWorldToLocalRect(localToWorld_scale_ZXonePointFive, rect_zero_negativeSevenOne),
+                 Is.EqualTo(new Rect(-4.666667f, -1f, 4.666667f, 1f)).Using<Rect>(EquivalencyWithTolerance)
+                 );
+             Assert.That(
+                 TransformUtil.ConvertWorldToLocalRect(localToWorld_scale_ZXonePointFive, rect_negativeOffset_seven),
+                 Is.EqualTo(new Rect(-9.333334f, -14f, 4.666667f, 7f)).Using<Rect>(EquivalencyWithTolerance)
+                 );
+             Assert.That(
+                 TransformUtil.ConvertWorldToLocalRect(localToWorld_scale_ZXonePointFive, rect_negativeOffset_negativeSeven),
+                 Is.EqualTo(new Rect(-14f, -21f, 4.666666f, 7f)).Using<Rect>(EquivalencyWithTolerance)
+                 );
+             Assert.That(
+                 TransformUtil.ConvertWorldToLocalRect(localToWorld_scale_ZXonePointFive, rect_centered_seven),
+                 Is.EqualTo(new Rect(-2.333333f, -3.5f, 4.666667f, 7f)).Using<Rect>(EquivalencyWithTolerance)
+                 );
+             Assert.That(
+                 TransformUtil.ConvertWorldToLocalRect(localToWorld_scale_ZXonePointFive, rect_centered_negativeSeven),
+                 Is.EqualTo(new Rect(-7f, -10.5f, 4.666667f, 7f)).Using<Rect>(EquivalencyWithTolerance)
+                 );
+             Assert.That(
+                 TransformUtil.ConvertWorldToLocalRect(localToWorld_scale_ZXonePointFive, rect_centered_negativePositiveSeven),
+                 Is.EqualTo(new Rect(-7f, -3.5f, 4.666667f, 7f)).Using<Rect>(EquivalencyWithTolerance)
+                 );
+
+
+            LocalToWorld localToWorld_scale_zero = new LocalToWorld()
+            {
+                Value = float4x4.TRS(point_zero, quaternion.identity, scale_zero)
+            };
+            Rect rect_infinity = Rect.MinMaxRect(
+                float.NegativeInfinity,
+                float.NegativeInfinity,
+                float.PositiveInfinity,
+                float.PositiveInfinity);
+
+            Logger.Debug("BEGIN: Expected error messages.");
+            LogAssert.Expect(LogType.Error, invalidMatrixError_rect);
+            Assert.That(
+                 TransformUtil.ConvertWorldToLocalRect(localToWorld_scale_zero, rect_zero_zero),
+                 Is.EqualTo(rect_infinity)
+                 );
+            LogAssert.Expect(LogType.Error, invalidMatrixError_rect);
+             Assert.That(
+                 TransformUtil.ConvertWorldToLocalRect(localToWorld_scale_zero, rect_seven_seven),
+                 Is.EqualTo(rect_infinity)
+                 );
+             LogAssert.Expect(LogType.Error, invalidMatrixError_rect);
+             Assert.That(
+                 TransformUtil.ConvertWorldToLocalRect(localToWorld_scale_zero, rect_zero_one),
+                 Is.EqualTo(rect_infinity)
+                 );
+             LogAssert.Expect(LogType.Error, invalidMatrixError_rect);
+             Assert.That(
+                 TransformUtil.ConvertWorldToLocalRect(localToWorld_scale_zero, rect_seven_negativeSeven),
+                 Is.EqualTo(rect_infinity)
+                 );
+             LogAssert.Expect(LogType.Error, invalidMatrixError_rect);
+             Assert.That(
+                 TransformUtil.ConvertWorldToLocalRect(localToWorld_scale_zero, rect_zero_oneSeven),
+                 Is.EqualTo(rect_infinity)
+                 );
+             LogAssert.Expect(LogType.Error, invalidMatrixError_rect);
+             Assert.That(
+                 TransformUtil.ConvertWorldToLocalRect(localToWorld_scale_zero, rect_zero_sevenOne),
+                 Is.EqualTo(rect_infinity)
+                 );
+             LogAssert.Expect(LogType.Error, invalidMatrixError_rect);
+             Assert.That(
+                 TransformUtil.ConvertWorldToLocalRect(localToWorld_scale_zero, rect_zero_negativeOneSeven),
+                 Is.EqualTo(rect_infinity)
+                 );
+             LogAssert.Expect(LogType.Error, invalidMatrixError_rect);
+             Assert.That(
+                 TransformUtil.ConvertWorldToLocalRect(localToWorld_scale_zero, rect_zero_negativeSevenOne),
+                 Is.EqualTo(rect_infinity)
+                 );
+             LogAssert.Expect(LogType.Error, invalidMatrixError_rect);
+             Assert.That(
+                 TransformUtil.ConvertWorldToLocalRect(localToWorld_scale_zero, rect_negativeOffset_seven),
+                 Is.EqualTo(rect_infinity)
+                 );
+             LogAssert.Expect(LogType.Error, invalidMatrixError_rect);
+             Assert.That(
+                 TransformUtil.ConvertWorldToLocalRect(localToWorld_scale_zero, rect_negativeOffset_negativeSeven),
+                 Is.EqualTo(rect_infinity)
+                 );
+             LogAssert.Expect(LogType.Error, invalidMatrixError_rect);
+             Assert.That(
+                 TransformUtil.ConvertWorldToLocalRect(localToWorld_scale_zero, rect_centered_seven),
+                 Is.EqualTo(rect_infinity)
+                 );
+             LogAssert.Expect(LogType.Error, invalidMatrixError_rect);
+             Assert.That(
+                 TransformUtil.ConvertWorldToLocalRect(localToWorld_scale_zero, rect_centered_negativeSeven),
+                 Is.EqualTo(rect_infinity)
+                 );
+             LogAssert.Expect(LogType.Error, invalidMatrixError_rect);
+             Assert.That(
+                TransformUtil.ConvertWorldToLocalRect(localToWorld_scale_zero, rect_centered_negativePositiveSeven),
+                Is.EqualTo(rect_infinity)
+                 );
+             Logger.Debug("END: Expected error messages.");
+        }
+
+        [Test]
+        public static void ConvertWorldToLocalRectTest_Compound()
+        {
+            Rect rect_zero_zero = Rect.zero;
+
+            Rect rect_zero_one = new Rect(0, 0, 1, 1);
+
+            Rect rect_seven_seven = new Rect(7, 7, 7, 7);
+            Rect rect_seven_negativeSeven = new Rect(7, 7, -7, -7);
+
+            Rect rect_zero_oneSeven = new Rect(0, 0, 1, 7);
+            Rect rect_zero_sevenOne = new Rect(0, 0, 7, 1);
+            Rect rect_zero_negativeOneSeven = new Rect(0, 0, -1, -7);
+            Rect rect_zero_negativeSevenOne = new Rect(0, 0, -7, -1);
+
+            Rect rect_negativeOffset_seven = new Rect(-14, -14, 7, 7);
+            Rect rect_negativeOffset_negativeSeven = new Rect(-14, -14, -7, -7);
+
+            Rect rect_centered_seven = new Rect(-3.5f, -3.5f, 7, 7);
+            Rect rect_centered_negativeSeven = new Rect(-3.5f, -3.5f, -7, -7);
+
+            Rect rect_centered_negativePositiveSeven = new Rect(-3.5f, -3.5f, -7, 7);
+
+            float3 point_XYseven = new float3(7f, 7f, 0f);
+            float3 scale_XnegativeOnePointFive_ZOnePointFive = new float3(-1.5f, 1f, 1.5f);
+            quaternion rotation_fortyFive = quaternion.Euler(math.radians(45f), math.radians(45f), math.radians(45f));
+
+
+            LocalToWorld localToWorld_compound = new LocalToWorld
+            {
+                Value = float4x4.TRS(point_XYseven, rotation_fortyFive, scale_XnegativeOnePointFive_ZOnePointFive)
+            };
+
+            Assert.That(
+                TransformUtil.ConvertWorldToLocalRect(localToWorld_compound, rect_zero_zero),
+                Is.EqualTo(new Rect(6.316583f, -2.474874f, 0f, 0f)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertWorldToLocalRect(localToWorld_compound, rect_seven_seven),
+                Is.EqualTo(new Rect(-6.316583f, -1.025126f, 6.316583f, 4.525126f)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertWorldToLocalRect(localToWorld_compound, rect_zero_one),
+                Is.EqualTo(new Rect(5.414214f, -2.62132f, 0.9023685f, 0.6464467f)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertWorldToLocalRect(localToWorld_compound, rect_seven_negativeSeven),
+                Is.EqualTo(new Rect(0f, -3.5f, 6.316583f, 4.525126f)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertWorldToLocalRect(localToWorld_compound, rect_zero_oneSeven),
+                Is.EqualTo(new Rect(3.414214f, -2.62132f, 2.902369f, 3.646446f)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertWorldToLocalRect(localToWorld_compound, rect_zero_sevenOne),
+                Is.EqualTo(new Rect(2f, -3.5f, 4.316583f, 1.525126f)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertWorldToLocalRect(localToWorld_compound, rect_zero_negativeOneSeven),
+                Is.EqualTo(new Rect(6.316583f, -5.974873f, 2.902369f, 3.646446f)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertWorldToLocalRect(localToWorld_compound, rect_zero_negativeSevenOne),
+                Is.EqualTo(new Rect(6.316583f, -2.974874f, 4.316583f, 1.525126f)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertWorldToLocalRect(localToWorld_compound, rect_negativeOffset_seven),
+                Is.EqualTo(new Rect(12.63317f, -8.449746f, 6.316584f, 4.525126f)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertWorldToLocalRect(localToWorld_compound, rect_negativeOffset_negativeSeven),
+                Is.EqualTo(new Rect(18.94975f, -10.92462f, 6.316582f, 4.525125f)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertWorldToLocalRect(localToWorld_compound, rect_centered_seven),
+                Is.EqualTo(new Rect(3.158291f, -4.737437f, 6.316583f, 4.525126f)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertWorldToLocalRect(localToWorld_compound, rect_centered_negativeSeven),
+                Is.EqualTo(new Rect(9.474874f, -7.21231f, 6.316582f, 4.525126f)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertWorldToLocalRect(localToWorld_compound, rect_centered_negativePositiveSeven),
+                Is.EqualTo(new Rect(7.141541f, -3.71231f, 6.316582f, 4.525126f)).Using<Rect>(EquivalencyWithTolerance)
+                );
+
+
+            LocalToWorld localToWorld_compoundNegative = new LocalToWorld
+            {
+                Value = float4x4.TRS(-point_XYseven, math.inverse(rotation_fortyFive), -scale_XnegativeOnePointFive_ZOnePointFive)
+            };
+
+            Assert.That(
+                TransformUtil.ConvertWorldToLocalRect(localToWorld_compoundNegative, rect_zero_zero),
+                Is.EqualTo(new Rect(3.299832f, -7f, 0f, 0f)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertWorldToLocalRect(localToWorld_compoundNegative, rect_seven_seven),
+                Is.EqualTo(new Rect(5.916246f, -21f, 4.666667f, 7.000001f)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertWorldToLocalRect(localToWorld_compoundNegative, rect_zero_one),
+                Is.EqualTo(new Rect(3.202201f, -8f, 0.666667f, 1f)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertWorldToLocalRect(localToWorld_compoundNegative, rect_seven_negativeSeven),
+                Is.EqualTo(new Rect(2.616414f, -14f, 4.666666f, 7f)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertWorldToLocalRect(localToWorld_compoundNegative, rect_zero_oneSeven),
+                Is.EqualTo(new Rect(2.616414f, -11f, 1.252453f, 4f)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertWorldToLocalRect(localToWorld_compoundNegative, rect_zero_sevenOne),
+                Is.EqualTo(new Rect(3.202201f, -11f, 4.08088f, 4f)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertWorldToLocalRect(localToWorld_compoundNegative, rect_zero_negativeOneSeven),
+                Is.EqualTo(new Rect(2.730796f, -7f, 1.252453f, 4f)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertWorldToLocalRect(localToWorld_compoundNegative, rect_zero_negativeSevenOne),
+                Is.EqualTo(new Rect(-0.6834174f, -7f, 4.08088f, 4f)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertWorldToLocalRect(localToWorld_compoundNegative, rect_negativeOffset_seven),
+                Is.EqualTo(new Rect(-3.983249f, 0f, 4.666667f, 7f)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertWorldToLocalRect(localToWorld_compoundNegative, rect_negativeOffset_negativeSeven),
+                Is.EqualTo(new Rect(-7.283081f, 7f, 4.666666f, 7f)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertWorldToLocalRect(localToWorld_compoundNegative, rect_centered_seven),
+                Is.EqualTo(new Rect(0.9664984f, -10.5f, 4.666667f, 7f)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertWorldToLocalRect(localToWorld_compoundNegative, rect_centered_negativeSeven),
+                Is.EqualTo(new Rect(-2.333333f, -3.5f, 4.666667f, 7f)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertWorldToLocalRect(localToWorld_compoundNegative, rect_centered_negativePositiveSeven),
+                Is.EqualTo(new Rect(-3.016751f, -7f, 4.666667f, 7f)).Using<Rect>(EquivalencyWithTolerance)
+                );
+        }
+
+        // ----- ConvertWorldToLocalRect ----- //
+        [Test]
+        public static void ConvertLocalToWorldRectTest_Identity()
+        {
+            float3 point_zero = float3.zero;
+            float3 point_one = new float3(1f);
+            float3 point_seven = new float3(7f);
+
+            Rect rect_zero_zero = Rect.zero;
+
+            Rect rect_zero_one = new Rect(0, 0, 1, 1);
+
+            Rect rect_seven_seven = new Rect(7, 7, 7, 7);
+            Rect rect_seven_negativeSeven = new Rect(7, 7, -7, -7);
+
+            Rect rect_zero_oneSeven = new Rect(0, 0, 1, 7);
+            Rect rect_zero_sevenOne = new Rect(0, 0, 7, 1);
+            Rect rect_zero_negativeOneSeven = new Rect(0, 0, -1, -7);
+            Rect rect_zero_negativeSevenOne = new Rect(0, 0, -7, -1);
+
+            Rect rect_negativeOffset_seven = new Rect(-14, -14, 7, 7);
+            Rect rect_negativeOffset_negativeSeven = new Rect(-14, -14, -7, -7);
+
+            Rect rect_centered_seven = new Rect(-3.5f, -3.5f, 7, 7);
+            Rect rect_centered_negativeSeven = new Rect(-3.5f, -3.5f, -7, -7);
+
+            Rect rect_centered_negativePositiveSeven = new Rect(-3.5f, -3.5f, -7, 7);
+
+
+            LocalToWorld localToWorld_identity = new LocalToWorld()
+            {
+                Value = float4x4.TRS(point_zero, quaternion.identity, point_one)
+            };
+
+            Assert.That(TransformUtil.ConvertLocalToWorldRect(localToWorld_identity, rect_zero_zero), Is.EqualTo(rect_zero_zero).Using<Rect>(EquivalencyWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldRect(localToWorld_identity, rect_zero_one), Is.EqualTo(rect_zero_one).Using<Rect>(EquivalencyWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldRect(localToWorld_identity, rect_seven_seven), Is.EqualTo(rect_seven_seven).Using<Rect>(EquivalencyWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldRect(localToWorld_identity, rect_seven_negativeSeven), Is.EqualTo(rect_seven_negativeSeven).Using<Rect>(EquivalencyWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldRect(localToWorld_identity, rect_zero_oneSeven), Is.EqualTo(rect_zero_oneSeven).Using<Rect>(EquivalencyWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldRect(localToWorld_identity, rect_zero_sevenOne), Is.EqualTo(rect_zero_sevenOne).Using<Rect>(EquivalencyWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldRect(localToWorld_identity, rect_zero_negativeOneSeven), Is.EqualTo(rect_zero_negativeOneSeven).Using<Rect>(EquivalencyWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldRect(localToWorld_identity, rect_zero_negativeSevenOne), Is.EqualTo(rect_zero_negativeSevenOne).Using<Rect>(EquivalencyWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldRect(localToWorld_identity, rect_negativeOffset_seven), Is.EqualTo(rect_negativeOffset_seven).Using<Rect>(EquivalencyWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldRect(localToWorld_identity, rect_negativeOffset_negativeSeven), Is.EqualTo(rect_negativeOffset_negativeSeven).Using<Rect>(EquivalencyWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldRect(localToWorld_identity, rect_centered_seven), Is.EqualTo(rect_centered_seven).Using<Rect>(EquivalencyWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldRect(localToWorld_identity, rect_centered_negativeSeven), Is.EqualTo(rect_centered_negativeSeven).Using<Rect>(EquivalencyWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldRect(localToWorld_identity, rect_centered_negativePositiveSeven), Is.EqualTo(rect_centered_negativePositiveSeven).Using<Rect>(EquivalencyWithTolerance));
+        }
+
+        [Test]
+        public static void ConvertLocalToWorldRectTest_Translate()
+        {
+            float3 point_zero = float3.zero;
+            float3 point_one = new float3(1f);
+            float3 point_seven = new float3(7f);
+
+            Rect rect_zero_zero = Rect.zero;
+
+            Rect rect_zero_one = new Rect(0, 0, 1, 1);
+
+            Rect rect_seven_seven = new Rect(7, 7, 7, 7);
+            Rect rect_seven_negativeSeven = new Rect(7, 7, -7, -7);
+
+            Rect rect_zero_oneSeven = new Rect(0, 0, 1, 7);
+            Rect rect_zero_sevenOne = new Rect(0, 0, 7, 1);
+            Rect rect_zero_negativeOneSeven = new Rect(0, 0, -1, -7);
+            Rect rect_zero_negativeSevenOne = new Rect(0, 0, -7, -1);
+
+            Rect rect_negativeOffset_seven = new Rect(-14, -14, 7, 7);
+            Rect rect_negativeOffset_negativeSeven = new Rect(-14, -14, -7, -7);
+
+            Rect rect_centered_seven = new Rect(-3.5f, -3.5f, 7, 7);
+            Rect rect_centered_negativeSeven = new Rect(-3.5f, -3.5f, -7, -7);
+
+            Rect rect_centered_negativePositiveSeven = new Rect(-3.5f, -3.5f, -7, 7);
+
+
+            LocalToWorld localToWorld_translate = new LocalToWorld()
+            {
+                Value = float4x4.TRS(point_seven, quaternion.identity, point_one)
+            };
+            Vector2 localToWorld_translateTranslation = point_seven.xy;
+
+            Assert.That(
+                TransformUtil.ConvertLocalToWorldRect(localToWorld_translate, rect_zero_zero),
+                Is.EqualTo(new Rect(rect_zero_zero.position + localToWorld_translateTranslation, rect_zero_zero.size)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertLocalToWorldRect(localToWorld_translate, rect_seven_seven),
+                Is.EqualTo(new Rect(rect_seven_seven.position + localToWorld_translateTranslation, rect_seven_seven.size)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertLocalToWorldRect(localToWorld_translate, rect_zero_one),
+                Is.EqualTo(new Rect(rect_zero_one.position + localToWorld_translateTranslation, rect_zero_one.size)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertLocalToWorldRect(localToWorld_translate, rect_seven_negativeSeven),
+                Is.EqualTo(new Rect(rect_seven_negativeSeven.position + localToWorld_translateTranslation, rect_seven_negativeSeven.size)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertLocalToWorldRect(localToWorld_translate, rect_zero_oneSeven),
+                Is.EqualTo(new Rect(rect_zero_oneSeven.position + localToWorld_translateTranslation, rect_zero_oneSeven.size)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertLocalToWorldRect(localToWorld_translate, rect_zero_sevenOne),
+                Is.EqualTo(new Rect(rect_zero_sevenOne.position + localToWorld_translateTranslation, rect_zero_sevenOne.size)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertLocalToWorldRect(localToWorld_translate, rect_zero_negativeOneSeven),
+                Is.EqualTo(new Rect(rect_zero_negativeOneSeven.position + localToWorld_translateTranslation, rect_zero_negativeOneSeven.size)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertLocalToWorldRect(localToWorld_translate, rect_zero_negativeSevenOne),
+                Is.EqualTo(new Rect(rect_zero_negativeSevenOne.position + localToWorld_translateTranslation, rect_zero_negativeSevenOne.size)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertLocalToWorldRect(localToWorld_translate, rect_negativeOffset_seven),
+                Is.EqualTo(new Rect(rect_negativeOffset_seven.position + localToWorld_translateTranslation, rect_negativeOffset_seven.size)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertLocalToWorldRect(localToWorld_translate, rect_negativeOffset_negativeSeven),
+                Is.EqualTo(new Rect(rect_negativeOffset_negativeSeven.position + localToWorld_translateTranslation, rect_negativeOffset_negativeSeven.size)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertLocalToWorldRect(localToWorld_translate, rect_centered_seven),
+                Is.EqualTo(new Rect(rect_centered_seven.position + localToWorld_translateTranslation, rect_centered_seven.size)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertLocalToWorldRect(localToWorld_translate, rect_centered_negativeSeven),
+                Is.EqualTo(new Rect(rect_centered_negativeSeven.position + localToWorld_translateTranslation, rect_centered_negativeSeven.size)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertLocalToWorldRect(localToWorld_translate, rect_centered_negativePositiveSeven),
+                Is.EqualTo(new Rect(rect_centered_negativePositiveSeven.position + localToWorld_translateTranslation, rect_centered_negativePositiveSeven.size)).Using<Rect>(EquivalencyWithTolerance)
+                );
+
+
+            LocalToWorld localToWorld_negativeTranslate = new LocalToWorld()
+            {
+                Value = float4x4.TRS(-point_seven, quaternion.identity, point_one)
+            };
+            Vector2 localToWorld_negativeTranslateTranslation = -point_seven.xy;
+
+            Assert.That(
+                TransformUtil.ConvertLocalToWorldRect(localToWorld_negativeTranslate, rect_zero_zero),
+                Is.EqualTo(new Rect(rect_zero_zero.position + localToWorld_negativeTranslateTranslation, rect_zero_zero.size)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertLocalToWorldRect(localToWorld_negativeTranslate, rect_seven_seven),
+                Is.EqualTo(new Rect(rect_seven_seven.position + localToWorld_negativeTranslateTranslation, rect_seven_seven.size)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertLocalToWorldRect(localToWorld_negativeTranslate, rect_zero_one),
+                Is.EqualTo(new Rect(rect_zero_one.position + localToWorld_negativeTranslateTranslation, rect_zero_one.size)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertLocalToWorldRect(localToWorld_negativeTranslate, rect_seven_negativeSeven),
+                Is.EqualTo(new Rect(rect_seven_negativeSeven.position + localToWorld_negativeTranslateTranslation, rect_seven_negativeSeven.size)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertLocalToWorldRect(localToWorld_negativeTranslate, rect_zero_oneSeven),
+                Is.EqualTo(new Rect(rect_zero_oneSeven.position + localToWorld_negativeTranslateTranslation, rect_zero_oneSeven.size)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertLocalToWorldRect(localToWorld_negativeTranslate, rect_zero_sevenOne),
+                Is.EqualTo(new Rect(rect_zero_sevenOne.position + localToWorld_negativeTranslateTranslation, rect_zero_sevenOne.size)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertLocalToWorldRect(localToWorld_negativeTranslate, rect_zero_negativeOneSeven),
+                Is.EqualTo(new Rect(rect_zero_negativeOneSeven.position + localToWorld_negativeTranslateTranslation, rect_zero_negativeOneSeven.size)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertLocalToWorldRect(localToWorld_negativeTranslate, rect_zero_negativeSevenOne),
+                Is.EqualTo(new Rect(rect_zero_negativeSevenOne.position + localToWorld_negativeTranslateTranslation, rect_zero_negativeSevenOne.size)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertLocalToWorldRect(localToWorld_negativeTranslate, rect_negativeOffset_seven),
+                Is.EqualTo(new Rect(rect_negativeOffset_seven.position + localToWorld_negativeTranslateTranslation, rect_negativeOffset_seven.size)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertLocalToWorldRect(localToWorld_negativeTranslate, rect_negativeOffset_negativeSeven),
+                Is.EqualTo(new Rect(rect_negativeOffset_negativeSeven.position + localToWorld_negativeTranslateTranslation, rect_negativeOffset_negativeSeven.size)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertLocalToWorldRect(localToWorld_negativeTranslate, rect_centered_seven),
+                Is.EqualTo(new Rect(rect_centered_seven.position + localToWorld_negativeTranslateTranslation, rect_centered_seven.size)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertLocalToWorldRect(localToWorld_negativeTranslate, rect_centered_negativeSeven),
+                Is.EqualTo(new Rect(rect_centered_negativeSeven.position + localToWorld_negativeTranslateTranslation, rect_centered_negativeSeven.size)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertLocalToWorldRect(localToWorld_negativeTranslate, rect_centered_negativePositiveSeven),
+                Is.EqualTo(new Rect(rect_centered_negativePositiveSeven.position + localToWorld_negativeTranslateTranslation, rect_centered_negativePositiveSeven.size)).Using<Rect>(EquivalencyWithTolerance)
+                );
+        }
+
+        [Test]
+        public static void ConvertLocalToWorldRectTest_Rotate()
+        {
+            float3 point_zero = float3.zero;
+            float3 point_one = new float3(1f);
+
+            Rect rect_zero_zero = Rect.zero;
+
+            Rect rect_zero_one = new Rect(0, 0, 1, 1);
+
+            Rect rect_seven_seven = new Rect(7, 7, 7, 7);
+            Rect rect_seven_negativeSeven = new Rect(7, 7, -7, -7);
+
+            Rect rect_zero_oneSeven = new Rect(0, 0, 1, 7);
+            Rect rect_zero_sevenOne = new Rect(0, 0, 7, 1);
+            Rect rect_zero_negativeOneSeven = new Rect(0, 0, -1, -7);
+            Rect rect_zero_negativeSevenOne = new Rect(0, 0, -7, -1);
+
+            Rect rect_negativeOffset_seven = new Rect(-14, -14, 7, 7);
+            Rect rect_negativeOffset_negativeSeven = new Rect(-14, -14, -7, -7);
+
+            Rect rect_centered_seven = new Rect(-3.5f, -3.5f, 7, 7);
+            Rect rect_centered_negativeSeven = new Rect(-3.5f, -3.5f, -7, -7);
+
+            Rect rect_centered_negativePositiveSeven = new Rect(-3.5f, -3.5f, -7, 7);
+
+            quaternion rotation_ninety = quaternion.Euler(math.radians(90f), math.radians(90f), math.radians(90f));
+            quaternion rotation_fortyFive = quaternion.Euler(math.radians(45f), math.radians(45f), math.radians(45f));
+            quaternion rotation_Xninety = quaternion.Euler(math.radians(90f), math.radians(0f), math.radians(0f));
+            quaternion rotation_Zninety = quaternion.Euler(math.radians(0f), math.radians(0f), math.radians(90f));
+
+
+            LocalToWorld localToWorld_rotate_ninety = new LocalToWorld
+            {
+                Value = float4x4.TRS(point_zero, rotation_ninety, point_one)
+            };
+
+            Assert.That(
+                TransformUtil.ConvertLocalToWorldRect(localToWorld_rotate_ninety, rect_zero_zero),
+                Is.EqualTo(new Rect(0f, 0f, 0f, 0f)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertLocalToWorldRect(localToWorld_rotate_ninety, rect_seven_seven),
+                Is.EqualTo(new Rect(7f, 0f, 7f, 0f)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertLocalToWorldRect(localToWorld_rotate_ninety, rect_zero_one),
+                Is.EqualTo(new Rect(0f, 0f, 1f, 0f)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertLocalToWorldRect(localToWorld_rotate_ninety, rect_seven_negativeSeven),
+                Is.EqualTo(new Rect(0f, 0f, 7f, 0f)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertLocalToWorldRect(localToWorld_rotate_ninety, rect_zero_oneSeven),
+                Is.EqualTo(new Rect(0f, 0f, 1f, 0f)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertLocalToWorldRect(localToWorld_rotate_ninety, rect_zero_sevenOne),
+                Is.EqualTo(new Rect(0f, 0f, 7f, 0f)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertLocalToWorldRect(localToWorld_rotate_ninety, rect_zero_negativeOneSeven),
+                Is.EqualTo(new Rect(-1f, 0f, 1f, 0f)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertLocalToWorldRect(localToWorld_rotate_ninety, rect_zero_negativeSevenOne),
+                Is.EqualTo(new Rect(-7f, 0f, 7f, 0f)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertLocalToWorldRect(localToWorld_rotate_ninety, rect_negativeOffset_seven),
+                Is.EqualTo(new Rect(-14f, 0f, 7f, 0f)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertLocalToWorldRect(localToWorld_rotate_ninety, rect_negativeOffset_negativeSeven),
+                Is.EqualTo(new Rect(-21f, 0f, 7f, 0f)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertLocalToWorldRect(localToWorld_rotate_ninety, rect_centered_seven),
+                Is.EqualTo(new Rect(-3.5f, 0f, 7f, 0f)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertLocalToWorldRect(localToWorld_rotate_ninety, rect_centered_negativeSeven),
+                Is.EqualTo(new Rect(-10.5f, 0f, 7f, 0f)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertLocalToWorldRect(localToWorld_rotate_ninety, rect_centered_negativePositiveSeven),
+                Is.EqualTo(new Rect(-10.5f, 0f, 7f, 0f)).Using<Rect>(EquivalencyWithTolerance)
+                );
+
+
+            LocalToWorld localToWorld_rotate_fortyFive = new LocalToWorld
+            {
+                Value = float4x4.TRS(point_zero, rotation_fortyFive, point_one)
+            };
+
+            Assert.That(
+                TransformUtil.ConvertLocalToWorldRect(localToWorld_rotate_fortyFive, rect_zero_zero),
+                Is.EqualTo(new Rect(0f, 0f, 0f, 0f)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertLocalToWorldRect(localToWorld_rotate_fortyFive, rect_seven_seven),
+                Is.EqualTo(new Rect(3.924621f, 7f, 6.999999f, 7f)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertLocalToWorldRect(localToWorld_rotate_fortyFive, rect_zero_one),
+                Is.EqualTo(new Rect(-0.1464466f, 0f, 1f, 0.9999999f)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertLocalToWorldRect(localToWorld_rotate_fortyFive, rect_seven_negativeSeven),
+                Is.EqualTo(new Rect(-1.025126f, 0f, 7f, 7f)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertLocalToWorldRect(localToWorld_rotate_fortyFive, rect_zero_oneSeven),
+                Is.EqualTo(new Rect(-1.025126f, 0f, 1.87868f, 4f)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertLocalToWorldRect(localToWorld_rotate_fortyFive, rect_zero_sevenOne),
+                Is.EqualTo(new Rect(-0.1464466f, 0f, 6.12132f, 4f)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertLocalToWorldRect(localToWorld_rotate_fortyFive, rect_zero_negativeOneSeven),
+                Is.EqualTo(new Rect(-0.8535534f, -4f, 1.87868f, 4f)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertLocalToWorldRect(localToWorld_rotate_fortyFive, rect_zero_negativeSevenOne),
+                Is.EqualTo(new Rect(-5.974874f, -4f, 6.12132f, 4f)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertLocalToWorldRect(localToWorld_rotate_fortyFive, rect_negativeOffset_seven),
+                Is.EqualTo(new Rect(-10.92462f, -14f, 6.999999f, 7f)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertLocalToWorldRect(localToWorld_rotate_fortyFive, rect_negativeOffset_negativeSeven),
+                Is.EqualTo(new Rect(-15.87437f, -21f, 7.000001f, 7.000001f)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertLocalToWorldRect(localToWorld_rotate_fortyFive, rect_centered_seven),
+                Is.EqualTo(new Rect(-3.5f, -3.5f, 7f, 7f)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertLocalToWorldRect(localToWorld_rotate_fortyFive, rect_centered_negativeSeven),
+                Is.EqualTo(new Rect(-8.449748f, -10.5f, 7f, 7f)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertLocalToWorldRect(localToWorld_rotate_fortyFive, rect_centered_negativePositiveSeven),
+                Is.EqualTo(new Rect(-9.474874f, -7f, 7f, 7f)).Using<Rect>(EquivalencyWithTolerance)
+                );
+
+
+            LocalToWorld localToWorld_rotate_Xninety = new LocalToWorld
+            {
+                Value = float4x4.TRS(point_zero, rotation_Xninety, point_one)
+            };
+
+            Assert.That(
+                TransformUtil.ConvertLocalToWorldRect(localToWorld_rotate_Xninety, rect_zero_zero),
+                Is.EqualTo(new Rect(0f, 0f, 0f, 0f)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertLocalToWorldRect(localToWorld_rotate_Xninety, rect_seven_seven),
+                Is.EqualTo(new Rect(7f, 0f, 7f, 0f)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertLocalToWorldRect(localToWorld_rotate_Xninety, rect_zero_one),
+                Is.EqualTo(new Rect(0f, 0f, 1f, 0f)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertLocalToWorldRect(localToWorld_rotate_Xninety, rect_seven_negativeSeven),
+                Is.EqualTo(new Rect(0f, 0f, 7f, 0f)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertLocalToWorldRect(localToWorld_rotate_Xninety, rect_zero_oneSeven),
+                Is.EqualTo(new Rect(0f, 0f, 1f, 0f)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertLocalToWorldRect(localToWorld_rotate_Xninety, rect_zero_sevenOne),
+                Is.EqualTo(new Rect(0f, 0f, 7f, 0f)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertLocalToWorldRect(localToWorld_rotate_Xninety, rect_zero_negativeOneSeven),
+                Is.EqualTo(new Rect(-1f, 0f, 1f, 0f)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertLocalToWorldRect(localToWorld_rotate_Xninety, rect_zero_negativeSevenOne),
+                Is.EqualTo(new Rect(-7f, 0f, 7f, 0f)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertLocalToWorldRect(localToWorld_rotate_Xninety, rect_negativeOffset_seven),
+                Is.EqualTo(new Rect(-14f, 0f, 7f, 0f)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertLocalToWorldRect(localToWorld_rotate_Xninety, rect_negativeOffset_negativeSeven),
+                Is.EqualTo(new Rect(-21f, 0f, 7f, 0f)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertLocalToWorldRect(localToWorld_rotate_Xninety, rect_centered_seven),
+                Is.EqualTo(new Rect(-3.5f, 0f, 7f, 0f)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertLocalToWorldRect(localToWorld_rotate_Xninety, rect_centered_negativeSeven),
+                Is.EqualTo(new Rect(-10.5f, 0f, 7f, 0f)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertLocalToWorldRect(localToWorld_rotate_Xninety, rect_centered_negativePositiveSeven),
+                Is.EqualTo(new Rect(-10.5f, 0f, 7f, 0f)).Using<Rect>(EquivalencyWithTolerance)
+                );
+
+
+            LocalToWorld localToWorld_rotate_Zninety = new LocalToWorld
+            {
+                Value = float4x4.TRS(point_zero, rotation_Zninety, point_one)
+            };
+
+            Assert.That(
+                TransformUtil.ConvertLocalToWorldRect(localToWorld_rotate_Zninety, rect_zero_zero),
+                Is.EqualTo(new Rect(0f, 0f, 0f, 0f)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertLocalToWorldRect(localToWorld_rotate_Zninety, rect_seven_seven),
+                Is.EqualTo(new Rect(-14f, 6.999998f, 7.000002f, 7.000003f)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertLocalToWorldRect(localToWorld_rotate_Zninety, rect_zero_one),
+                Is.EqualTo(new Rect(-1f, 0f, 1f, 1f)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertLocalToWorldRect(localToWorld_rotate_Zninety, rect_seven_negativeSeven),
+                Is.EqualTo(new Rect(-7.000002f, 0f, 7.000002f, 7.000002f)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertLocalToWorldRect(localToWorld_rotate_Zninety, rect_zero_oneSeven),
+                Is.EqualTo(new Rect(-7.000001f, 0f, 7.000001f, 1.000001f)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertLocalToWorldRect(localToWorld_rotate_Zninety, rect_zero_sevenOne),
+                Is.EqualTo(new Rect(-1.000001f, 0f, 1.000001f, 7.000001f)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertLocalToWorldRect(localToWorld_rotate_Zninety, rect_zero_negativeOneSeven),
+                Is.EqualTo(new Rect(0f, -1f, 7.000001f, 1.000001f)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertLocalToWorldRect(localToWorld_rotate_Zninety, rect_zero_negativeSevenOne),
+                Is.EqualTo(new Rect(0f, -7.000001f, 1.000001f, 7.000001f)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertLocalToWorldRect(localToWorld_rotate_Zninety, rect_negativeOffset_seven),
+                Is.EqualTo(new Rect(7.000002f, -14f, 7.000002f, 7.000003f)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertLocalToWorldRect(localToWorld_rotate_Zninety, rect_negativeOffset_negativeSeven),
+                Is.EqualTo(new Rect(14f, -21f, 7f, 7f)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertLocalToWorldRect(localToWorld_rotate_Zninety, rect_centered_seven),
+                Is.EqualTo(new Rect(-3.500001f, -3.500001f, 7.000002f, 7.000002f)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertLocalToWorldRect(localToWorld_rotate_Zninety, rect_centered_negativeSeven),
+                Is.EqualTo(new Rect(3.500001f, -10.5f, 7.000001f, 7.000001f)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertLocalToWorldRect(localToWorld_rotate_Zninety, rect_centered_negativePositiveSeven),
+                Is.EqualTo(new Rect(-3.5f, -10.5f, 7.000001f, 7.000002f)).Using<Rect>(EquivalencyWithTolerance)
+                );
+        }
+
+        [Test]
+        public static void ConvertLocalToWorldRectTest_Scale()
+        {
+            Regex invalidMatrixError_rect = new Regex(@"This transform is invalid\. Returning infinite min/max rect\.");
+
+            float3 point_zero = float3.zero;
+            float3 point_one = new float3(1f);
+
+            Rect rect_zero_zero = Rect.zero;
+
+            Rect rect_zero_one = new Rect(0, 0, 1, 1);
+
+            Rect rect_seven_seven = new Rect(7, 7, 7, 7);
+            Rect rect_seven_negativeSeven = new Rect(7, 7, -7, -7);
+
+            Rect rect_zero_oneSeven = new Rect(0, 0, 1, 7);
+            Rect rect_zero_sevenOne = new Rect(0, 0, 7, 1);
+            Rect rect_zero_negativeOneSeven = new Rect(0, 0, -1, -7);
+            Rect rect_zero_negativeSevenOne = new Rect(0, 0, -7, -1);
+
+            Rect rect_negativeOffset_seven = new Rect(-14, -14, 7, 7);
+            Rect rect_negativeOffset_negativeSeven = new Rect(-14, -14, -7, -7);
+
+            Rect rect_centered_seven = new Rect(-3.5f, -3.5f, 7, 7);
+            Rect rect_centered_negativeSeven = new Rect(-3.5f, -3.5f, -7, -7);
+
+            Rect rect_centered_negativePositiveSeven = new Rect(-3.5f, -3.5f, -7, 7);
+
+            float3 scale_two = new float3(2f);
+            float3 scale_negativeTwo = -scale_two;
+            float3 scale_twoNegativeZ = new float3(2f,2f,-2f);
+            float3 scale_ZnegativeTwo = new float3(point_one.xy, -2f);
+            float3 scale_ZXonePointFive = new float3(1.5f, 1f, 1.5f);
+            float3 scale_zero = float3.zero;
+
+
+            LocalToWorld localToWorld_scale_two = new LocalToWorld()
+            {
+                Value = float4x4.TRS(point_zero, quaternion.identity, scale_two)
+            };
+
+            Assert.That(
+                 TransformUtil.ConvertLocalToWorldRect(localToWorld_scale_two, rect_zero_zero),
+                 Is.EqualTo(new Rect(0f, 0f, 0f, 0f)).Using<Rect>(EquivalencyWithTolerance)
+                 );
+             Assert.That(
+                 TransformUtil.ConvertLocalToWorldRect(localToWorld_scale_two, rect_seven_seven),
+                 Is.EqualTo(new Rect(14f, 14f, 14f, 14f)).Using<Rect>(EquivalencyWithTolerance)
+                 );
+             Assert.That(
+                 TransformUtil.ConvertLocalToWorldRect(localToWorld_scale_two, rect_zero_one),
+                 Is.EqualTo(new Rect(0f, 0f, 2f, 2f)).Using<Rect>(EquivalencyWithTolerance)
+                 );
+             Assert.That(
+                 TransformUtil.ConvertLocalToWorldRect(localToWorld_scale_two, rect_seven_negativeSeven),
+                 Is.EqualTo(new Rect(0f, 0f, 14f, 14f)).Using<Rect>(EquivalencyWithTolerance)
+                 );
+             Assert.That(
+                 TransformUtil.ConvertLocalToWorldRect(localToWorld_scale_two, rect_zero_oneSeven),
+                 Is.EqualTo(new Rect(0f, 0f, 2f, 14f)).Using<Rect>(EquivalencyWithTolerance)
+                 );
+             Assert.That(
+                 TransformUtil.ConvertLocalToWorldRect(localToWorld_scale_two, rect_zero_sevenOne),
+                 Is.EqualTo(new Rect(0f, 0f, 14f, 2f)).Using<Rect>(EquivalencyWithTolerance)
+                 );
+             Assert.That(
+                 TransformUtil.ConvertLocalToWorldRect(localToWorld_scale_two, rect_zero_negativeOneSeven),
+                 Is.EqualTo(new Rect(-2f, -14f, 2f, 14f)).Using<Rect>(EquivalencyWithTolerance)
+                 );
+             Assert.That(
+                 TransformUtil.ConvertLocalToWorldRect(localToWorld_scale_two, rect_zero_negativeSevenOne),
+                 Is.EqualTo(new Rect(-14f, -2f, 14f, 2f)).Using<Rect>(EquivalencyWithTolerance)
+                 );
+             Assert.That(
+                 TransformUtil.ConvertLocalToWorldRect(localToWorld_scale_two, rect_negativeOffset_seven),
+                 Is.EqualTo(new Rect(-28f, -28f, 14f, 14f)).Using<Rect>(EquivalencyWithTolerance)
+                 );
+             Assert.That(
+                 TransformUtil.ConvertLocalToWorldRect(localToWorld_scale_two, rect_negativeOffset_negativeSeven),
+                 Is.EqualTo(new Rect(-42f, -42f, 14f, 14f)).Using<Rect>(EquivalencyWithTolerance)
+                 );
+             Assert.That(
+                 TransformUtil.ConvertLocalToWorldRect(localToWorld_scale_two, rect_centered_seven),
+                 Is.EqualTo(new Rect(-7f, -7f, 14f, 14f)).Using<Rect>(EquivalencyWithTolerance)
+                 );
+             Assert.That(
+                 TransformUtil.ConvertLocalToWorldRect(localToWorld_scale_two, rect_centered_negativeSeven),
+                 Is.EqualTo(new Rect(-21f, -21f, 14f, 14f)).Using<Rect>(EquivalencyWithTolerance)
+                 );
+             Assert.That(
+                 TransformUtil.ConvertLocalToWorldRect(localToWorld_scale_two, rect_centered_negativePositiveSeven),
+                 Is.EqualTo(new Rect(-21f, -7f, 14f, 14f)).Using<Rect>(EquivalencyWithTolerance)
+                 );
+
+
+            LocalToWorld localToWorld_scale_negativeTwo = new LocalToWorld()
+            {
+                Value = float4x4.TRS(point_zero, quaternion.identity, scale_negativeTwo)
+            };
+
+            Assert.That(
+                 TransformUtil.ConvertLocalToWorldRect(localToWorld_scale_negativeTwo, rect_zero_zero),
+                 Is.EqualTo(new Rect(0f, 0f, 0f, 0f)).Using<Rect>(EquivalencyWithTolerance)
+                 );
+             Assert.That(
+                 TransformUtil.ConvertLocalToWorldRect(localToWorld_scale_negativeTwo, rect_seven_seven),
+                 Is.EqualTo(new Rect(-28f, -28f, 14f, 14f)).Using<Rect>(EquivalencyWithTolerance)
+                 );
+             Assert.That(
+                 TransformUtil.ConvertLocalToWorldRect(localToWorld_scale_negativeTwo, rect_zero_one),
+                 Is.EqualTo(new Rect(-2f, -2f, 2f, 2f)).Using<Rect>(EquivalencyWithTolerance)
+                 );
+             Assert.That(
+                 TransformUtil.ConvertLocalToWorldRect(localToWorld_scale_negativeTwo, rect_seven_negativeSeven),
+                 Is.EqualTo(new Rect(-14f, -14f, 14f, 14f)).Using<Rect>(EquivalencyWithTolerance)
+                 );
+             Assert.That(
+                 TransformUtil.ConvertLocalToWorldRect(localToWorld_scale_negativeTwo, rect_zero_oneSeven),
+                 Is.EqualTo(new Rect(-2f, -14f, 2f, 14f)).Using<Rect>(EquivalencyWithTolerance)
+                 );
+             Assert.That(
+                 TransformUtil.ConvertLocalToWorldRect(localToWorld_scale_negativeTwo, rect_zero_sevenOne),
+                 Is.EqualTo(new Rect(-14f, -2f, 14f, 2f)).Using<Rect>(EquivalencyWithTolerance)
+                 );
+             Assert.That(
+                 TransformUtil.ConvertLocalToWorldRect(localToWorld_scale_negativeTwo, rect_zero_negativeOneSeven),
+                 Is.EqualTo(new Rect(0f, 0f, 2f, 14f)).Using<Rect>(EquivalencyWithTolerance)
+                 );
+             Assert.That(
+                 TransformUtil.ConvertLocalToWorldRect(localToWorld_scale_negativeTwo, rect_zero_negativeSevenOne),
+                 Is.EqualTo(new Rect(0f, 0f, 14f, 2f)).Using<Rect>(EquivalencyWithTolerance)
+                 );
+             Assert.That(
+                 TransformUtil.ConvertLocalToWorldRect(localToWorld_scale_negativeTwo, rect_negativeOffset_seven),
+                 Is.EqualTo(new Rect(14f, 14f, 14f, 14f)).Using<Rect>(EquivalencyWithTolerance)
+                 );
+             Assert.That(
+                 TransformUtil.ConvertLocalToWorldRect(localToWorld_scale_negativeTwo, rect_negativeOffset_negativeSeven),
+                 Is.EqualTo(new Rect(28f, 28f, 14f, 14f)).Using<Rect>(EquivalencyWithTolerance)
+                 );
+             Assert.That(
+                 TransformUtil.ConvertLocalToWorldRect(localToWorld_scale_negativeTwo, rect_centered_seven),
+                 Is.EqualTo(new Rect(-7f, -7f, 14f, 14f)).Using<Rect>(EquivalencyWithTolerance)
+                 );
+             Assert.That(
+                 TransformUtil.ConvertLocalToWorldRect(localToWorld_scale_negativeTwo, rect_centered_negativeSeven),
+                 Is.EqualTo(new Rect(7f, 7f, 14f, 14f)).Using<Rect>(EquivalencyWithTolerance)
+                 );
+             Assert.That(
+                 TransformUtil.ConvertLocalToWorldRect(localToWorld_scale_negativeTwo, rect_centered_negativePositiveSeven),
+                 Is.EqualTo(new Rect(7f, -7f, 14f, 14f)).Using<Rect>(EquivalencyWithTolerance)
+                 );
+
+
+            LocalToWorld localToWorld_scale_twoNegativeZ = new LocalToWorld()
+            {
+                Value = float4x4.TRS(point_zero, quaternion.identity, scale_twoNegativeZ)
+            };
+
+            Assert.That(
+                 TransformUtil.ConvertLocalToWorldRect(localToWorld_scale_twoNegativeZ, rect_zero_zero),
+                 Is.EqualTo(new Rect(0f, 0f, 0f, 0f)).Using<Rect>(EquivalencyWithTolerance)
+                 );
+             Assert.That(
+                 TransformUtil.ConvertLocalToWorldRect(localToWorld_scale_twoNegativeZ, rect_seven_seven),
+                 Is.EqualTo(new Rect(14f, 14f, 14f, 14f)).Using<Rect>(EquivalencyWithTolerance)
+                 );
+             Assert.That(
+                 TransformUtil.ConvertLocalToWorldRect(localToWorld_scale_twoNegativeZ, rect_zero_one),
+                 Is.EqualTo(new Rect(0f, 0f, 2f, 2f)).Using<Rect>(EquivalencyWithTolerance)
+                 );
+             Assert.That(
+                 TransformUtil.ConvertLocalToWorldRect(localToWorld_scale_twoNegativeZ, rect_seven_negativeSeven),
+                 Is.EqualTo(new Rect(0f, 0f, 14f, 14f)).Using<Rect>(EquivalencyWithTolerance)
+                 );
+             Assert.That(
+                 TransformUtil.ConvertLocalToWorldRect(localToWorld_scale_twoNegativeZ, rect_zero_oneSeven),
+                 Is.EqualTo(new Rect(0f, 0f, 2f, 14f)).Using<Rect>(EquivalencyWithTolerance)
+                 );
+             Assert.That(
+                 TransformUtil.ConvertLocalToWorldRect(localToWorld_scale_twoNegativeZ, rect_zero_sevenOne),
+                 Is.EqualTo(new Rect(0f, 0f, 14f, 2f)).Using<Rect>(EquivalencyWithTolerance)
+                 );
+             Assert.That(
+                 TransformUtil.ConvertLocalToWorldRect(localToWorld_scale_twoNegativeZ, rect_zero_negativeOneSeven),
+                 Is.EqualTo(new Rect(-2f, -14f, 2f, 14f)).Using<Rect>(EquivalencyWithTolerance)
+                 );
+             Assert.That(
+                 TransformUtil.ConvertLocalToWorldRect(localToWorld_scale_twoNegativeZ, rect_zero_negativeSevenOne),
+                 Is.EqualTo(new Rect(-14f, -2f, 14f, 2f)).Using<Rect>(EquivalencyWithTolerance)
+                 );
+             Assert.That(
+                 TransformUtil.ConvertLocalToWorldRect(localToWorld_scale_twoNegativeZ, rect_negativeOffset_seven),
+                 Is.EqualTo(new Rect(-28f, -28f, 14f, 14f)).Using<Rect>(EquivalencyWithTolerance)
+                 );
+             Assert.That(
+                 TransformUtil.ConvertLocalToWorldRect(localToWorld_scale_twoNegativeZ, rect_negativeOffset_negativeSeven),
+                 Is.EqualTo(new Rect(-42f, -42f, 14f, 14f)).Using<Rect>(EquivalencyWithTolerance)
+                 );
+             Assert.That(
+                 TransformUtil.ConvertLocalToWorldRect(localToWorld_scale_twoNegativeZ, rect_centered_seven),
+                 Is.EqualTo(new Rect(-7f, -7f, 14f, 14f)).Using<Rect>(EquivalencyWithTolerance)
+                 );
+             Assert.That(
+                 TransformUtil.ConvertLocalToWorldRect(localToWorld_scale_twoNegativeZ, rect_centered_negativeSeven),
+                 Is.EqualTo(new Rect(-21f, -21f, 14f, 14f)).Using<Rect>(EquivalencyWithTolerance)
+                 );
+             Assert.That(
+                 TransformUtil.ConvertLocalToWorldRect(localToWorld_scale_twoNegativeZ, rect_centered_negativePositiveSeven),
+                 Is.EqualTo(new Rect(-21f, -7f, 14f, 14f)).Using<Rect>(EquivalencyWithTolerance)
+                 );
+
+
+             LocalToWorld localToWorld_scale_ZnegativeTwo = new LocalToWorld()
+            {
+                Value = float4x4.TRS(point_zero, quaternion.identity, scale_ZnegativeTwo)
+            };
+
+            Assert.That(
+                 TransformUtil.ConvertLocalToWorldRect(localToWorld_scale_ZnegativeTwo, rect_zero_zero),
+                 Is.EqualTo(new Rect(0f, 0f, 0f, 0f)).Using<Rect>(EquivalencyWithTolerance)
+                 );
+             Assert.That(
+                 TransformUtil.ConvertLocalToWorldRect(localToWorld_scale_ZnegativeTwo, rect_seven_seven),
+                 Is.EqualTo(new Rect(7f, 7f, 7f, 7f)).Using<Rect>(EquivalencyWithTolerance)
+                 );
+             Assert.That(
+                 TransformUtil.ConvertLocalToWorldRect(localToWorld_scale_ZnegativeTwo, rect_zero_one),
+                 Is.EqualTo(new Rect(0f, 0f, 1f, 1f)).Using<Rect>(EquivalencyWithTolerance)
+                 );
+             Assert.That(
+                 TransformUtil.ConvertLocalToWorldRect(localToWorld_scale_ZnegativeTwo, rect_seven_negativeSeven),
+                 Is.EqualTo(new Rect(0f, 0f, 7f, 7f)).Using<Rect>(EquivalencyWithTolerance)
+                 );
+             Assert.That(
+                 TransformUtil.ConvertLocalToWorldRect(localToWorld_scale_ZnegativeTwo, rect_zero_oneSeven),
+                 Is.EqualTo(new Rect(0f, 0f, 1f, 7f)).Using<Rect>(EquivalencyWithTolerance)
+                 );
+             Assert.That(
+                 TransformUtil.ConvertLocalToWorldRect(localToWorld_scale_ZnegativeTwo, rect_zero_sevenOne),
+                 Is.EqualTo(new Rect(0f, 0f, 7f, 1f)).Using<Rect>(EquivalencyWithTolerance)
+                 );
+             Assert.That(
+                 TransformUtil.ConvertLocalToWorldRect(localToWorld_scale_ZnegativeTwo, rect_zero_negativeOneSeven),
+                 Is.EqualTo(new Rect(-1f, -7f, 1f, 7f)).Using<Rect>(EquivalencyWithTolerance)
+                 );
+             Assert.That(
+                 TransformUtil.ConvertLocalToWorldRect(localToWorld_scale_ZnegativeTwo, rect_zero_negativeSevenOne),
+                 Is.EqualTo(new Rect(-7f, -1f, 7f, 1f)).Using<Rect>(EquivalencyWithTolerance)
+                 );
+             Assert.That(
+                 TransformUtil.ConvertLocalToWorldRect(localToWorld_scale_ZnegativeTwo, rect_negativeOffset_seven),
+                 Is.EqualTo(new Rect(-14f, -14f, 7f, 7f)).Using<Rect>(EquivalencyWithTolerance)
+                 );
+             Assert.That(
+                 TransformUtil.ConvertLocalToWorldRect(localToWorld_scale_ZnegativeTwo, rect_negativeOffset_negativeSeven),
+                 Is.EqualTo(new Rect(-21f, -21f, 7f, 7f)).Using<Rect>(EquivalencyWithTolerance)
+                 );
+             Assert.That(
+                 TransformUtil.ConvertLocalToWorldRect(localToWorld_scale_ZnegativeTwo, rect_centered_seven),
+                 Is.EqualTo(new Rect(-3.5f, -3.5f, 7f, 7f)).Using<Rect>(EquivalencyWithTolerance)
+                 );
+             Assert.That(
+                 TransformUtil.ConvertLocalToWorldRect(localToWorld_scale_ZnegativeTwo, rect_centered_negativeSeven),
+                 Is.EqualTo(new Rect(-10.5f, -10.5f, 7f, 7f)).Using<Rect>(EquivalencyWithTolerance)
+                 );
+             Assert.That(
+                 TransformUtil.ConvertLocalToWorldRect(localToWorld_scale_ZnegativeTwo, rect_centered_negativePositiveSeven),
+                 Is.EqualTo(new Rect(-10.5f, -3.5f, 7f, 7f)).Using<Rect>(EquivalencyWithTolerance)
+                 );
+
+
+            LocalToWorld localToWorld_scale_ZXonePointFive = new LocalToWorld()
+            {
+                Value = float4x4.TRS(point_zero, quaternion.identity, scale_ZXonePointFive)
+            };
+
+            Assert.That(
+                 TransformUtil.ConvertLocalToWorldRect(localToWorld_scale_ZXonePointFive, rect_zero_zero),
+                 Is.EqualTo(new Rect(0f, 0f, 0f, 0f)).Using<Rect>(EquivalencyWithTolerance)
+                 );
+             Assert.That(
+                 TransformUtil.ConvertLocalToWorldRect(localToWorld_scale_ZXonePointFive, rect_seven_seven),
+                 Is.EqualTo(new Rect(10.5f, 7f, 10.5f, 7f)).Using<Rect>(EquivalencyWithTolerance)
+                 );
+             Assert.That(
+                 TransformUtil.ConvertLocalToWorldRect(localToWorld_scale_ZXonePointFive, rect_zero_one),
+                 Is.EqualTo(new Rect(0f, 0f, 1.5f, 1f)).Using<Rect>(EquivalencyWithTolerance)
+                 );
+             Assert.That(
+                 TransformUtil.ConvertLocalToWorldRect(localToWorld_scale_ZXonePointFive, rect_seven_negativeSeven),
+                 Is.EqualTo(new Rect(0f, 0f, 10.5f, 7f)).Using<Rect>(EquivalencyWithTolerance)
+                 );
+             Assert.That(
+                 TransformUtil.ConvertLocalToWorldRect(localToWorld_scale_ZXonePointFive, rect_zero_oneSeven),
+                 Is.EqualTo(new Rect(0f, 0f, 1.5f, 7f)).Using<Rect>(EquivalencyWithTolerance)
+                 );
+             Assert.That(
+                 TransformUtil.ConvertLocalToWorldRect(localToWorld_scale_ZXonePointFive, rect_zero_sevenOne),
+                 Is.EqualTo(new Rect(0f, 0f, 10.5f, 1f)).Using<Rect>(EquivalencyWithTolerance)
+                 );
+             Assert.That(
+                 TransformUtil.ConvertLocalToWorldRect(localToWorld_scale_ZXonePointFive, rect_zero_negativeOneSeven),
+                 Is.EqualTo(new Rect(-1.5f, -7f, 1.5f, 7f)).Using<Rect>(EquivalencyWithTolerance)
+                 );
+             Assert.That(
+                 TransformUtil.ConvertLocalToWorldRect(localToWorld_scale_ZXonePointFive, rect_zero_negativeSevenOne),
+                 Is.EqualTo(new Rect(-10.5f, -1f, 10.5f, 1f)).Using<Rect>(EquivalencyWithTolerance)
+                 );
+             Assert.That(
+                 TransformUtil.ConvertLocalToWorldRect(localToWorld_scale_ZXonePointFive, rect_negativeOffset_seven),
+                 Is.EqualTo(new Rect(-21f, -14f, 10.5f, 7f)).Using<Rect>(EquivalencyWithTolerance)
+                 );
+             Assert.That(
+                 TransformUtil.ConvertLocalToWorldRect(localToWorld_scale_ZXonePointFive, rect_negativeOffset_negativeSeven),
+                 Is.EqualTo(new Rect(-31.5f, -21f, 10.5f, 7f)).Using<Rect>(EquivalencyWithTolerance)
+                 );
+             Assert.That(
+                 TransformUtil.ConvertLocalToWorldRect(localToWorld_scale_ZXonePointFive, rect_centered_seven),
+                 Is.EqualTo(new Rect(-5.25f, -3.5f, 10.5f, 7f)).Using<Rect>(EquivalencyWithTolerance)
+                 );
+             Assert.That(
+                 TransformUtil.ConvertLocalToWorldRect(localToWorld_scale_ZXonePointFive, rect_centered_negativeSeven),
+                 Is.EqualTo(new Rect(-15.75f, -10.5f, 10.5f, 7f)).Using<Rect>(EquivalencyWithTolerance)
+                 );
+             Assert.That(
+                 TransformUtil.ConvertLocalToWorldRect(localToWorld_scale_ZXonePointFive, rect_centered_negativePositiveSeven),
+                 Is.EqualTo(new Rect(-15.75f, -3.5f, 10.5f, 7f)).Using<Rect>(EquivalencyWithTolerance)
+                 );
+
+
+            LocalToWorld localToWorld_scale_zero = new LocalToWorld()
+            {
+                Value = float4x4.TRS(point_zero, quaternion.identity, scale_zero)
+            };
+            Rect rect_infinity = Rect.MinMaxRect(
+                float.NegativeInfinity,
+                float.NegativeInfinity,
+                float.PositiveInfinity,
+                float.PositiveInfinity);
+
+            Logger.Debug("BEGIN: Expected error messages.");
+            LogAssert.Expect(LogType.Error, invalidMatrixError_rect);
+            Assert.That(
+                 TransformUtil.ConvertLocalToWorldRect(localToWorld_scale_zero, rect_zero_zero),
+                 Is.EqualTo(rect_infinity)
+                 );
+            LogAssert.Expect(LogType.Error, invalidMatrixError_rect);
+             Assert.That(
+                 TransformUtil.ConvertLocalToWorldRect(localToWorld_scale_zero, rect_seven_seven),
+                 Is.EqualTo(rect_infinity)
+                 );
+             LogAssert.Expect(LogType.Error, invalidMatrixError_rect);
+             Assert.That(
+                 TransformUtil.ConvertLocalToWorldRect(localToWorld_scale_zero, rect_zero_one),
+                 Is.EqualTo(rect_infinity)
+                 );
+             LogAssert.Expect(LogType.Error, invalidMatrixError_rect);
+             Assert.That(
+                 TransformUtil.ConvertLocalToWorldRect(localToWorld_scale_zero, rect_seven_negativeSeven),
+                 Is.EqualTo(rect_infinity)
+                 );
+             LogAssert.Expect(LogType.Error, invalidMatrixError_rect);
+             Assert.That(
+                 TransformUtil.ConvertLocalToWorldRect(localToWorld_scale_zero, rect_zero_oneSeven),
+                 Is.EqualTo(rect_infinity)
+                 );
+             LogAssert.Expect(LogType.Error, invalidMatrixError_rect);
+             Assert.That(
+                 TransformUtil.ConvertLocalToWorldRect(localToWorld_scale_zero, rect_zero_sevenOne),
+                 Is.EqualTo(rect_infinity)
+                 );
+             LogAssert.Expect(LogType.Error, invalidMatrixError_rect);
+             Assert.That(
+                 TransformUtil.ConvertLocalToWorldRect(localToWorld_scale_zero, rect_zero_negativeOneSeven),
+                 Is.EqualTo(rect_infinity)
+                 );
+             LogAssert.Expect(LogType.Error, invalidMatrixError_rect);
+             Assert.That(
+                 TransformUtil.ConvertLocalToWorldRect(localToWorld_scale_zero, rect_zero_negativeSevenOne),
+                 Is.EqualTo(rect_infinity)
+                 );
+             LogAssert.Expect(LogType.Error, invalidMatrixError_rect);
+             Assert.That(
+                 TransformUtil.ConvertLocalToWorldRect(localToWorld_scale_zero, rect_negativeOffset_seven),
+                 Is.EqualTo(rect_infinity)
+                 );
+             LogAssert.Expect(LogType.Error, invalidMatrixError_rect);
+             Assert.That(
+                 TransformUtil.ConvertLocalToWorldRect(localToWorld_scale_zero, rect_negativeOffset_negativeSeven),
+                 Is.EqualTo(rect_infinity)
+                 );
+             LogAssert.Expect(LogType.Error, invalidMatrixError_rect);
+             Assert.That(
+                 TransformUtil.ConvertLocalToWorldRect(localToWorld_scale_zero, rect_centered_seven),
+                 Is.EqualTo(rect_infinity)
+                 );
+             LogAssert.Expect(LogType.Error, invalidMatrixError_rect);
+             Assert.That(
+                 TransformUtil.ConvertLocalToWorldRect(localToWorld_scale_zero, rect_centered_negativeSeven),
+                 Is.EqualTo(rect_infinity)
+                 );
+             LogAssert.Expect(LogType.Error, invalidMatrixError_rect);
+             Assert.That(
+                TransformUtil.ConvertLocalToWorldRect(localToWorld_scale_zero, rect_centered_negativePositiveSeven),
+                Is.EqualTo(rect_infinity)
+                 );
+             Logger.Debug("END: Expected error messages.");
+        }
+
+        [Test]
+        public static void ConvertLocalToWorldRectTest_Compound()
+        {
+            Rect rect_zero_zero = Rect.zero;
+
+            Rect rect_zero_one = new Rect(0, 0, 1, 1);
+
+            Rect rect_seven_seven = new Rect(7, 7, 7, 7);
+            Rect rect_seven_negativeSeven = new Rect(7, 7, -7, -7);
+
+            Rect rect_zero_oneSeven = new Rect(0, 0, 1, 7);
+            Rect rect_zero_sevenOne = new Rect(0, 0, 7, 1);
+            Rect rect_zero_negativeOneSeven = new Rect(0, 0, -1, -7);
+            Rect rect_zero_negativeSevenOne = new Rect(0, 0, -7, -1);
+
+            Rect rect_negativeOffset_seven = new Rect(-14, -14, 7, 7);
+            Rect rect_negativeOffset_negativeSeven = new Rect(-14, -14, -7, -7);
+
+            Rect rect_centered_seven = new Rect(-3.5f, -3.5f, 7, 7);
+            Rect rect_centered_negativeSeven = new Rect(-3.5f, -3.5f, -7, -7);
+
+            Rect rect_centered_negativePositiveSeven = new Rect(-3.5f, -3.5f, -7, 7);
+
+            float3 point_XYseven = new float3(7f, 7f, 0f);
+            float3 scale_XnegativeOnePointFive_ZOnePointFive = new float3(-1.5f, 1f, 1.5f);
+            quaternion rotation_fortyFive = quaternion.Euler(math.radians(45f), math.radians(45f), math.radians(45f));
+
+
+            LocalToWorld localToWorld_compound = new LocalToWorld
+            {
+                Value = float4x4.TRS(point_XYseven, rotation_fortyFive, scale_XnegativeOnePointFive_ZOnePointFive)
+            };
+
+            Assert.That(
+                TransformUtil.ConvertLocalToWorldRect(localToWorld_compound, rect_zero_zero),
+                Is.EqualTo(new Rect(7f, 7f, 0f, 0f)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertLocalToWorldRect(localToWorld_compound, rect_seven_seven),
+                Is.EqualTo(new Rect(-12.97487f, 0f, 9.987437f, 8.75f)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertLocalToWorldRect(localToWorld_compound, rect_zero_one),
+                Is.EqualTo(new Rect(5.573223f, 6.25f, 1.426777f, 1.25f)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertLocalToWorldRect(localToWorld_compound, rect_seven_negativeSeven),
+                Is.EqualTo(new Rect(-2.987437f, 1.75f, 9.987437f, 8.75f)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertLocalToWorldRect(localToWorld_compound, rect_zero_oneSeven),
+                Is.EqualTo(new Rect(4.694544f, 6.25f, 2.305456f, 4.25f)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertLocalToWorldRect(localToWorld_compound, rect_zero_sevenOne),
+                Is.EqualTo(new Rect(-2.108757f, 1.75f, 9.108757f, 5.75f)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertLocalToWorldRect(localToWorld_compound, rect_zero_negativeOneSeven),
+                Is.EqualTo(new Rect(7f, 3.5f, 2.305456f, 4.25f)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertLocalToWorldRect(localToWorld_compound, rect_zero_negativeSevenOne),
+                Is.EqualTo(new Rect(7f, 6.5f, 9.108757f, 5.75f)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertLocalToWorldRect(localToWorld_compound, rect_negativeOffset_seven),
+                Is.EqualTo(new Rect(16.98744f, 5.250001f, 9.987436f, 8.749999f)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertLocalToWorldRect(localToWorld_compound, rect_negativeOffset_negativeSeven),
+                Is.EqualTo(new Rect(26.97487f, 7.000001f, 9.987436f, 8.75f)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertLocalToWorldRect(localToWorld_compound, rect_centered_seven),
+                Is.EqualTo(new Rect(2.006281f, 2.625f, 9.987438f, 8.75f)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertLocalToWorldRect(localToWorld_compound, rect_centered_negativeSeven),
+                Is.EqualTo(new Rect(11.99372f, 4.375f, 9.987436f, 8.75f)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertLocalToWorldRect(localToWorld_compound, rect_centered_negativePositiveSeven),
+                Is.EqualTo(new Rect(10.96859f, 7.875f, 9.987435f, 8.75f)).Using<Rect>(EquivalencyWithTolerance)
+                );
+
+
+            LocalToWorld localToWorld_compoundNegative = new LocalToWorld
+            {
+                Value = float4x4.TRS(-point_XYseven, math.inverse(rotation_fortyFive), -scale_XnegativeOnePointFive_ZOnePointFive)
+            };
+
+            Assert.That(
+                TransformUtil.ConvertLocalToWorldRect(localToWorld_compoundNegative, rect_zero_zero),
+                Is.EqualTo(new Rect(-7f, -7f, 0f, 0f)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertLocalToWorldRect(localToWorld_compoundNegative, rect_seven_seven),
+                Is.EqualTo(new Rect(-5.037689f, -17.07538f, 12.46231f, 5.037689f)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertLocalToWorldRect(localToWorld_compoundNegative, rect_zero_one),
+                Is.EqualTo(new Rect(-7.5f, -7.71967f, 1.78033f, 0.7196698f)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertLocalToWorldRect(localToWorld_compoundNegative, rect_seven_negativeSeven),
+                Is.EqualTo(new Rect(-10.5f, -12.03769f, 12.46231f, 5.037689f)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertLocalToWorldRect(localToWorld_compoundNegative, rect_zero_oneSeven),
+                Is.EqualTo(new Rect(-10.5f, -10.71967f, 4.78033f, 3.719669f)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertLocalToWorldRect(localToWorld_compoundNegative, rect_zero_sevenOne),
+                Is.EqualTo(new Rect(-7.5f, -9.037689f, 9.462311f, 2.037689f)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertLocalToWorldRect(localToWorld_compoundNegative, rect_zero_negativeOneSeven),
+                Is.EqualTo(new Rect(-8.28033f, -7f, 4.78033f, 3.719669f)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertLocalToWorldRect(localToWorld_compoundNegative, rect_zero_negativeSevenOne),
+                Is.EqualTo(new Rect(-15.96231f, -7f, 9.462311f, 2.037689f)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertLocalToWorldRect(localToWorld_compoundNegative, rect_negativeOffset_seven),
+                Is.EqualTo(new Rect(-21.42462f, -1.962311f, 12.46231f, 5.037689f)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertLocalToWorldRect(localToWorld_compoundNegative, rect_negativeOffset_negativeSeven),
+                Is.EqualTo(new Rect(-26.88693f, 3.075377f, 12.46231f, 5.037689f)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertLocalToWorldRect(localToWorld_compoundNegative, rect_centered_seven),
+                Is.EqualTo(new Rect(-13.23116f, -9.518845f, 12.46231f, 5.037689f)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertLocalToWorldRect(localToWorld_compoundNegative, rect_centered_negativeSeven),
+                Is.EqualTo(new Rect(-18.69347f, -4.481155f, 12.46231f, 5.037689f)).Using<Rect>(EquivalencyWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertLocalToWorldRect(localToWorld_compoundNegative, rect_centered_negativePositiveSeven),
+                Is.EqualTo(new Rect(-22.19347f, -7.981155f, 12.46231f, 5.037689f)).Using<Rect>(EquivalencyWithTolerance)
+                );
+        }
     }
 }

--- a/Scripts/Editor/Tests/Entities/Transform/TransformUtilTests.cs
+++ b/Scripts/Editor/Tests/Entities/Transform/TransformUtilTests.cs
@@ -1056,16 +1056,256 @@ namespace Anvil.Unity.DOTS.Tests.Entities.Transform
 
         // ----- ConvertLocalToWorldRotation ----- //
         [Test]
-        public static void ConvertLocalToWorldRotation()
+        public static void ConvertLocalToWorldRotationTest_Rotate()
         {
+            float3 point_one = new float3(1f, 1f, 1f);
+            quaternion rotation_fortyFive = quaternion.Euler(math.radians(45f), math.radians(45f), math.radians(45f));
+            quaternion rotation_nintey = quaternion.Euler(math.radians(90f), math.radians(90f), math.radians(90f));
+            quaternion rotation_ZfortyFive = quaternion.Euler(0f, 0f, math.radians(45f));
+            quaternion rotation_Znintey = quaternion.Euler(0f, 0f, math.radians(90f));
 
+
+            LocalToWorld localToWorld_nintey = new LocalToWorld()
+            {
+                Value = float4x4.TRS(float3.zero, rotation_nintey, point_one)
+            };
+            Assert.That(TransformUtil.ConvertLocalToWorldRotation(localToWorld_nintey, quaternion.identity), Is.EqualTo(math.mul(rotation_nintey, quaternion.identity)).Using<quaternion>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldRotation(localToWorld_nintey, rotation_nintey), Is.EqualTo(math.mul(rotation_nintey, rotation_nintey)).Using<quaternion>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldRotation(localToWorld_nintey, rotation_Znintey), Is.EqualTo(math.mul(rotation_nintey, rotation_Znintey)).Using<quaternion>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldRotation(localToWorld_nintey, rotation_fortyFive), Is.EqualTo(math.mul(rotation_nintey, rotation_fortyFive)).Using<quaternion>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldRotation(localToWorld_nintey, rotation_ZfortyFive), Is.EqualTo(math.mul(rotation_nintey, rotation_ZfortyFive)).Using<quaternion>(EqualityWithTolerance));
+
+            Assert.That(TransformUtil.ConvertLocalToWorldRotation(localToWorld_nintey.Value, quaternion.identity), Is.EqualTo(math.mul(rotation_nintey, quaternion.identity)).Using<quaternion>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldRotation(localToWorld_nintey.Value, rotation_nintey), Is.EqualTo(math.mul(rotation_nintey, rotation_nintey)).Using<quaternion>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldRotation(localToWorld_nintey.Value, rotation_Znintey), Is.EqualTo(math.mul(rotation_nintey, rotation_Znintey)).Using<quaternion>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldRotation(localToWorld_nintey.Value, rotation_fortyFive), Is.EqualTo(math.mul(rotation_nintey, rotation_fortyFive)).Using<quaternion>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldRotation(localToWorld_nintey.Value, rotation_ZfortyFive), Is.EqualTo(math.mul(rotation_nintey, rotation_ZfortyFive)).Using<quaternion>(EqualityWithTolerance));
+
+
+            LocalToWorld localToWorld_fortyFive = new LocalToWorld()
+            {
+                Value = float4x4.TRS(float3.zero, rotation_fortyFive, point_one)
+            };
+            Assert.That(TransformUtil.ConvertLocalToWorldRotation(localToWorld_fortyFive, quaternion.identity), Is.EqualTo(math.mul(rotation_fortyFive, quaternion.identity)).Using<quaternion>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldRotation(localToWorld_fortyFive, rotation_nintey), Is.EqualTo(math.mul(rotation_fortyFive, rotation_nintey)).Using<quaternion>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldRotation(localToWorld_fortyFive, rotation_Znintey), Is.EqualTo(math.mul(rotation_fortyFive, rotation_Znintey)).Using<quaternion>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldRotation(localToWorld_fortyFive, rotation_fortyFive), Is.EqualTo(math.mul(rotation_fortyFive, rotation_fortyFive)).Using<quaternion>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldRotation(localToWorld_fortyFive, rotation_ZfortyFive), Is.EqualTo(math.mul(rotation_fortyFive, rotation_ZfortyFive)).Using<quaternion>(EqualityWithTolerance));
+
+            Assert.That(TransformUtil.ConvertLocalToWorldRotation(localToWorld_fortyFive.Value, quaternion.identity), Is.EqualTo(math.mul(rotation_fortyFive, quaternion.identity)).Using<quaternion>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldRotation(localToWorld_fortyFive.Value, rotation_nintey), Is.EqualTo(math.mul(rotation_fortyFive, rotation_nintey)).Using<quaternion>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldRotation(localToWorld_fortyFive.Value, rotation_Znintey), Is.EqualTo(math.mul(rotation_fortyFive, rotation_Znintey)).Using<quaternion>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldRotation(localToWorld_fortyFive.Value, rotation_fortyFive), Is.EqualTo(math.mul(rotation_fortyFive, rotation_fortyFive)).Using<quaternion>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldRotation(localToWorld_fortyFive.Value, rotation_ZfortyFive), Is.EqualTo(math.mul(rotation_fortyFive, rotation_ZfortyFive)).Using<quaternion>(EqualityWithTolerance));
+
+
+            LocalToWorld localToWorld_Znintey = new LocalToWorld()
+            {
+                Value = float4x4.TRS(float3.zero, rotation_Znintey, point_one)
+            };
+            Assert.That(TransformUtil.ConvertLocalToWorldRotation(localToWorld_Znintey, quaternion.identity), Is.EqualTo(math.mul(rotation_Znintey, quaternion.identity)).Using<quaternion>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldRotation(localToWorld_Znintey, rotation_nintey), Is.EqualTo(math.mul(rotation_Znintey, rotation_nintey)).Using<quaternion>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldRotation(localToWorld_Znintey, rotation_Znintey), Is.EqualTo(math.mul(rotation_Znintey, rotation_Znintey)).Using<quaternion>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldRotation(localToWorld_Znintey, rotation_fortyFive), Is.EqualTo(math.mul(rotation_Znintey, rotation_fortyFive)).Using<quaternion>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldRotation(localToWorld_Znintey, rotation_ZfortyFive), Is.EqualTo(math.mul(rotation_Znintey, rotation_ZfortyFive)).Using<quaternion>(EqualityWithTolerance));
+
+            Assert.That(TransformUtil.ConvertLocalToWorldRotation(localToWorld_Znintey.Value, quaternion.identity), Is.EqualTo(math.mul(rotation_Znintey, quaternion.identity)).Using<quaternion>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldRotation(localToWorld_Znintey.Value, rotation_nintey), Is.EqualTo(math.mul(rotation_Znintey, rotation_nintey)).Using<quaternion>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldRotation(localToWorld_Znintey.Value, rotation_Znintey), Is.EqualTo(math.mul(rotation_Znintey, rotation_Znintey)).Using<quaternion>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldRotation(localToWorld_Znintey.Value, rotation_fortyFive), Is.EqualTo(math.mul(rotation_Znintey, rotation_fortyFive)).Using<quaternion>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldRotation(localToWorld_Znintey.Value, rotation_ZfortyFive), Is.EqualTo(math.mul(rotation_Znintey, rotation_ZfortyFive)).Using<quaternion>(EqualityWithTolerance));
+
+
+            LocalToWorld localToWorld_ZfortyFive = new LocalToWorld()
+            {
+                Value = float4x4.TRS(float3.zero, rotation_ZfortyFive, point_one)
+            };
+            Assert.That(TransformUtil.ConvertLocalToWorldRotation(localToWorld_ZfortyFive, quaternion.identity), Is.EqualTo(math.mul(rotation_ZfortyFive, quaternion.identity)).Using<quaternion>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldRotation(localToWorld_ZfortyFive, rotation_nintey), Is.EqualTo(math.mul(rotation_ZfortyFive, rotation_nintey)).Using<quaternion>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldRotation(localToWorld_ZfortyFive, rotation_Znintey), Is.EqualTo(math.mul(rotation_ZfortyFive, rotation_Znintey)).Using<quaternion>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldRotation(localToWorld_ZfortyFive, rotation_fortyFive), Is.EqualTo(math.mul(rotation_ZfortyFive, rotation_fortyFive)).Using<quaternion>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldRotation(localToWorld_ZfortyFive, rotation_ZfortyFive), Is.EqualTo(math.mul(rotation_ZfortyFive, rotation_ZfortyFive)).Using<quaternion>(EqualityWithTolerance));
+
+            Assert.That(TransformUtil.ConvertLocalToWorldRotation(localToWorld_ZfortyFive.Value, quaternion.identity), Is.EqualTo(math.mul(rotation_ZfortyFive, quaternion.identity)).Using<quaternion>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldRotation(localToWorld_ZfortyFive.Value, rotation_nintey), Is.EqualTo(math.mul(rotation_ZfortyFive, rotation_nintey)).Using<quaternion>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldRotation(localToWorld_ZfortyFive.Value, rotation_Znintey), Is.EqualTo(math.mul(rotation_ZfortyFive, rotation_Znintey)).Using<quaternion>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldRotation(localToWorld_ZfortyFive.Value, rotation_fortyFive), Is.EqualTo(math.mul(rotation_ZfortyFive, rotation_fortyFive)).Using<quaternion>(EqualityWithTolerance));
+            Assert.That(TransformUtil.ConvertLocalToWorldRotation(localToWorld_ZfortyFive.Value, rotation_ZfortyFive), Is.EqualTo(math.mul(rotation_ZfortyFive, rotation_ZfortyFive)).Using<quaternion>(EqualityWithTolerance));
         }
 
-        // [Test]
-        // public static quaternion ConvertLocalToWorldRotationTest()
-        // {
-        //     return ConvertLocalToWorldRotation(localToWorld.Value, rotation);
-        // }
+        [Test]
+        public static void ConvertLocalToWorldRotationTest_Compound()
+        {
+            float3 point_one = new float3(1f, 1f, 1f);
+            float3 point_sevenXY = new float3(7f, 7f, 0f);
+            quaternion rotation_fortyFive = quaternion.Euler(math.radians(45f), math.radians(45f), math.radians(45f));
+            quaternion rotation_nintey = quaternion.Euler(math.radians(90f), math.radians(90f), math.radians(90f));
+            quaternion rotation_ZfortyFive = quaternion.Euler(0f, 0f, math.radians(45f));
+            quaternion rotation_Znintey = quaternion.Euler(0f, 0f, math.radians(90f));
+
+            quaternion rotation_XZ_fortyFive = quaternion.Euler(math.radians(45), 0, math.radians(45));
+            quaternion rotation_XZ_fortyFive_inverse = math.inverse(rotation_XZ_fortyFive);
+            quaternion rotation_XZ_negativeFortyFive = quaternion.Euler(math.radians(-45), 0, math.radians(-45));
+            quaternion rotation_XZ_negativeFortyFive_inverse = math.inverse(rotation_XZ_negativeFortyFive);
+
+
+            LocalToWorld localToWorld_compound = new LocalToWorld()
+            {
+                Value = float4x4.TRS(point_sevenXY, rotation_XZ_fortyFive, point_one*2f)
+            };
+            Assert.That(
+                TransformUtil.ConvertLocalToWorldRotation(localToWorld_compound, quaternion.identity),
+                Is.EqualTo(math.mul(rotation_XZ_fortyFive, quaternion.identity)).Using<quaternion>(EqualityWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertLocalToWorldRotation(localToWorld_compound, rotation_nintey),
+                Is.EqualTo(math.mul(rotation_XZ_fortyFive, rotation_nintey)).Using<quaternion>(EqualityWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertLocalToWorldRotation(localToWorld_compound, rotation_Znintey),
+                Is.EqualTo(math.mul(rotation_XZ_fortyFive, rotation_Znintey)).Using<quaternion>(EqualityWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertLocalToWorldRotation(localToWorld_compound, rotation_fortyFive),
+                Is.EqualTo(math.mul(rotation_XZ_fortyFive, rotation_fortyFive)).Using<quaternion>(EqualityWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertLocalToWorldRotation(localToWorld_compound, rotation_ZfortyFive),
+                Is.EqualTo(math.mul(rotation_XZ_fortyFive, rotation_ZfortyFive)).Using<quaternion>(EqualityWithTolerance)
+                );
+
+            Assert.That(
+                TransformUtil.ConvertLocalToWorldRotation(localToWorld_compound.Value, quaternion.identity),
+                Is.EqualTo(math.mul(rotation_XZ_fortyFive, quaternion.identity)).Using<quaternion>(EqualityWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertLocalToWorldRotation(localToWorld_compound.Value, rotation_nintey),
+                Is.EqualTo(math.mul(rotation_XZ_fortyFive, rotation_nintey)).Using<quaternion>(EqualityWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertLocalToWorldRotation(localToWorld_compound.Value, rotation_Znintey),
+                Is.EqualTo(math.mul(rotation_XZ_fortyFive, rotation_Znintey)).Using<quaternion>(EqualityWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertLocalToWorldRotation(localToWorld_compound.Value, rotation_fortyFive),
+                Is.EqualTo(math.mul(rotation_XZ_fortyFive, rotation_fortyFive)).Using<quaternion>(EqualityWithTolerance)
+                );
+            Assert.That(
+                TransformUtil.ConvertLocalToWorldRotation(localToWorld_compound.Value, rotation_ZfortyFive),
+                Is.EqualTo(math.mul(rotation_XZ_fortyFive, rotation_ZfortyFive)).Using<quaternion>(EqualityWithTolerance)
+                );
+
+
+            LocalToWorld localToWorld_compound_negativeZ = new LocalToWorld()
+            {
+                Value = float4x4.TRS(-point_sevenXY, rotation_XZ_negativeFortyFive, new float3(2f, 2f, -2f))
+            };
+            float4x4 localToWorldMatrix_compound_negativeZ = localToWorld_compound_negativeZ.Value;
+            float3x3 localToWorld_compound_negativeZScale = float3x3.Scale(localToWorldMatrix_compound_negativeZ.GetScale());
+
+            Assert.That(
+                math.mul(new float3x3(TransformUtil.ConvertLocalToWorldRotation(localToWorld_compound_negativeZ, quaternion.identity)), localToWorld_compound_negativeZScale),
+                Is.EqualTo(math.mul((float3x3)localToWorldMatrix_compound_negativeZ, new float3x3(quaternion.identity))).Using<float3x3>(EqualityWithTolerance)
+                );
+            Assert.That(
+                math.mul(new float3x3(TransformUtil.ConvertLocalToWorldRotation(localToWorld_compound_negativeZ, rotation_nintey)), localToWorld_compound_negativeZScale),
+                Is.EqualTo(math.mul((float3x3)localToWorldMatrix_compound_negativeZ, new float3x3(rotation_nintey))).Using<float3x3>(EqualityWithTolerance)
+            );
+            Assert.That(
+                math.mul(new float3x3(TransformUtil.ConvertLocalToWorldRotation(localToWorld_compound_negativeZ, rotation_Znintey)), localToWorld_compound_negativeZScale),
+                Is.EqualTo(math.mul((float3x3)localToWorldMatrix_compound_negativeZ, new float3x3(rotation_Znintey))).Using<float3x3>(EqualityWithTolerance)
+            );
+            Assert.That(
+                math.mul(new float3x3(TransformUtil.ConvertLocalToWorldRotation(localToWorld_compound_negativeZ, rotation_fortyFive)), localToWorld_compound_negativeZScale),
+                Is.EqualTo(math.mul((float3x3)localToWorldMatrix_compound_negativeZ, new float3x3(rotation_fortyFive))).Using<float3x3>(EqualityWithTolerance)
+            );
+            Assert.That(
+                math.mul(new float3x3(TransformUtil.ConvertLocalToWorldRotation(localToWorld_compound_negativeZ, rotation_ZfortyFive)), localToWorld_compound_negativeZScale),
+                Is.EqualTo(math.mul((float3x3)localToWorldMatrix_compound_negativeZ, new float3x3(rotation_ZfortyFive))).Using<float3x3>(EqualityWithTolerance)
+            );
+
+            Assert.That(
+                math.mul(new float3x3(TransformUtil.ConvertLocalToWorldRotation(localToWorldMatrix_compound_negativeZ, quaternion.identity)), localToWorld_compound_negativeZScale),
+                Is.EqualTo(math.mul((float3x3)localToWorldMatrix_compound_negativeZ, new float3x3(quaternion.identity))).Using<float3x3>(EqualityWithTolerance)
+            );
+            Assert.That(
+                math.mul(new float3x3(TransformUtil.ConvertLocalToWorldRotation(localToWorldMatrix_compound_negativeZ, rotation_nintey)), localToWorld_compound_negativeZScale),
+                Is.EqualTo(math.mul((float3x3)localToWorldMatrix_compound_negativeZ, new float3x3(rotation_nintey))).Using<float3x3>(EqualityWithTolerance)
+            );
+            Assert.That(
+                math.mul(new float3x3(TransformUtil.ConvertLocalToWorldRotation(localToWorldMatrix_compound_negativeZ, rotation_Znintey)), localToWorld_compound_negativeZScale),
+                Is.EqualTo(math.mul((float3x3)localToWorldMatrix_compound_negativeZ, new float3x3(rotation_Znintey))).Using<float3x3>(EqualityWithTolerance)
+            );
+            Assert.That(
+                math.mul(new float3x3(TransformUtil.ConvertLocalToWorldRotation(localToWorldMatrix_compound_negativeZ, rotation_fortyFive)), localToWorld_compound_negativeZScale),
+                Is.EqualTo(math.mul((float3x3)localToWorldMatrix_compound_negativeZ, new float3x3(rotation_fortyFive))).Using<float3x3>(EqualityWithTolerance)
+            );
+            Assert.That(
+                math.mul(new float3x3(TransformUtil.ConvertLocalToWorldRotation(localToWorldMatrix_compound_negativeZ, rotation_ZfortyFive)), localToWorld_compound_negativeZScale),
+                Is.EqualTo(math.mul((float3x3)localToWorldMatrix_compound_negativeZ, new float3x3(rotation_ZfortyFive))).Using<float3x3>(EqualityWithTolerance)
+            );
+
+
+            //TODO: #116 - Transforms with non-uniform scale operations are not currently supported.
+            LocalToWorld localToWorld_compound_negativeYZ = new LocalToWorld()
+            {
+                Value = float4x4.TRS(-point_sevenXY, quaternion.identity, new float3(1f, -2f, -1.5f))
+            };
+            float4x4 localToWorldMatrix_compound_negativeYZ = localToWorld_compound_negativeYZ.Value;
+            float3x3 localToWorld_compound_negativeYZScale = float3x3.Scale(localToWorldMatrix_compound_negativeYZ.GetScale());
+
+#if DEBUG
+            // The assert ensures the utility method emits a log message when a non-uniform transform is provided.
+            LogAssert.Expect(LogType.Error, new Regex(@"This conversion does not support transforms with non-uniform scaling\."));
+            TransformUtil.ConvertLocalToWorldRotation(localToWorld_compound_negativeYZ, quaternion.identity);
+            Log.GetLogger(typeof(TransformUtilTests)).Debug("The previous error message is expected.");
+#endif
+
+            // // These follow the template of the asserts for uniform scale transforms. They may or may not result in correct values for
+            // // non-uniform scaling.
+            // Assert.That(
+            //     math.mul(new float3x3(TransformUtil.ConvertLocalToWorldRotation(localToWorld_compound_negativeYZ, quaternion.identity)), localToWorld_compound_negativeYZScale),
+            //     Is.EqualTo(math.mul((float3x3)localToWorldMatrix_compound_negativeYZ, new float3x3(quaternion.identity))).Using<float3x3>(EqualityWithTolerance)
+            //     );
+            // Assert.That(
+            //     math.mul(new float3x3(TransformUtil.ConvertLocalToWorldRotation(localToWorld_compound_negativeYZ, rotation_nintey)), localToWorld_compound_negativeYZScale),
+            //     Is.EqualTo(math.mul((float3x3)localToWorldMatrix_compound_negativeYZ, new float3x3(rotation_nintey))).Using<float3x3>(EqualityWithTolerance)
+            // );
+            // Assert.That(
+            //     math.mul(new float3x3(TransformUtil.ConvertLocalToWorldRotation(localToWorld_compound_negativeYZ, rotation_Znintey)), localToWorld_compound_negativeYZScale),
+            //     Is.EqualTo(math.mul((float3x3)localToWorldMatrix_compound_negativeYZ, new float3x3(rotation_Znintey))).Using<float3x3>(EqualityWithTolerance)
+            // );
+            // Assert.That(
+            //     math.mul(new float3x3(TransformUtil.ConvertLocalToWorldRotation(localToWorld_compound_negativeYZ, rotation_fortyFive)), localToWorld_compound_negativeYZScale),
+            //     Is.EqualTo(math.mul((float3x3)localToWorldMatrix_compound_negativeYZ, new float3x3(rotation_fortyFive))).Using<float3x3>(EqualityWithTolerance)
+            // );
+            // Assert.That(
+            //     math.mul(new float3x3(TransformUtil.ConvertLocalToWorldRotation(localToWorld_compound_negativeYZ, rotation_ZfortyFive)), localToWorld_compound_negativeYZScale),
+            //     Is.EqualTo(math.mul((float3x3)localToWorldMatrix_compound_negativeYZ, new float3x3(rotation_ZfortyFive))).Using<float3x3>(EqualityWithTolerance)
+            // );
+            //
+            // Assert.That(
+            //     math.mul(new float3x3(TransformUtil.ConvertLocalToWorldRotation(localToWorldMatrix_compound_negativeYZ, quaternion.identity)), localToWorld_compound_negativeYZScale),
+            //     Is.EqualTo(math.mul((float3x3)localToWorldMatrix_compound_negativeYZ, new float3x3(quaternion.identity))).Using<float3x3>(EqualityWithTolerance)
+            // );
+            // Assert.That(
+            //     math.mul(new float3x3(TransformUtil.ConvertLocalToWorldRotation(localToWorldMatrix_compound_negativeYZ, rotation_nintey)), localToWorld_compound_negativeYZScale),
+            //     Is.EqualTo(math.mul((float3x3)localToWorldMatrix_compound_negativeYZ, new float3x3(rotation_nintey))).Using<float3x3>(EqualityWithTolerance)
+            // );
+            // Assert.That(
+            //     math.mul(new float3x3(TransformUtil.ConvertLocalToWorldRotation(localToWorldMatrix_compound_negativeYZ, rotation_Znintey)), localToWorld_compound_negativeYZScale),
+            //     Is.EqualTo(math.mul((float3x3)localToWorldMatrix_compound_negativeYZ, new float3x3(rotation_Znintey))).Using<float3x3>(EqualityWithTolerance)
+            // );
+            // Assert.That(
+            //     math.mul(new float3x3(TransformUtil.ConvertLocalToWorldRotation(localToWorldMatrix_compound_negativeYZ, rotation_fortyFive)), localToWorld_compound_negativeYZScale),
+            //     Is.EqualTo(math.mul((float3x3)localToWorldMatrix_compound_negativeYZ, new float3x3(rotation_fortyFive))).Using<float3x3>(EqualityWithTolerance)
+            // );
+            // Assert.That(
+            //     math.mul(new float3x3(TransformUtil.ConvertLocalToWorldRotation(localToWorldMatrix_compound_negativeYZ, rotation_ZfortyFive)), localToWorld_compound_negativeYZScale),
+            //     Is.EqualTo(math.mul((float3x3)localToWorldMatrix_compound_negativeYZ, new float3x3(rotation_ZfortyFive))).Using<float3x3>(EqualityWithTolerance)
+            // );
+        }
+
         //
         // [Test]
         // public static float3 ConvertLocalToWorldScaleTest()

--- a/Scripts/Editor/Tests/Entities/Transform/TransformUtilTests.cs.meta
+++ b/Scripts/Editor/Tests/Entities/Transform/TransformUtilTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 431badb3c9a494fb8ad778a2e0ad9469
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/Runtime/Entities/Transform.meta
+++ b/Scripts/Runtime/Entities/Transform.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 004389e7dd6249df9e5f5bc57de204ef
+timeCreated: 1668546691

--- a/Scripts/Runtime/Entities/Transform/TransformUtil.cs
+++ b/Scripts/Runtime/Entities/Transform/TransformUtil.cs
@@ -1,0 +1,109 @@
+using System;
+using System.Runtime.CompilerServices;
+using Anvil.Unity.Core;
+using Anvil.Unity.DOTS.Mathematics;
+using Unity.Mathematics;
+using Unity.Transforms;
+using UnityEngine;
+
+namespace Anvil.Unity.DOTS.Entities.Transform
+{
+    public static class TransformUtil
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static float3 ConvertWorldToLocalPoint(LocalToWorld localToWorld, float3 point)
+        {
+            return ConvertWorldToLocalPoint(math.inverse(localToWorld.Value), point);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static float3 ConvertWorldToLocalPoint(float4x4 worldToLocalMtx, float3 point)
+        {
+            return math.transform(worldToLocalMtx, point);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static float3 ConvertLocalToWorldPoint(LocalToWorld localToWorld, float3 point)
+        {
+            return ConvertLocalToWorldPoint(localToWorld.Value, point);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static float3 ConvertLocalToWorldPoint(float4x4 localToWorldMtx, float3 point)
+        {
+            return math.transform(localToWorldMtx, point);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static quaternion ConvertWorldToLocalRotation(LocalToWorld localToWorld, quaternion rotation)
+        {
+            return ConvertWorldToLocalRotation(math.inverse(localToWorld.Value), rotation);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static quaternion ConvertWorldToLocalRotation(float4x4 worldToLocalMtx, quaternion rotation)
+        {
+            return math.mul(worldToLocalMtx.GetRotation(), rotation);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static quaternion ConvertLocalToWorldRotation(LocalToWorld localToWorld, quaternion rotation)
+        {
+            return ConvertLocalToWorldRotation(localToWorld.Value, rotation);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static quaternion ConvertLocalToWorldRotation(float4x4 localToWorldMtx, quaternion rotation)
+        {
+            return math.mul(localToWorldMtx.GetRotation(),rotation);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static float3 ConvertLocalToWorldScale(LocalToWorld localToWorld, float3 scale)
+        {
+            return ConvertLocalToWorldScale(localToWorld.Value, scale);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static float3 ConvertLocalToWorldScale(float4x4 localToWorldMtx, float3 scale)
+        {
+            return localToWorldMtx.GetScale() * scale;
+        }
+
+        public static Rect ConvertWorldToLocalRect(LocalToWorld localToWorld, Rect worldRect)
+        {
+            //TODO: #321 - Optimize...
+            float4x4 worldToLocalMtx = math.inverse(localToWorld.Value);
+
+            float3 point1 = (Vector3)worldRect.min;
+            float3 point2 = (Vector3)worldRect.max;
+            float3 point3 = new float3(point1.x, point2.y, 0);
+            float3 point4 = new float3(point2.x, point1.y, 0);
+
+            return RectUtil.CreateFromPoints(
+                ConvertWorldToLocalPoint(worldToLocalMtx, point1).xy,
+                ConvertWorldToLocalPoint(worldToLocalMtx, point2).xy,
+                ConvertWorldToLocalPoint(worldToLocalMtx, point3).xy,
+                ConvertWorldToLocalPoint(worldToLocalMtx, point4).xy
+            );
+        }
+
+        public static Rect ConvertLocalToWorldRect(LocalToWorld localToWorld, Rect localRect)
+        {
+            //TODO: #321 - Optimize...
+            float4x4 worldToLocalMtx = math.inverse(localToWorld.Value);
+
+            float3 point1 = (Vector3)localRect.min;
+            float3 point2 = (Vector3)localRect.max;
+            float3 point3 = new float3(point1.x, point2.y, 0);
+            float3 point4 = new float3(point2.x, point1.y, 0);
+
+            return RectUtil.CreateFromPoints(
+                ConvertLocalToWorldPoint(worldToLocalMtx, point1).xy,
+                ConvertLocalToWorldPoint(worldToLocalMtx, point2).xy,
+                ConvertLocalToWorldPoint(worldToLocalMtx, point3).xy,
+                ConvertLocalToWorldPoint(worldToLocalMtx, point4).xy
+            );
+        }
+    }
+}

--- a/Scripts/Runtime/Entities/Transform/TransformUtil.cs
+++ b/Scripts/Runtime/Entities/Transform/TransformUtil.cs
@@ -61,7 +61,10 @@ namespace Anvil.Unity.DOTS.Entities.Transform
         public static quaternion ConvertLocalToWorldRotation(float4x4 localToWorldMtx, quaternion rotation)
         {
             EmitErrorIfNonUniformScale(localToWorldMtx.GetScale());
-            return math.mul(localToWorldMtx.GetRotation(),rotation);
+            return quaternion.LookRotationSafe(
+                math.rotate(localToWorldMtx, math.mul(rotation, math.forward())),
+                math.rotate(localToWorldMtx, math.mul(rotation, math.up()))
+            );
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/Scripts/Runtime/Entities/Transform/TransformUtil.cs
+++ b/Scripts/Runtime/Entities/Transform/TransformUtil.cs
@@ -27,7 +27,7 @@ namespace Anvil.Unity.DOTS.Entities.Transform
         public static float3 ConvertWorldToLocalPoint(float4x4 worldToLocalMtx, float3 point)
         {
             // If the matrix is invalid it cannot produce reliable transformations and the point is infinite
-            if (!worldToLocalMtx.isValidTransform())
+            if (!worldToLocalMtx.IsValidTransform())
             {
                 Logger.Error("This transform is invalid. Returning a signed infinite position.");
                 return point.ToSignedInfinite();
@@ -46,7 +46,7 @@ namespace Anvil.Unity.DOTS.Entities.Transform
         public static float3 ConvertLocalToWorldPoint(float4x4 localToWorldMtx, float3 point)
         {
             // If the matrix is invalid it cannot produce reliable transformations and the point is infinite
-            if (!localToWorldMtx.isValidTransform())
+            if (!localToWorldMtx.IsValidTransform())
             {
                 Logger.Error("This transform is invalid. Returning a signed infinite position.");
                 return point.ToSignedInfinite();
@@ -65,7 +65,7 @@ namespace Anvil.Unity.DOTS.Entities.Transform
         public static quaternion ConvertWorldToLocalRotation(float4x4 worldToLocalMtx, quaternion rotation)
         {
             // If the matrix is invalid it cannot produce reliable transformations and the rotation is 0
-            if (!worldToLocalMtx.isValidTransform())
+            if (!worldToLocalMtx.IsValidTransform())
             {
                 Logger.Error("Transform is not valid. Returning identity rotation.");
                 return quaternion.identity;
@@ -89,7 +89,7 @@ namespace Anvil.Unity.DOTS.Entities.Transform
         public static quaternion ConvertLocalToWorldRotation(float4x4 localToWorldMtx, quaternion rotation)
         {
             // If the matrix is invalid it cannot produce reliable transformations and the rotation is 0
-            if (!localToWorldMtx.isValidTransform())
+            if (!localToWorldMtx.IsValidTransform())
             {
                 Logger.Error("Transform is not valid. Returning identity rotation.");
                 return quaternion.identity;
@@ -125,7 +125,7 @@ namespace Anvil.Unity.DOTS.Entities.Transform
         public static float3 ConvertWorldToLocalScale(float4x4 worldToLocalMtx, float3 scale)
         {
             // If the matrix is invalid cannot it produce reliable transformations and the scale is infinite
-            if (!worldToLocalMtx.isValidTransform())
+            if (!worldToLocalMtx.IsValidTransform())
             {
                 Logger.Error("This transform is invalid. Returning a signed infinite scale.");
                 return scale.ToSignedInfinite();
@@ -147,7 +147,7 @@ namespace Anvil.Unity.DOTS.Entities.Transform
         public static float3 ConvertLocalToWorldScale(float4x4 localToWorldMtx, float3 scale)
         {
             // If the matrix is invalid cannot it produce reliable transformations and the scale is infinite
-            if (!localToWorldMtx.isValidTransform())
+            if (!localToWorldMtx.IsValidTransform())
             {
                 Logger.Error("This transform is invalid. Returning a signed infinite scale.");
                 return scale.ToSignedInfinite();
@@ -164,7 +164,7 @@ namespace Anvil.Unity.DOTS.Entities.Transform
             //TODO: #321 - Optimize...
 
             // If the matrix is invalid it cannot produce reliable transformations and the rect is infinite
-            if (!localToWorld.Value.isValidTransform())
+            if (!localToWorld.Value.IsValidTransform())
             {
                 Logger.Error("This transform is invalid. Returning infinite min/max rect.");
                 return Rect.MinMaxRect(float.NegativeInfinity, float.NegativeInfinity, float.PositiveInfinity, float.PositiveInfinity);
@@ -188,6 +188,13 @@ namespace Anvil.Unity.DOTS.Entities.Transform
         public static Rect ConvertLocalToWorldRect(LocalToWorld localToWorld, Rect localRect)
         {
             //TODO: #321 - Optimize...
+
+            // If the matrix is invalid it cannot produce reliable transformations and the rect is infinite
+            if (!localToWorld.Value.IsValidTransform())
+            {
+                Logger.Error("This transform is invalid. Returning infinite min/max rect.");
+                return Rect.MinMaxRect(float.NegativeInfinity, float.NegativeInfinity, float.PositiveInfinity, float.PositiveInfinity);
+            }
 
             float3 point1 = (Vector3)localRect.min;
             float3 point2 = (Vector3)localRect.max;

--- a/Scripts/Runtime/Entities/Transform/TransformUtil.cs
+++ b/Scripts/Runtime/Entities/Transform/TransformUtil.cs
@@ -292,7 +292,8 @@ namespace Anvil.Unity.DOTS.Entities.Transform
         /// </remarks>
         public static Rect ConvertWorldToLocalRect(LocalToWorld localToWorld, Rect worldRect)
         {
-            //TODO: #321 - Optimize...
+            //TODO: #119, #118 - Optimize...
+            //TODO: #118 - Consider adopting MinMaxAABB or AABB instead (Unity.Mathematics.Extensions + Unity.Mathematics.Extension.Hybrid)
 
             // If the matrix is invalid it cannot produce reliable transformations and the rect is infinite
             if (!localToWorld.Value.IsValidTransform())
@@ -336,7 +337,8 @@ namespace Anvil.Unity.DOTS.Entities.Transform
         /// </remarks>
         public static Rect ConvertLocalToWorldRect(LocalToWorld localToWorld, Rect localRect)
         {
-            //TODO: #321 - Optimize...
+            //TODO: #119, #118 - Optimize...
+            //TODO: #118 - Consider adopting MinMaxAABB or AABB instead (Unity.Mathematics.Extensions + Unity.Mathematics.Extension.Hybrid)
 
             // If the matrix is invalid it cannot produce reliable transformations and the rect is infinite
             if (!localToWorld.Value.IsValidTransform())

--- a/Scripts/Runtime/Entities/Transform/TransformUtil.cs
+++ b/Scripts/Runtime/Entities/Transform/TransformUtil.cs
@@ -309,7 +309,7 @@ namespace Anvil.Unity.DOTS.Entities.Transform
             float3 point3 = new float3(point1.x, point2.y, 0);
             float3 point4 = new float3(point2.x, point1.y, 0);
 
-            return RectUtil.CreateFromPoints(
+            return RectUtil.CreateBoundingRect(
                 ConvertWorldToLocalPoint(worldToLocalMtx, point1).xy,
                 ConvertWorldToLocalPoint(worldToLocalMtx, point2).xy,
                 ConvertWorldToLocalPoint(worldToLocalMtx, point3).xy,
@@ -352,7 +352,7 @@ namespace Anvil.Unity.DOTS.Entities.Transform
             float3 point3 = new float3(point1.x, point2.y, 0);
             float3 point4 = new float3(point2.x, point1.y, 0);
 
-            return RectUtil.CreateFromPoints(
+            return RectUtil.CreateBoundingRect(
                 ConvertLocalToWorldPoint(localToWorld.Value, point1).xy,
                 ConvertLocalToWorldPoint(localToWorld.Value, point2).xy,
                 ConvertLocalToWorldPoint(localToWorld.Value, point3).xy,

--- a/Scripts/Runtime/Entities/Transform/TransformUtil.cs
+++ b/Scripts/Runtime/Entities/Transform/TransformUtil.cs
@@ -188,7 +188,6 @@ namespace Anvil.Unity.DOTS.Entities.Transform
         public static Rect ConvertLocalToWorldRect(LocalToWorld localToWorld, Rect localRect)
         {
             //TODO: #321 - Optimize...
-            float4x4 worldToLocalMtx = math.inverse(localToWorld.Value);
 
             float3 point1 = (Vector3)localRect.min;
             float3 point2 = (Vector3)localRect.max;
@@ -196,10 +195,10 @@ namespace Anvil.Unity.DOTS.Entities.Transform
             float3 point4 = new float3(point2.x, point1.y, 0);
 
             return RectUtil.CreateFromPoints(
-                ConvertLocalToWorldPoint(worldToLocalMtx, point1).xy,
-                ConvertLocalToWorldPoint(worldToLocalMtx, point2).xy,
-                ConvertLocalToWorldPoint(worldToLocalMtx, point3).xy,
-                ConvertLocalToWorldPoint(worldToLocalMtx, point4).xy
+                ConvertLocalToWorldPoint(localToWorld.Value, point1).xy,
+                ConvertLocalToWorldPoint(localToWorld.Value, point2).xy,
+                ConvertLocalToWorldPoint(localToWorld.Value, point3).xy,
+                ConvertLocalToWorldPoint(localToWorld.Value, point4).xy
             );
         }
 

--- a/Scripts/Runtime/Entities/Transform/TransformUtil.cs
+++ b/Scripts/Runtime/Entities/Transform/TransformUtil.cs
@@ -10,6 +10,9 @@ using Logger = Anvil.CSharp.Logging.Logger;
 
 namespace Anvil.Unity.DOTS.Entities.Transform
 {
+    /// <summary>
+    /// A collection of utilities to help work with transforming values through matrices.
+    /// </summary>
     public static class TransformUtil
     {
         private static Logger Logger
@@ -17,12 +20,28 @@ namespace Anvil.Unity.DOTS.Entities.Transform
             get => Log.GetStaticLogger(typeof(TransformUtil));
         }
 
+        /// <summary>
+        /// Converts a world position value to the local space expressed by a matrix.
+        /// </summary>
+        /// <param name="localToWorld">The local to world transformation matrix. (will be inverted)</param>
+        /// <param name="point">The world position value to convert.</param>
+        /// <returns>The local position value.</returns>
+        /// <remarks>
+        /// NOTE: If calling frequently it may be more performant to invert the <see cref="LocalToWorld.Value"/> matrix
+        /// and call the version of this method that takes a matrix instead.
+        /// </remarks>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static float3 ConvertWorldToLocalPoint(LocalToWorld localToWorld, float3 point)
         {
             return ConvertWorldToLocalPoint(math.inverse(localToWorld.Value), point);
         }
 
+        /// <summary>
+        /// Converts a world position value to the local space expressed by a matrix.
+        /// </summary>
+        /// <param name="worldToLocalMtx">The world to local transformation matrix.</param>
+        /// <param name="point">The world position value to convert.</param>
+        /// <returns>The local position value.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static float3 ConvertWorldToLocalPoint(float4x4 worldToLocalMtx, float3 point)
         {
@@ -36,12 +55,24 @@ namespace Anvil.Unity.DOTS.Entities.Transform
             return math.transform(worldToLocalMtx, point);
         }
 
+        /// <summary>
+        /// Converts a local position value to the world space expressed by a matrix.
+        /// </summary>
+        /// <param name="localToWorld">The local to world transformation matrix.</param>
+        /// <param name="point">The local position value to convert.</param>
+        /// <returns>The world position value.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static float3 ConvertLocalToWorldPoint(LocalToWorld localToWorld, float3 point)
         {
             return ConvertLocalToWorldPoint(localToWorld.Value, point);
         }
 
+        /// <summary>
+        /// Converts a local position value to the world space expressed by a matrix.
+        /// </summary>
+        /// <param name="localToWorldMtx">The local to world transformation matrix.</param>
+        /// <param name="point">The local position value to convert.</param>
+        /// <returns>The world position value.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static float3 ConvertLocalToWorldPoint(float4x4 localToWorldMtx, float3 point)
         {
@@ -55,12 +86,38 @@ namespace Anvil.Unity.DOTS.Entities.Transform
             return math.transform(localToWorldMtx, point);
         }
 
+        /// <summary>
+        /// Converts a world rotation value to the local space expressed by a matrix.
+        ///
+        /// NOTE: Transform matrices with negative scale values may produce output inconsistent with the existing
+        /// component values. The results are still valid but should be applied in tandem with
+        /// <see cref="ConvertWorldToLocalScale"/>.
+        /// (transforms with negative scale may be represented by multiple combinations of rotation and scale)
+        /// </summary>
+        /// <param name="localToWorldMtx">The local to world transformation matrix. (will be inverted)</param>
+        /// <param name="rotation">The world rotation value to convert.</param>
+        /// <returns>The local rotation value.</returns>
+        /// <remarks>
+        /// NOTE: If calling frequently it may be more performant to invert the <see cref="LocalToWorld.Value"/> matrix
+        /// and call the version of this method that takes a matrix instead.
+        /// </remarks>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static quaternion ConvertWorldToLocalRotation(LocalToWorld localToWorld, quaternion rotation)
         {
             return ConvertWorldToLocalRotation(math.inverse(localToWorld.Value), rotation);
         }
 
+        /// <summary>
+        /// Converts a world rotation value to the local space expressed by a matrix.
+        ///
+        /// NOTE: Transform matrices with negative scale values may produce output inconsistent with the existing
+        /// component values. The results are still valid but should be applied in tandem with
+        /// <see cref="ConvertWorldToLocalScale"/>.
+        /// (transforms with negative scale may be represented by multiple combinations of rotation and scale)
+        /// </summary>
+        /// <param name="worldToLocalMtx">The world to local transformation matrix.</param>
+        /// <param name="rotation">The world rotation value to convert.</param>
+        /// <returns>The local rotation value.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static quaternion ConvertWorldToLocalRotation(float4x4 worldToLocalMtx, quaternion rotation)
         {
@@ -79,12 +136,34 @@ namespace Anvil.Unity.DOTS.Entities.Transform
             );
         }
 
+        /// <summary>
+        /// Converts a local rotation value to the world space expressed by a matrix.
+        ///
+        /// NOTE: Transform matrices with negative scale values may produce output inconsistent with the existing
+        /// component values. The results are still valid but should be applied in tandem with
+        /// <see cref="ConvertWorldToLocalScale"/>.
+        /// (transforms with negative scale may be represented by multiple combinations of rotation and scale)
+        /// </summary>
+        /// <param name="localToWorld">The local to world transformation matrix.</param>
+        /// <param name="rotation">The local rotation value to convert.</param>
+        /// <returns>The world rotation value.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static quaternion ConvertLocalToWorldRotation(LocalToWorld localToWorld, quaternion rotation)
         {
             return ConvertLocalToWorldRotation(localToWorld.Value, rotation);
         }
 
+        /// <summary>
+        /// Converts a local rotation value to the world space expressed by a matrix.
+        ///
+        /// NOTE: Transform matrices with negative scale values may produce output inconsistent with the existing
+        /// component values. The results are still valid but should be applied in tandem with
+        /// <see cref="ConvertWorldToLocalScale"/>.
+        /// (transforms with negative scale may be represented by multiple combinations of rotation and scale)
+        /// </summary>
+        /// <param name="localToWorldMtx">The local to world transformation matrix.</param>
+        /// <param name="rotation">The local rotation value to convert.</param>
+        /// <returns>The world rotation value.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static quaternion ConvertLocalToWorldRotation(float4x4 localToWorldMtx, quaternion rotation)
         {
@@ -103,6 +182,21 @@ namespace Anvil.Unity.DOTS.Entities.Transform
             );
         }
 
+        /// <summary>
+        /// Converts a world scale value to the local space expressed by a matrix.
+        ///
+        /// NOTE: Transform matrices with negative scale values may produce output inconsistent with the existing
+        /// component values. The results are still valid but should be applied in tandem with
+        /// <see cref="ConvertWorldToLocalRotation"/>.
+        /// (transforms with negative scale may be represented by multiple combinations of rotation and scale)
+        /// </summary>
+        /// <param name="localToWorld">The local to world transformation matrix. (will be inverted)</param>
+        /// <param name="scale">The world scale value transform.</param>
+        /// <returns>The local scale value.</returns>
+        /// <remarks>
+        /// NOTE: If calling frequently it may be more performant to invert the <see cref="LocalToWorld.Value"/> matrix
+        /// and call the version of this method that takes a matrix instead.
+        /// </remarks>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static float3 ConvertWorldToLocalScale(LocalToWorld localToWorld, float3 scale)
         {
@@ -119,7 +213,6 @@ namespace Anvil.Unity.DOTS.Entities.Transform
         /// </summary>
         /// <param name="worldToLocalMtx">The world to local transformation matrix.</param>
         /// <param name="scale">The world scale value transform.</param>
-        /// <remarks>NOTE: This </remarks>
         /// <returns>The local scale value.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static float3 ConvertWorldToLocalScale(float4x4 worldToLocalMtx, float3 scale)
@@ -137,12 +230,32 @@ namespace Anvil.Unity.DOTS.Entities.Transform
             return worldToLocalScale * scale;
         }
 
+        /// <summary>
+        /// Converts a local scale value to the world space expressed by a matrix.
+        ///
+        /// NOTE: Transform matrices with negative scale values may produce output inconsistent with the existing
+        /// component values. The results are still valid but should be applied in tandem with
+        /// <see cref="ConvertLocalToWorldScale"/>.
+        /// </summary>
+        /// <param name="localToWorld">The local to world transformation matrix.</param>
+        /// <param name="scale">The local scale value transform.</param>
+        /// <returns>The world scale value.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static float3 ConvertLocalToWorldScale(LocalToWorld localToWorld, float3 scale)
         {
             return ConvertLocalToWorldScale(localToWorld.Value, scale);
         }
 
+        /// <summary>
+        /// Converts a local scale value to the world space expressed by a matrix.
+        ///
+        /// NOTE: Transform matrices with negative scale values may produce output inconsistent with the existing
+        /// component values. The results are still valid but should be applied in tandem with
+        /// <see cref="ConvertLocalToWorldScale"/>.
+        /// </summary>
+        /// <param name="localToWorldMtx">The local to world transformation matrix.</param>
+        /// <param name="scale">The local scale value transform.</param>
+        /// <returns>The world scale value.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static float3 ConvertLocalToWorldScale(float4x4 localToWorldMtx, float3 scale)
         {
@@ -159,6 +272,24 @@ namespace Anvil.Unity.DOTS.Entities.Transform
             return localToWorldScale * scale;
         }
 
+        /// <summary>
+        /// Converts a world space <see cref="Rect"/> to a local coordinate space through a <see cref="LocalToWorld"/>
+        /// transform.
+        /// </summary>
+        /// <param name="localToWorld">The transform to apply to the <see cref="Rect"/>.</param>
+        /// <param name="worldRect">The world space <see cref="Rect"/> to convert.</param>
+        /// <returns>The <see cref="Rect"/> represented in the transform's local space.</returns>
+        /// <remarks>
+        /// NOTE: Since the <see cref="Rect"/> is a 2D representation being passed through a 3D transformation the resulting
+        /// rectangle may not represent the same world area. The resulting rectangle is the 2D world (X/Y) world direction
+        /// view of the rectangle after it passes through the transform.
+        ///
+        /// <example>
+        ///     A rectangle that is converted through a transform that rotates 90-degrees on the X-axis will result in a
+        ///     height of 0. All of the world height will have been converted to z-depth and is not captured by the
+        ///     <see cref="Rect"/> object.
+        /// </example>
+        /// </remarks>
         public static Rect ConvertWorldToLocalRect(LocalToWorld localToWorld, Rect worldRect)
         {
             //TODO: #321 - Optimize...
@@ -185,6 +316,24 @@ namespace Anvil.Unity.DOTS.Entities.Transform
             );
         }
 
+        /// <summary>
+        /// Converts a local space <see cref="Rect"/> to a world coordinate space through a <see cref="LocalToWorld"/>
+        /// transform.
+        /// </summary>
+        /// <param name="localToWorld">The transform invert and apply to the <see cref="Rect"/>.</param>
+        /// <param name="localRect">The local space <see cref="Rect"/> to convert.</param>
+        /// <returns>The <see cref="Rect"/> represented in the transform's world space.</returns>
+        /// <remarks>
+        /// NOTE: Since the <see cref="Rect"/> is a 2D representation being passed through a 3D transformation the resulting
+        /// rectangle may not represent the same local area. The resulting rectangle is the 2D (X/Y) world direction
+        /// view of the rectangle after it passes through the transform.
+        ///
+        /// <example>
+        ///     A rectangle that is converted through a transform that rotates 90-degrees on the X-axis will result in a
+        ///     height of 0. All of the local height will have been converted to z-depth and is not captured by the
+        ///     <see cref="Rect"/> object.
+        /// </example>
+        /// </remarks>
         public static Rect ConvertLocalToWorldRect(LocalToWorld localToWorld, Rect localRect)
         {
             //TODO: #321 - Optimize...
@@ -211,7 +360,6 @@ namespace Anvil.Unity.DOTS.Entities.Transform
 
         //TODO: #116 - Transforms with non-uniform scale operations are not currently supported.
         [Conditional("DEBUG")]
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static void EmitErrorIfNonUniformScale(
             float3 scale,
             [CallerMemberName] string callerMethodName = "",

--- a/Scripts/Runtime/Entities/Transform/TransformUtil.cs.meta
+++ b/Scripts/Runtime/Entities/Transform/TransformUtil.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 9d5aaef5d60c4954b2d21e4485abf7ec
+timeCreated: 1668546696

--- a/Scripts/Runtime/anvil-unity-dots-runtime.asmdef
+++ b/Scripts/Runtime/anvil-unity-dots-runtime.asmdef
@@ -8,7 +8,8 @@
         "Unity.Collections",
         "Unity.Entities",
         "Unity.Jobs",
-        "Unity.Mathematics"
+        "Unity.Mathematics",
+        "Unity.Transforms"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],


### PR DESCRIPTION
Add a collection of utility methods for working with spacial transformations in DOTS.

### What is the current behaviour?

There are limited built in operations to convert between local and world contexts in Unity's transform system. Having to repeatedly re-implement the calculations is cumbersome and error prone...particularly when handling edge cases.

### What is the new behaviour?

Add methods that provide the ability to convert the following components between local to world space (and back)
 - Scale
 - Rotation
 - Position
 - Rectangles

These conversions can be performed through either a `LocalToWorld` instance or valid 4x4 matrix(`float4x4) represented.

Note: Transformations that contain non-uniform scale operations are not currently supported. #116 

**Unit Tests**
This PR also includes a robust set of unit tests to help clarify expected behaviour and ensure future optimizations and additional features maintain accurate output.

To help generate expected values I hacked together a quick script that applies transformations to Unity's `GameObject` based hierarchy and prints out the values. This script doesn't have a logical home so it lives as a gist at the link below.
https://gist.github.com/mbaker3/c1f1e83aacb80879c88af8c4638bdfdd


### What issues does this resolve?
- None

### What PRs does this depend on?
 - #121 

### Does this introduce a breaking change?
 - [ ] Yes <!-- If so, what are the migration considerations? -->
 - [x] No
