### PR TITLE
Test name assertions more resilient to refactor

### DIFF
--- a/Scripts/Editor/Tests/Entities/Transform/TransformUtilTests.cs
+++ b/Scripts/Editor/Tests/Entities/Transform/TransformUtilTests.cs
@@ -49,7 +49,7 @@ namespace Anvil.Unity.DOTS.Tests.Entities.Transform
         [Test]
         public static void ConvertWorldToLocalPointTest_Identity()
         {
-            Assert.That(nameof(ConvertWorldToLocalPointTest_Identity), Does.StartWith(nameof(TransformUtil.ConvertWorldToLocalPoint)));
+            Assert.That(nameof(ConvertWorldToLocalPointTest_Identity), Does.StartWith(nameof(TransformUtil.ConvertWorldToLocalPoint) + "Test"));
 
             float3 point_zero = float3.zero;
             float3 point_one = new float3(1, 1, 1);
@@ -78,7 +78,7 @@ namespace Anvil.Unity.DOTS.Tests.Entities.Transform
         [Test]
         public static void ConvertWorldToLocalPointTest_Translate()
         {
-            Assert.That(nameof(ConvertWorldToLocalPointTest_Translate), Does.StartWith(nameof(TransformUtil.ConvertWorldToLocalPoint)));
+            Assert.That(nameof(ConvertWorldToLocalPointTest_Translate), Does.StartWith(nameof(TransformUtil.ConvertWorldToLocalPoint) + "Test"));
 
             float3 point_zero = float3.zero;
             float3 point_one = new float3(1, 1, 1);
@@ -199,7 +199,7 @@ namespace Anvil.Unity.DOTS.Tests.Entities.Transform
         [Test]
         public static void ConvertWorldToLocalPointTest_Rotate()
         {
-            Assert.That(nameof(ConvertWorldToLocalPointTest_Rotate), Does.StartWith(nameof(TransformUtil.ConvertWorldToLocalPoint)));
+            Assert.That(nameof(ConvertWorldToLocalPointTest_Rotate), Does.StartWith(nameof(TransformUtil.ConvertWorldToLocalPoint) + "Test"));
 
             float3 point_zero = float3.zero;
             float3 point_one = new float3(1, 1, 1);
@@ -298,7 +298,7 @@ namespace Anvil.Unity.DOTS.Tests.Entities.Transform
         [Test]
         public static void ConvertWorldToLocalPointTest_Scale()
         {
-            Assert.That(nameof(ConvertWorldToLocalPointTest_Scale), Does.StartWith(nameof(TransformUtil.ConvertWorldToLocalPoint)));
+            Assert.That(nameof(ConvertWorldToLocalPointTest_Scale), Does.StartWith(nameof(TransformUtil.ConvertWorldToLocalPoint) + "Test"));
 
             Regex invalidMatrixError_point = new Regex(@"This transform is invalid\. Returning a signed infinite position\.");
 
@@ -444,7 +444,7 @@ namespace Anvil.Unity.DOTS.Tests.Entities.Transform
         [Test]
         public static void ConvertWorldToLocalPointTest_Compound()
         {
-            Assert.That(nameof(ConvertWorldToLocalPointTest_Compound), Does.StartWith(nameof(TransformUtil.ConvertWorldToLocalPoint)));
+            Assert.That(nameof(ConvertWorldToLocalPointTest_Compound), Does.StartWith(nameof(TransformUtil.ConvertWorldToLocalPoint) + "Test"));
 
             float3 point_zero = float3.zero;
             float3 point_one = new float3(1f, 1f, 1f);
@@ -491,7 +491,7 @@ namespace Anvil.Unity.DOTS.Tests.Entities.Transform
         [Test]
         public static void ConvertLocalToWorldPointTest_Identity()
         {
-            Assert.That(nameof(ConvertLocalToWorldPointTest_Identity), Does.StartWith(nameof(TransformUtil.ConvertLocalToWorldPoint)));
+            Assert.That(nameof(ConvertLocalToWorldPointTest_Identity), Does.StartWith(nameof(TransformUtil.ConvertLocalToWorldPoint) + "Test"));
 
             float3 point_zero = float3.zero;
             float3 point_one = new float3(1, 1, 1);
@@ -520,7 +520,7 @@ namespace Anvil.Unity.DOTS.Tests.Entities.Transform
         [Test]
         public static void ConvertLocalToWorldPointTest_Translate()
         {
-            Assert.That(nameof(ConvertLocalToWorldPointTest_Translate), Does.StartWith(nameof(TransformUtil.ConvertLocalToWorldPoint)));
+            Assert.That(nameof(ConvertLocalToWorldPointTest_Translate), Does.StartWith(nameof(TransformUtil.ConvertLocalToWorldPoint) + "Test"));
 
             float3 point_zero = float3.zero;
             float3 point_one = new float3(1, 1, 1);
@@ -637,7 +637,7 @@ namespace Anvil.Unity.DOTS.Tests.Entities.Transform
         [Test]
         public static void ConvertLocalToWorldPointTest_Rotate()
         {
-            Assert.That(nameof(ConvertLocalToWorldPointTest_Rotate), Does.StartWith(nameof(TransformUtil.ConvertLocalToWorldPoint)));
+            Assert.That(nameof(ConvertLocalToWorldPointTest_Rotate), Does.StartWith(nameof(TransformUtil.ConvertLocalToWorldPoint) + "Test"));
 
             float3 point_zero = float3.zero;
             float3 point_one = new float3(1, 1, 1);
@@ -731,7 +731,7 @@ namespace Anvil.Unity.DOTS.Tests.Entities.Transform
         [Test]
         public static void ConvertLocalToWorldPointTest_Scale()
         {
-            Assert.That(nameof(ConvertLocalToWorldPointTest_Scale), Does.StartWith(nameof(TransformUtil.ConvertLocalToWorldPoint)));
+            Assert.That(nameof(ConvertLocalToWorldPointTest_Scale), Does.StartWith(nameof(TransformUtil.ConvertLocalToWorldPoint) + "Test"));
 
             Regex invalidMatrixError_point = new Regex(@"This transform is invalid\. Returning a signed infinite position\.");
 
@@ -871,7 +871,7 @@ namespace Anvil.Unity.DOTS.Tests.Entities.Transform
         [Test]
         public static void ConvertLocalToWorldPointTest_Compound()
         {
-            Assert.That(nameof(ConvertLocalToWorldPointTest_Compound), Does.StartWith(nameof(TransformUtil.ConvertLocalToWorldPoint)));
+            Assert.That(nameof(ConvertLocalToWorldPointTest_Compound), Does.StartWith(nameof(TransformUtil.ConvertLocalToWorldPoint) + "Test"));
 
             float3 point_zero = float3.zero;
             float3 point_one = new float3(1f, 1f, 1f);
@@ -916,7 +916,7 @@ namespace Anvil.Unity.DOTS.Tests.Entities.Transform
         [Test]
         public static void ConvertWorldToLocalRotationTest_Rotate()
         {
-            Assert.That(nameof(ConvertWorldToLocalRotationTest_Rotate), Does.StartWith(nameof(TransformUtil.ConvertWorldToLocalRotation)));
+            Assert.That(nameof(ConvertWorldToLocalRotationTest_Rotate), Does.StartWith(nameof(TransformUtil.ConvertWorldToLocalRotation) + "Test"));
 
             float3 point_zero = float3.zero;
             float3 point_one = new float3(1f, 1f, 1f);
@@ -1009,7 +1009,7 @@ namespace Anvil.Unity.DOTS.Tests.Entities.Transform
         [Test]
         public static void ConvertWorldToLocalRotationTest_Compound()
         {
-            Assert.That(nameof(ConvertWorldToLocalRotationTest_Compound), Does.StartWith(nameof(TransformUtil.ConvertWorldToLocalRotation)));
+            Assert.That(nameof(ConvertWorldToLocalRotationTest_Compound), Does.StartWith(nameof(TransformUtil.ConvertWorldToLocalRotation) + "Test"));
 
             Regex invalidMatrixError_rotate = new Regex(@"Transform is not valid\. Returning identity rotation\.");
 
@@ -1243,7 +1243,7 @@ namespace Anvil.Unity.DOTS.Tests.Entities.Transform
         [Test]
         public static void ConvertLocalToWorldRotationTest_Rotate()
         {
-            Assert.That(nameof(ConvertLocalToWorldRotationTest_Rotate), Does.StartWith(nameof(TransformUtil.ConvertLocalToWorldRotation)));
+            Assert.That(nameof(ConvertLocalToWorldRotationTest_Rotate), Does.StartWith(nameof(TransformUtil.ConvertLocalToWorldRotation) + "Test"));
 
             float3 point_zero = float3.zero;
             float3 point_one = new float3(1f, 1f, 1f);
@@ -1324,7 +1324,7 @@ namespace Anvil.Unity.DOTS.Tests.Entities.Transform
         [Test]
         public static void ConvertLocalToWorldRotationTest_Compound()
         {
-            Assert.That(nameof(ConvertLocalToWorldRotationTest_Compound), Does.StartWith(nameof(TransformUtil.ConvertLocalToWorldRotation)));
+            Assert.That(nameof(ConvertLocalToWorldRotationTest_Compound), Does.StartWith(nameof(TransformUtil.ConvertLocalToWorldRotation) + "Test"));
 
             Regex invalidMatrixError_rotate = new Regex(@"Transform is not valid\. Returning identity rotation\.");
 
@@ -1553,7 +1553,7 @@ namespace Anvil.Unity.DOTS.Tests.Entities.Transform
         [Test]
         public static void ConvertWorldToLocalScaleTest_Scale()
         {
-            Assert.That(nameof(ConvertWorldToLocalScaleTest_Scale), Does.StartWith(nameof(TransformUtil.ConvertWorldToLocalScale)));
+            Assert.That(nameof(ConvertWorldToLocalScaleTest_Scale), Does.StartWith(nameof(TransformUtil.ConvertWorldToLocalScale) + "Test"));
 
             Regex invalidMatrixError_scale = new Regex(@"This transform is invalid\. Returning a signed infinite scale\.");
             float3 point_zero = float3.zero;
@@ -1829,7 +1829,7 @@ namespace Anvil.Unity.DOTS.Tests.Entities.Transform
         [Test]
         public static void ConvertWorldToLocalScaleTest_Compound()
         {
-            Assert.That(nameof(ConvertWorldToLocalScaleTest_Compound), Does.StartWith(nameof(TransformUtil.ConvertWorldToLocalScale)));
+            Assert.That(nameof(ConvertWorldToLocalScaleTest_Compound), Does.StartWith(nameof(TransformUtil.ConvertWorldToLocalScale) + "Test"));
 
             float3 point_zero = float3.zero;
             float3 point_one = new float3(1f, 1f, 1f);
@@ -1944,7 +1944,7 @@ namespace Anvil.Unity.DOTS.Tests.Entities.Transform
         [Test]
         public static void ConvertLocalToWorldScaleTest_Scale()
         {
-            Assert.That(nameof(ConvertLocalToWorldScaleTest_Scale), Does.StartWith(nameof(TransformUtil.ConvertLocalToWorldScale)));
+            Assert.That(nameof(ConvertLocalToWorldScaleTest_Scale), Does.StartWith(nameof(TransformUtil.ConvertLocalToWorldScale) + "Test"));
 
             Regex invalidMatrixError_scale = new Regex(@"This transform is invalid\. Returning a signed infinite scale\.");
             float3 point_zero = float3.zero;
@@ -2219,7 +2219,7 @@ namespace Anvil.Unity.DOTS.Tests.Entities.Transform
         [Test]
         public static void ConvertLocalToWorldScaleTest_Compound()
         {
-            Assert.That(nameof(ConvertLocalToWorldScaleTest_Compound), Does.StartWith(nameof(TransformUtil.ConvertLocalToWorldScale)));
+            Assert.That(nameof(ConvertLocalToWorldScaleTest_Compound), Does.StartWith(nameof(TransformUtil.ConvertLocalToWorldScale) + "Test"));
 
             float3 point_zero = float3.zero;
             float3 point_one = new float3(1f, 1f, 1f);
@@ -2334,7 +2334,7 @@ namespace Anvil.Unity.DOTS.Tests.Entities.Transform
         [Test]
         public static void ConvertWorldToLocalRectTest_Identity()
         {
-            Assert.That(nameof(ConvertWorldToLocalRectTest_Identity), Does.StartWith(nameof(TransformUtil.ConvertWorldToLocalRect)));
+            Assert.That(nameof(ConvertWorldToLocalRectTest_Identity), Does.StartWith(nameof(TransformUtil.ConvertWorldToLocalRect) + "Test"));
 
             float3 point_zero = float3.zero;
             float3 point_one = new float3(1f);
@@ -2384,7 +2384,7 @@ namespace Anvil.Unity.DOTS.Tests.Entities.Transform
         [Test]
         public static void ConvertWorldToLocalRectTest_Translate()
         {
-            Assert.That(nameof(ConvertWorldToLocalRectTest_Translate), Does.StartWith(nameof(TransformUtil.ConvertWorldToLocalRect)));
+            Assert.That(nameof(ConvertWorldToLocalRectTest_Translate), Does.StartWith(nameof(TransformUtil.ConvertWorldToLocalRect) + "Test"));
 
             float3 point_zero = float3.zero;
             float3 point_one = new float3(1f);
@@ -2534,7 +2534,7 @@ namespace Anvil.Unity.DOTS.Tests.Entities.Transform
         [Test]
         public static void ConvertWorldToLocalRectTest_Rotate()
         {
-            Assert.That(nameof(ConvertWorldToLocalRectTest_Rotate), Does.StartWith(nameof(TransformUtil.ConvertWorldToLocalRect)));
+            Assert.That(nameof(ConvertWorldToLocalRectTest_Rotate), Does.StartWith(nameof(TransformUtil.ConvertWorldToLocalRect) + "Test"));
 
             float3 point_zero = float3.zero;
             float3 point_one = new float3(1f);
@@ -2804,7 +2804,7 @@ namespace Anvil.Unity.DOTS.Tests.Entities.Transform
         [Test]
         public static void ConvertWorldToLocalRectTest_Scale()
         {
-            Assert.That(nameof(ConvertWorldToLocalRectTest_Scale), Does.StartWith(nameof(TransformUtil.ConvertWorldToLocalRect)));
+            Assert.That(nameof(ConvertWorldToLocalRectTest_Scale), Does.StartWith(nameof(TransformUtil.ConvertWorldToLocalRect) + "Test"));
 
             Regex invalidMatrixError_rect = new Regex(@"This transform is invalid\. Returning infinite min/max rect\.");
 
@@ -3216,7 +3216,7 @@ namespace Anvil.Unity.DOTS.Tests.Entities.Transform
         [Test]
         public static void ConvertWorldToLocalRectTest_Compound()
         {
-            Assert.That(nameof(ConvertWorldToLocalRectTest_Compound), Does.StartWith(nameof(TransformUtil.ConvertWorldToLocalRect)));
+            Assert.That(nameof(ConvertWorldToLocalRectTest_Compound), Does.StartWith(nameof(TransformUtil.ConvertWorldToLocalRect) + "Test"));
 
             Rect rect_zero_zero = Rect.zero;
 
@@ -3365,7 +3365,7 @@ namespace Anvil.Unity.DOTS.Tests.Entities.Transform
         [Test]
         public static void ConvertLocalToWorldRectTest_Identity()
         {
-            Assert.That(nameof(ConvertLocalToWorldRectTest_Identity), Does.StartWith(nameof(TransformUtil.ConvertLocalToWorldRect)));
+            Assert.That(nameof(ConvertLocalToWorldRectTest_Identity), Does.StartWith(nameof(TransformUtil.ConvertLocalToWorldRect) + "Test"));
 
             float3 point_zero = float3.zero;
             float3 point_one = new float3(1f);
@@ -3415,7 +3415,7 @@ namespace Anvil.Unity.DOTS.Tests.Entities.Transform
         [Test]
         public static void ConvertLocalToWorldRectTest_Translate()
         {
-            Assert.That(nameof(ConvertLocalToWorldRectTest_Translate), Does.StartWith(nameof(TransformUtil.ConvertLocalToWorldRect)));
+            Assert.That(nameof(ConvertLocalToWorldRectTest_Translate), Does.StartWith(nameof(TransformUtil.ConvertLocalToWorldRect) + "Test"));
 
             float3 point_zero = float3.zero;
             float3 point_one = new float3(1f);
@@ -3565,7 +3565,7 @@ namespace Anvil.Unity.DOTS.Tests.Entities.Transform
         [Test]
         public static void ConvertLocalToWorldRectTest_Rotate()
         {
-            Assert.That(nameof(ConvertLocalToWorldRectTest_Rotate), Does.StartWith(nameof(TransformUtil.ConvertLocalToWorldRect)));
+            Assert.That(nameof(ConvertLocalToWorldRectTest_Rotate), Does.StartWith(nameof(TransformUtil.ConvertLocalToWorldRect) + "Test"));
 
             float3 point_zero = float3.zero;
             float3 point_one = new float3(1f);
@@ -3835,7 +3835,7 @@ namespace Anvil.Unity.DOTS.Tests.Entities.Transform
         [Test]
         public static void ConvertLocalToWorldRectTest_Scale()
         {
-            Assert.That(nameof(ConvertLocalToWorldRectTest_Scale), Does.StartWith(nameof(TransformUtil.ConvertLocalToWorldRect)));
+            Assert.That(nameof(ConvertLocalToWorldRectTest_Scale), Does.StartWith(nameof(TransformUtil.ConvertLocalToWorldRect) + "Test"));
 
             Regex invalidMatrixError_rect = new Regex(@"This transform is invalid\. Returning infinite min/max rect\.");
 
@@ -4247,7 +4247,7 @@ namespace Anvil.Unity.DOTS.Tests.Entities.Transform
         [Test]
         public static void ConvertLocalToWorldRectTest_Compound()
         {
-            Assert.That(nameof(ConvertLocalToWorldRectTest_Compound), Does.StartWith(nameof(TransformUtil.ConvertLocalToWorldRect)));
+            Assert.That(nameof(ConvertLocalToWorldRectTest_Compound), Does.StartWith(nameof(TransformUtil.ConvertLocalToWorldRect) + "Test"));
 
             Rect rect_zero_zero = Rect.zero;
 


### PR DESCRIPTION
Update test name assertions to match convention discussed in the PR below:
https://github.com/decline-cookies/anvil-csharp-core/pull/137

~### What is the current behaviour?~

~### What is the new behaviour?~

~### What issues does this resolve?~
<!-- None is a perfectly valid answer -->

### What PRs does this depend on?
<!-- List PRs in other repos that need to be merged before this one -->
 - None

### Does this introduce a breaking change?
 - [ ] Yes <!-- If so, what are the migration considerations? -->
 - [x] No
