### PR TITLE
Expose `internal` World events

### DIFF
--- a/Scripts/AssemblyInjections.meta
+++ b/Scripts/AssemblyInjections.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b31524c701c72486181b341cdf4bd991
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/AssemblyInjections/Unity.Entities.meta
+++ b/Scripts/AssemblyInjections/Unity.Entities.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 5e4b24a470ea149b09d1a0a0b3d64e69
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/AssemblyInjections/Unity.Entities/Unity.Entities-ref.asmref
+++ b/Scripts/AssemblyInjections/Unity.Entities/Unity.Entities-ref.asmref
@@ -1,0 +1,3 @@
+{
+    "reference": "GUID:734d92eba21c94caba915361bd5ac177"
+}

--- a/Scripts/AssemblyInjections/Unity.Entities/Unity.Entities-ref.asmref.meta
+++ b/Scripts/AssemblyInjections/Unity.Entities/Unity.Entities-ref.asmref.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 3b33459829ad9485fb8b905808cddb59
+AssemblyDefinitionReferenceImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/AssemblyInjections/Unity.Entities/WorldInternal.cs
+++ b/Scripts/AssemblyInjections/Unity.Entities/WorldInternal.cs
@@ -1,0 +1,59 @@
+using System;
+using Unity.Entities;
+
+namespace Anvil.Unity.DOTS.Entities
+{
+    /// <summary>
+    /// A collection of methods to to gain access to static <see cref="World"/> members that are marked internal.
+    /// </summary>
+    public static class WorldInternal
+    {
+        /// <summary>
+        /// Dispatched after a world is created.
+        /// </summary>
+        /// <remarks>
+        /// This is a proxy for the internal <see cref="World.WorldCreated"/> static event that Unity has made internal.
+        /// </remarks>
+        public static event Action<World> OnWorldCreated
+        {
+            add => World.WorldCreated += value;
+            remove => World.WorldCreated -= value;
+        }
+
+        /// <summary>
+        /// Dispatched before a world is destroyed.
+        /// </summary>
+        /// <remarks>
+        /// This is a proxy for the internal <see cref="World.WorldDestroyed"/> static event that Unity has made internal.
+        /// </remarks>
+        public static event Action<World> OnWorldDestroyed
+        {
+            add => World.WorldDestroyed += value;
+            remove => World.WorldDestroyed -= value;
+        }
+
+        /// <summary>
+        /// Dispatched after a system is created.
+        /// </summary>
+        /// <remarks>
+        /// This is a proxy for the internal <see cref="World.SystemCreated"/> static event that Unity has made internal.
+        /// </remarks>
+        public static event Action<World, ComponentSystemBase> OnSystemCreated
+        {
+            add => World.SystemCreated += value;
+            remove => World.SystemCreated -= value;
+        }
+
+        /// <summary>
+        /// Dispatched before a system is destroyed.
+        /// </summary>
+        /// <remarks>
+        /// This is a proxy for the internal <see cref="World.SystemDestroyed"/> static event that Unity has made internal.
+        /// </remarks>
+        public static event Action<World, ComponentSystemBase> OnSystemDestroyed
+        {
+            add => World.SystemDestroyed += value;
+            remove => World.SystemDestroyed -= value;
+        }
+    }
+}

--- a/Scripts/AssemblyInjections/Unity.Entities/WorldInternal.cs.meta
+++ b/Scripts/AssemblyInjections/Unity.Entities/WorldInternal.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: fbbe3a45ce13c4cfaa0110286e708ae6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/Runtime/Entities/Util/WorldUtil.cs
+++ b/Scripts/Runtime/Entities/Util/WorldUtil.cs
@@ -79,10 +79,11 @@ namespace Anvil.Unity.DOTS.Entities
         /// If Unity makes the event public or provides a mechanism for a world instance to know when it is being disposed
         /// this method will be redundant.
         /// </remarks>
+        //TODO: Use assembly injection?
         public static event Action<World> OnWorldDestroyed
         {
-            add => s_WorldDestroyedEvent.AddEventHandler(null, value);
-            remove => s_WorldDestroyedEvent.RemoveEventHandler(null, value);
+            add => s_WorldDestroyedEvent.AddMethod.Invoke(null, new[] { value });
+            remove => s_WorldDestroyedEvent.RemoveMethod.Invoke(null, new[] { value });
         }
 
         /// <summary>
@@ -94,8 +95,8 @@ namespace Anvil.Unity.DOTS.Entities
         /// </remarks>
         public static event Action<World> OnWorldCreated
         {
-            add => s_WorldCreatedEvent.AddEventHandler(null, value);
-            remove => s_WorldCreatedEvent.RemoveEventHandler(null, value);
+            add => s_WorldCreatedEvent.AddMethod.Invoke(null, new[] { value });
+            remove => s_WorldCreatedEvent.RemoveMethod.Invoke(null, new[] { value });
         }
 
         // No need to reset between play sessions because PlayerLoop systems are stateless and
@@ -105,10 +106,10 @@ namespace Anvil.Unity.DOTS.Entities
         static WorldUtil()
         {
             Debug.Assert(s_WorldDestroyedEvent != null);
-            Debug.Assert(s_WorldDestroyedEvent.EventHandlerType != typeof(Action<World>));
+            Debug.Assert(s_WorldDestroyedEvent.EventHandlerType == typeof(Action<World>));
 
             Debug.Assert(s_WorldCreatedEvent != null);
-            Debug.Assert(s_WorldCreatedEvent.EventHandlerType != typeof(Action<World>));
+            Debug.Assert(s_WorldCreatedEvent.EventHandlerType == typeof(Action<World>));
         }
 
         /// <summary>

--- a/Scripts/Runtime/Entities/Util/WorldUtil.cs
+++ b/Scripts/Runtime/Entities/Util/WorldUtil.cs
@@ -68,16 +68,29 @@ namespace Anvil.Unity.DOTS.Entities
     /// </summary>
     public static class WorldUtil
     {
-        private static readonly EventInfo s_WorldDestroyedEvent = typeof(World).GetEvent("WorldDestroyed", BindingFlags.Static | BindingFlags.NonPublic);
         private static readonly EventInfo s_WorldCreatedEvent = typeof(World).GetEvent("WorldCreated", BindingFlags.Static | BindingFlags.NonPublic);
+        private static readonly EventInfo s_WorldDestroyedEvent = typeof(World).GetEvent("WorldDestroyed", BindingFlags.Static | BindingFlags.NonPublic);
+        private static readonly EventInfo s_SystemCreatedEvent = typeof(World).GetEvent("SystemCreated", BindingFlags.Static | BindingFlags.NonPublic);
+        private static readonly EventInfo s_SystemDestroyedEvent = typeof(World).GetEvent("SystemDestroyed", BindingFlags.Static | BindingFlags.NonPublic);
+
+        /// <summary>
+        /// Dispatched after a world is created.
+        /// </summary>
+        /// <remarks>
+        /// This is a proxy for the internal <see cref="World.WorldCreated"/> static event that Unity has made internal.
+        /// </remarks>
+        //TODO: Use assembly injection?
+        public static event Action<World> OnWorldCreated
+        {
+            add => s_WorldCreatedEvent.AddMethod.Invoke(null, new[] { value });
+            remove => s_WorldCreatedEvent.RemoveMethod.Invoke(null, new[] { value });
+        }
 
         /// <summary>
         /// Dispatched before a world is destroyed.
         /// </summary>
         /// <remarks>
         /// This is a proxy for the internal <see cref="World.WorldDestroyed"/> static event that Unity has made internal.
-        /// If Unity makes the event public or provides a mechanism for a world instance to know when it is being disposed
-        /// this method will be redundant.
         /// </remarks>
         //TODO: Use assembly injection?
         public static event Action<World> OnWorldDestroyed
@@ -87,16 +100,29 @@ namespace Anvil.Unity.DOTS.Entities
         }
 
         /// <summary>
-        /// Dispatched after a world is created.
+        /// Dispatched after a system is created.
         /// </summary>
         /// <remarks>
-        /// This is a proxy for the internal <see cref="World.WorldCreated"/> static event that Unity has made internal.
-        /// Added for the sake of completion after adding <see cref="OnWorldDestroyed"/>.
+        /// This is a proxy for the internal <see cref="World.SystemCreated"/> static event that Unity has made internal.
         /// </remarks>
-        public static event Action<World> OnWorldCreated
+        //TODO: Use assembly injection?
+        public static event Action<World, ComponentSystemBase> OnSystemCreated
         {
-            add => s_WorldCreatedEvent.AddMethod.Invoke(null, new[] { value });
-            remove => s_WorldCreatedEvent.RemoveMethod.Invoke(null, new[] { value });
+            add => s_SystemCreatedEvent.AddMethod.Invoke(null, new[] { value });
+            remove => s_SystemCreatedEvent.RemoveMethod.Invoke(null, new[] { value });
+        }
+
+        /// <summary>
+        /// Dispatched before a system is destroyed.
+        /// </summary>
+        /// <remarks>
+        /// This is a proxy for the internal <see cref="World.SystemDestroyed"/> static event that Unity has made internal.
+        /// </remarks>
+        //TODO: Use assembly injection?
+        public static event Action<World, ComponentSystemBase> OnSystemDestroyed
+        {
+            add => s_SystemDestroyedEvent.AddMethod.Invoke(null, new[] { value });
+            remove => s_SystemDestroyedEvent.RemoveMethod.Invoke(null, new[] { value });
         }
 
         // No need to reset between play sessions because PlayerLoop systems are stateless and

--- a/Scripts/Runtime/Entities/Util/WorldUtil.cs
+++ b/Scripts/Runtime/Entities/Util/WorldUtil.cs
@@ -63,80 +63,16 @@ namespace Anvil.Unity.DOTS.Entities
     }
 
     /// <summary>
-    /// A collection of utilities to manipulate and augments <see cref="World"/>s.
+    /// A collection of utilities to manipulate and augment <see cref="World"/>s.
     /// The Anvil compliment to <see cref="ScriptBehaviourUpdateOrder"/>.
     /// </summary>
     public static class WorldUtil
     {
-        private static readonly EventInfo s_WorldCreatedEvent = typeof(World).GetEvent("WorldCreated", BindingFlags.Static | BindingFlags.NonPublic);
-        private static readonly EventInfo s_WorldDestroyedEvent = typeof(World).GetEvent("WorldDestroyed", BindingFlags.Static | BindingFlags.NonPublic);
-        private static readonly EventInfo s_SystemCreatedEvent = typeof(World).GetEvent("SystemCreated", BindingFlags.Static | BindingFlags.NonPublic);
-        private static readonly EventInfo s_SystemDestroyedEvent = typeof(World).GetEvent("SystemDestroyed", BindingFlags.Static | BindingFlags.NonPublic);
-
-        /// <summary>
-        /// Dispatched after a world is created.
-        /// </summary>
-        /// <remarks>
-        /// This is a proxy for the internal <see cref="World.WorldCreated"/> static event that Unity has made internal.
-        /// </remarks>
-        //TODO: Use assembly injection?
-        public static event Action<World> OnWorldCreated
-        {
-            add => s_WorldCreatedEvent.AddMethod.Invoke(null, new[] { value });
-            remove => s_WorldCreatedEvent.RemoveMethod.Invoke(null, new[] { value });
-        }
-
-        /// <summary>
-        /// Dispatched before a world is destroyed.
-        /// </summary>
-        /// <remarks>
-        /// This is a proxy for the internal <see cref="World.WorldDestroyed"/> static event that Unity has made internal.
-        /// </remarks>
-        //TODO: Use assembly injection?
-        public static event Action<World> OnWorldDestroyed
-        {
-            add => s_WorldDestroyedEvent.AddMethod.Invoke(null, new[] { value });
-            remove => s_WorldDestroyedEvent.RemoveMethod.Invoke(null, new[] { value });
-        }
-
-        /// <summary>
-        /// Dispatched after a system is created.
-        /// </summary>
-        /// <remarks>
-        /// This is a proxy for the internal <see cref="World.SystemCreated"/> static event that Unity has made internal.
-        /// </remarks>
-        //TODO: Use assembly injection?
-        public static event Action<World, ComponentSystemBase> OnSystemCreated
-        {
-            add => s_SystemCreatedEvent.AddMethod.Invoke(null, new[] { value });
-            remove => s_SystemCreatedEvent.RemoveMethod.Invoke(null, new[] { value });
-        }
-
-        /// <summary>
-        /// Dispatched before a system is destroyed.
-        /// </summary>
-        /// <remarks>
-        /// This is a proxy for the internal <see cref="World.SystemDestroyed"/> static event that Unity has made internal.
-        /// </remarks>
-        //TODO: Use assembly injection?
-        public static event Action<World, ComponentSystemBase> OnSystemDestroyed
-        {
-            add => s_SystemDestroyedEvent.AddMethod.Invoke(null, new[] { value });
-            remove => s_SystemDestroyedEvent.RemoveMethod.Invoke(null, new[] { value });
-        }
-
         // No need to reset between play sessions because PlayerLoop systems are stateless and
         // persist between sessions when domain reloading is disabled.
         private static bool s_AreCustomPlayerLoopPhasesAdded = false;
 
-        static WorldUtil()
-        {
-            Debug.Assert(s_WorldDestroyedEvent != null);
-            Debug.Assert(s_WorldDestroyedEvent.EventHandlerType == typeof(Action<World>));
-
-            Debug.Assert(s_WorldCreatedEvent != null);
-            Debug.Assert(s_WorldCreatedEvent.EventHandlerType == typeof(Action<World>));
-        }
+        static WorldUtil() { }
 
         /// <summary>
         /// Add custom phases to the <see cref="PlayerLoop"/>.


### PR DESCRIPTION
Add `WorldInternal` to expose `internal static` events on the `World` type.

## Tag Along
 - `WorldUtil` add empty static constructor
 - `WorldUtil` fix typo in docs

### What is the current behaviour?

There is no easy way to access the following static events on `World`:
 - `WorldCreated`
 - `WorldDestroyed`
 - `SystemCreated`
 - `SystemDestroyed`

### What is the new behaviour?

Using assembly referencing developers can now easily listen to these events using the methods in `WorldInternal` without the need to use reflection.

### What issues does this resolve?
None

### What PRs does this depend on?
 - None

### Does this introduce a breaking change?
 - [ ] Yes <!-- If so, what are the migration considerations? -->
 - [x] No
