### PR TITLE
Move `ComponentDataFromSingleEntity` and `BufferDataFromSingleEntity` to extension methods

### DIFF
--- a/Scripts/Runtime/Entities/AbstractAnvilSystemBase.cs
+++ b/Scripts/Runtime/Entities/AbstractAnvilSystemBase.cs
@@ -52,53 +52,6 @@ namespace Anvil.Unity.DOTS.Entities
         {
         }
 
-        // ----- Buffer and Component Getters for Jobs ----- //
-        /// <summary>
-        /// Builds a container to provide in job access to a singleton <see cref="DynamicBuffer{T}" />.
-        /// </summary>
-        /// <typeparam name="T">The element type of the <see cref="DynamicBuffer{T}" />.</typeparam>
-        /// <param name="isReadOnly">true if the data will not be written to.</param>
-        /// <returns>A container that provides in job access to the requested <see cref="DynamicBuffer{T}" />.</returns>
-        protected BufferFromSingleEntity<T> GetBufferFromSingletonEntity<T>(bool isReadOnly = false) where T : struct, IBufferElementData
-        {
-            return new BufferFromSingleEntity<T>(GetBufferFromEntity<T>(isReadOnly), GetSingletonEntity<T>());
-        }
-
-        /// <summary>
-        /// Builds a container to provide in job access to a <see cref="DynamicBuffer{T}" /> on an entity.
-        /// </summary>
-        /// <typeparam name="T">The element type of the <see cref="DynamicBuffer{T}" />.</typeparam>
-        /// <param name="entity">The <see cref="Entity" /> to get the <see cref="DynamicBuffer{T}" /> from.</param>
-        /// <param name="isReadOnly">true if the data will not be written to.</param>
-        /// <returns>A container that provides in job access to the requested <see cref="DynamicBuffer{T}" />.</returns>
-        protected BufferFromSingleEntity<T> GetBufferFromSingleEntity<T>(Entity entity, bool isReadOnly = false) where T : struct, IBufferElementData
-        {
-            return new BufferFromSingleEntity<T>(GetBufferFromEntity<T>(isReadOnly), entity);
-        }
-
-        /// <summary>
-        /// Builds a container to provide in job access to a singleton <see cref="IComponentData" />.
-        /// </summary>
-        /// <typeparam name="T">The type that implements <see cref="IComponentData" />.</typeparam>
-        /// <param name="isReadOnly">true if the data will not be written to.</param>
-        /// <returns>A container that provides in job access to the requested <see cref="T" />.</returns>
-        protected ComponentDataFromSingleEntity<T> GetComponentDataFromSingletonEntity<T>(bool isReadOnly) where T : struct, IComponentData
-        {
-            return new ComponentDataFromSingleEntity<T>(GetComponentDataFromEntity<T>(isReadOnly), GetSingletonEntity<T>());
-        }
-
-        /// <summary>
-        /// Builds a container to provide in job access to a <see cref="IComponentData{T}" /> on an entity.
-        /// </summary>
-        /// <typeparam name="T">The element type of the <see cref="IComponentData" />.</typeparam>
-        /// <param name="entity">The <see cref="Entity" /> to get the <see cref="T" /> from.</param>
-        /// <param name="isReadOnly">true if the data will not be written to.</param>
-        /// <returns>A container that provides in job access to the requested <see cref="T" />.</returns>
-        protected ComponentDataFromSingleEntity<T> GetComponentDataFromSingleEntity<T>(Entity entity, bool isReadOnly) where T : struct, IComponentData
-        {
-            return new ComponentDataFromSingleEntity<T>(GetComponentDataFromEntity<T>(isReadOnly), entity);
-        }
-
         // ----- Copy From Buffers ----- //
         /// <summary>
         /// Schedule a job to asynchronously copy a singleton <see cref="DynamicBuffer{T}" /> to

--- a/Scripts/Runtime/Entities/Data/BufferFromSingleEntity.cs
+++ b/Scripts/Runtime/Entities/Data/BufferFromSingleEntity.cs
@@ -1,16 +1,20 @@
 using Unity.Collections;
+using Unity.Collections.LowLevel.Unsafe;
 using Unity.Entities;
 
 
 namespace Anvil.Unity.DOTS.Entities
 {
     /// <summary>
-    /// A container that provides access to a <see cref="DynamicBuffer{T}" from a single entity.
+    /// A container that provides access to a <see cref="DynamicBuffer{T}"/> from a single entity.
     /// </summary>
     /// <typeparam name="T">The element type of the buffer</typeparam>
     /// <remarks>Allows developers to define jobs with fewer parameters that clearly communicate intent.</remarks>
     public struct BufferFromSingleEntity<T> where T : struct, IBufferElementData
     {
+        //TODO: #115 - Implement a safety check to make sure there isn't another lookup/entity combination in flight.
+        // Until the above is implemented leave it to consuming jobs to add the attributes.
+        [NativeDisableContainerSafetyRestriction]
         [NativeDisableParallelForRestriction]
         private BufferFromEntity<T> m_Lookup;
         private readonly Entity m_Entity;
@@ -27,7 +31,7 @@ namespace Anvil.Unity.DOTS.Entities
         }
 
         /// <summary>
-        /// Gets the <see cref="DynamicBuffer{T}" />. 
+        /// Gets the <see cref="DynamicBuffer{T}" />.
         /// Call during job execution.
         /// </summary>
         /// <returns>The <see cref="DynamicBuffer{T}" /> instance</returns>

--- a/Scripts/Runtime/Entities/Data/ComponentDataFromSingleEntity.cs
+++ b/Scripts/Runtime/Entities/Data/ComponentDataFromSingleEntity.cs
@@ -10,6 +10,9 @@ namespace Anvil.Unity.DOTS.Entities
     /// <remarks>Allows developers to define jobs with fewer parameters that clearly communicate intent.</remarks>
     public readonly struct ComponentDataFromSingleEntity<T> where T : struct, IComponentData
     {
+        //TODO: #115 - Implement a safety check to make sure there isn't another lookup/entity combination in flight.
+        // Until the above is implemented leave it to consuming jobs to add the attributes.
+        // [NativeDisableContainerSafetyRestriction]
         private readonly ComponentDataFromEntity<T> m_Lookup;
         private readonly Entity m_Entity;
 
@@ -25,7 +28,7 @@ namespace Anvil.Unity.DOTS.Entities
         }
 
         /// <summary>
-        /// Gets the <see cref="DynamicBuffer{T}" />. 
+        /// Gets the <see cref="DynamicBuffer{T}" />.
         /// Call during job execution.
         /// </summary>
         /// <returns>The <see cref="T" /> instance</returns>

--- a/Scripts/Runtime/Entities/Data/ComponentDataFromSingleEntity.cs
+++ b/Scripts/Runtime/Entities/Data/ComponentDataFromSingleEntity.cs
@@ -28,7 +28,7 @@ namespace Anvil.Unity.DOTS.Entities
         }
 
         /// <summary>
-        /// Gets the <see cref="DynamicBuffer{T}" />.
+        /// Gets the <see cref="T" />.
         /// Call during job execution.
         /// </summary>
         /// <returns>The <see cref="T" /> instance</returns>

--- a/Scripts/Runtime/Entities/Util/BufferFromEntityExtension.cs
+++ b/Scripts/Runtime/Entities/Util/BufferFromEntityExtension.cs
@@ -1,0 +1,23 @@
+using Unity.Entities;
+
+namespace Anvil.Unity.DOTS.Entities
+{
+    /// <summary>
+    /// A collection of extension methods for working with <see cref="BufferFromEntity{T}"/>
+    /// </summary>
+    public static class BufferFromEntityExtension
+    {
+        /// <summary>
+        /// Builds a container to provide in job access to a <see cref="DynamicBuffer{T}"/> on an entity.
+        /// </summary>
+        /// <param name="lookup">The <see cref="BufferFromEntity{T}"/> instance to get the <see cref="T"/> from</param>
+        /// <param name="entity">The <see cref="Entity" /> to get the <see cref="T"/> from.</param>
+        /// <typeparam name="T">The element type of the <see cref="DynamicBuffer"/>.</typeparam>
+        /// <returns>A container that provides in job access to the requested <see cref="T"/>.</returns>
+        public static BufferFromSingleEntity<T> ForSingleEntity<T>(this BufferFromEntity<T> lookup, Entity entity)
+            where T : struct, IBufferElementData
+        {
+            return new BufferFromSingleEntity<T>(lookup, entity);
+        }
+    }
+}

--- a/Scripts/Runtime/Entities/Util/BufferFromEntityExtension.cs.meta
+++ b/Scripts/Runtime/Entities/Util/BufferFromEntityExtension.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 83630841931d43a88180abb53e42b410
+timeCreated: 1668721036

--- a/Scripts/Runtime/Entities/Util/ComponentDataFromEntityExtension.cs
+++ b/Scripts/Runtime/Entities/Util/ComponentDataFromEntityExtension.cs
@@ -1,0 +1,23 @@
+using Unity.Entities;
+
+namespace Anvil.Unity.DOTS.Entities
+{
+    /// <summary>
+    /// A collection of extension methods for working with <see cref="ComponentDataFromEntity{T}"/>
+    /// </summary>
+    public static class ComponentDataFromEntityExtension
+    {
+        /// <summary>
+        /// Builds a container to provide in job access to a <see cref="IComponentData{T}"/> on an entity.
+        /// </summary>
+        /// <param name="lookup">The <see cref="ComponentDataFromEntity{T}"/> instance to get the <see cref="T"/> from</param>
+        /// <param name="entity">The <see cref="Entity" /> to get the <see cref="T"/> from.</param>
+        /// <typeparam name="T">The element type of the <see cref="IComponentData"/>.</typeparam>
+        /// <returns>A container that provides in job access to the requested <see cref="T"/>.</returns>
+        public static ComponentDataFromSingleEntity<T> ForSingleEntity<T>(this ComponentDataFromEntity<T> lookup, Entity entity)
+            where T : struct, IComponentData
+        {
+            return new ComponentDataFromSingleEntity<T>(lookup, entity);
+        }
+    }
+}

--- a/Scripts/Runtime/Entities/Util/ComponentDataFromEntityExtension.cs.meta
+++ b/Scripts/Runtime/Entities/Util/ComponentDataFromEntityExtension.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 1581211ed10a41788251feffe6b5802c
+timeCreated: 1668720417

--- a/Scripts/Runtime/Entities/Util/ComponentSystemBaseExtension.cs
+++ b/Scripts/Runtime/Entities/Util/ComponentSystemBaseExtension.cs
@@ -1,0 +1,64 @@
+using Unity.Entities;
+
+namespace Anvil.Unity.DOTS.Entities
+{
+    /// <summary>
+    /// A collection of extension methods for working with <see cref="ComponentSystemBaseExtension"/>
+    /// </summary>
+    public static class ComponentSystemBaseExtension
+    {
+        /// <summary>
+        /// Builds a container to provide in job access to a singleton <see cref="DynamicBuffer{T}"/>.
+        /// </summary>
+        /// <param name="isReadOnly">true if the data will not be written to.</param>
+        /// <typeparam name="T">The element type of the <see cref="DynamicBuffer{T}"/>.</typeparam>
+        /// <returns>A container that provides in job access to the requested <see cref="DynamicBuffer{T}"/>.</returns>
+        public static BufferFromSingleEntity<T> GetBufferFromSingletonEntity<T>(this ComponentSystemBase system, bool isReadOnly = false) where T : struct, IBufferElementData
+        {
+            return system.GetBufferFromEntity<T>(isReadOnly).ForSingleEntity(system.GetSingletonEntity<T>());
+        }
+
+        /// <summary>
+        /// Builds a container to provide in job access to a <see cref="DynamicBuffer{T}"/> on an entity.
+        /// </summary>
+        /// <param name="entity">The <see cref="Entity"/> to get the <see cref="DynamicBuffer{T}"/> from.</param>
+        /// <param name="isReadOnly">true if the data will not be written to.</param>
+        /// <typeparam name="T">The element type of the <see cref="DynamicBuffer{T}"/>.</typeparam>
+        /// <returns>A container that provides in job access to the requested <see cref="DynamicBuffer{T}"/>.</returns>
+        /// <remarks>
+        /// If fetching many single entity containers at once, getting a <see cref="BufferFromEntity{T}"/> instance and
+        /// calling <see cref="BufferFromEntityExtension.ForSingleEntity{T}"/> is more efficient.
+        /// </remarks>
+        public static BufferFromSingleEntity<T> GetBufferFromSingleEntity<T>(this ComponentSystemBase system, Entity entity, bool isReadOnly = false) where T : struct, IBufferElementData
+        {
+            return system.GetBufferFromEntity<T>(isReadOnly).ForSingleEntity(entity);
+        }
+
+        /// <summary>
+        /// Builds a container to provide in job access to a singleton <see cref="IComponentData"/>.
+        /// </summary>
+        /// <param name="isReadOnly">true if the data will not be written to.</param>
+        /// <typeparam name="T">The type that implements <see cref="IComponentData"/>.</typeparam>
+        /// <returns>A container that provides in job access to the requested <see cref="T"/>.</returns>
+        public static ComponentDataFromSingleEntity<T> GetComponentDataFromSingletonEntity<T>(this ComponentSystemBase system, bool isReadOnly) where T : struct, IComponentData
+        {
+            return system.GetComponentDataFromEntity<T>(isReadOnly).ForSingleEntity(system.GetSingletonEntity<T>());
+        }
+
+        /// <summary>
+        /// Builds a container to provide in job access to a <see cref="IComponentData{T}"/> on an entity.
+        /// </summary>
+        /// <param name="entity">The <see cref="Entity"/> to get the <see cref="T"/> from.</param>
+        /// <param name="isReadOnly">true if the data will not be written to.</param>
+        /// <typeparam name="T">The element type of the <see cref="IComponentData"/>.</typeparam>
+        /// <returns>A container that provides in job access to the requested <see cref="T"/>.</returns>
+        /// <remarks>
+        /// If fetching many single entity containers at once, getting a <see cref="ComponentDataFromEntity{T}"/> instance and
+        /// calling <see cref="ComponentDataFromEntityExtension.ForSingleEntity{T}"/> is more efficient.
+        /// </remarks>
+        public static ComponentDataFromSingleEntity<T> GetComponentDataFromSingleEntity<T>(this ComponentSystemBase system, Entity entity, bool isReadOnly) where T : struct, IComponentData
+        {
+            return system.GetComponentDataFromEntity<T>(isReadOnly).ForSingleEntity(entity);
+        }
+    }
+}

--- a/Scripts/Runtime/Entities/Util/ComponentSystemBaseExtension.cs.meta
+++ b/Scripts/Runtime/Entities/Util/ComponentSystemBaseExtension.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: f0a8f51a0a7e43409176aa68ef1e8b10
+timeCreated: 1668720709


### PR DESCRIPTION
Move `ComponentDataFromSingleEntity` and `BufferDataFromSingleEntity` out of `AbstractAnilSystemBase` to extension methods so they may be used when working with any stock entities system/CDFE/BDFE.

### What is the current behaviour?

Developers must subclass `AbstractAnvilSystemBase` to get access to convenience methods to create single entity CDFE/BDFE instances.

### What is the new behaviour?

Developers get access to the convenience methods when using any stock CDFE, BDFE, or `ComponentSystemBase`

### What issues does this resolve?
 - None

### What PRs does this depend on?
 - None

### Does this introduce a breaking change?
 - [ ] Yes
 - [x] No - The extension methods have the same signature, they're just defined in a new location and more widely available. It should just work ™️ 
