### PR TITLE
`AccessControlledValue`/`AccessController` - Add AccessHandle for safer sync use

### DIFF
--- a/Scripts/Runtime/Job/AccessControl/AccessControlledValue.cs
+++ b/Scripts/Runtime/Job/AccessControl/AccessControlledValue.cs
@@ -1,6 +1,5 @@
 using Anvil.CSharp.Core;
 using System;
-using Unity.Collections;
 using Unity.Jobs;
 
 namespace Anvil.Unity.DOTS.Jobs
@@ -63,12 +62,12 @@ namespace Anvil.Unity.DOTS.Jobs
         /// <see cref="AccessControlledValue{T}"/>. Paired with a using statement access to the value will be released
         /// when the handle falls out of scope.
         /// </remarks>
-        /// <example>using var valueHandle = myAccessControlledValue.AcquireAsHandle(AccessType.SharedRead);</example>
+        /// <example>using var valueHandle = myAccessControlledValue.AcquireWithHandle(AccessType.SharedRead);</example>
         /// <param name="accessType">The type of <see cref="AccessType"/> needed.</param>
         /// <returns>
         /// The <see cref="AccessHandle"/> that maintains access to the controlled value until disposed.
         /// </returns>
-        public AccessHandle AcquireAsHandle(AccessType accessType)
+        public AccessHandle AcquireWithHandle(AccessType accessType)
         {
             return new AccessHandle(this, accessType);
         }
@@ -148,23 +147,25 @@ namespace Anvil.Unity.DOTS.Jobs
             /// </summary>
             public readonly T Value;
 
-            private readonly AccessControlledValue<T> m_Access;
+            private readonly AccessControlledValue<T> m_Controller;
 
 
             /// <summary>
-            /// Creates a new instance that gains synchronous access from the provided value controller.
+            /// Creates a new instance that gains synchronous access from the provided
+            /// <see cref="AccessControlledValue{T}"/>.
             /// </summary>
-            /// <param name="access">The access controlled value to acquire from.</param>
+            /// <param name="controller">The <see cref="AccessControlledValue{T}"/> to acquire from.</param>
             /// <param name="accessType">The type of <see cref="AccessType"/> needed.</param>
-            public AccessHandle(AccessControlledValue<T> access, AccessType accessType)
+            public AccessHandle(AccessControlledValue<T> controller, AccessType accessType)
             {
-                Value = access.Acquire(accessType);
-                m_Access = access;
+                Value = controller.Acquire(accessType);
+                m_Controller = controller;
             }
 
+            /// <inheritdoc cref="IDisposable"/>
             public void Dispose()
             {
-                m_Access.Release();
+                m_Controller.Release();
             }
         }
     }

--- a/Scripts/Runtime/Job/AccessControl/AccessController.cs
+++ b/Scripts/Runtime/Job/AccessControl/AccessController.cs
@@ -136,6 +136,25 @@ namespace Anvil.Unity.DOTS.Jobs
         }
 
         /// <summary>
+        /// Acquires access synchronously for a given <see cref="AccessType"/> and returns an <see cref="AccessHandle"/>.
+        /// This is the preferred method of synchronous access vs <see cref="Acquire"/>/<see cref="Release"/>.
+        /// </summary>
+        /// <remarks>
+        /// The <see cref="AccessHandle"/> is a safer way to synchronously maintain access to an
+        /// <see cref="AccessController{T}"/>. Paired with a using statement access to the controller will be released
+        /// when the handle falls out of scope.
+        /// </remarks>
+        /// <example>using var valueHandle = myAccessController.AcquireWithHandle(AccessType.SharedRead);</example>
+        /// <param name="accessType">The type of <see cref="AccessType"/> needed.</param>
+        /// <returns>
+        /// The <see cref="AccessHandle"/> that maintains access to the controller until disposed.
+        /// </returns>
+        public AccessHandle AcquireWithHandle(AccessType accessType)
+        {
+            return new AccessHandle(this, accessType);
+        }
+
+        /// <summary>
         /// Acquires access synchronously for a given <see cref="AccessType"/>
         /// Will block on the calling thread if there are any jobs that need to complete before this
         /// can be used.
@@ -283,6 +302,39 @@ namespace Anvil.Unity.DOTS.Jobs
             if (!releaseAccessDependency.DependsOn(m_LastHandleAcquired))
             {
                 throw new InvalidOperationException($"Dependency Chain Broken: The {nameof(JobHandle)} passed into {nameof(ReleaseAsync)} is not part of the chain from the {nameof(JobHandle)} that was given in the last call to {nameof(AcquireAsync)}. Check to ensure your ordering of {nameof(AcquireAsync)} and {nameof(ReleaseAsync)} match.");
+            }
+        }
+
+        // ----- Inner Types ----- //
+        /// <summary>
+        /// A convenience type that provides a synchronous handle to the <see cref="AccessController"/> that is released
+        /// when disposed.
+        /// </summary>
+        /// <remarks>
+        /// This type is the equivalent of calling <see cref="AccessController.Acquire"/> and
+        /// <see cref="AccessController.Release"/> yourself but is intended to be used with a using statement so
+        /// that the handle is always released.
+        /// </remarks>
+        public readonly struct AccessHandle : IDisposable
+        {
+            private readonly AccessController m_Controller;
+
+
+            /// <summary>
+            /// Creates a new instance that gains synchronous access from the provided controller.
+            /// </summary>
+            /// <param name="access">The <see cref="AccessController"/> to acquire from.</param>
+            /// <param name="accessType">The type of <see cref="AccessType"/> needed.</param>
+            public AccessHandle(AccessController controller, AccessType accessType)
+            {
+                m_Controller = controller;
+                m_Controller.Acquire(accessType);
+            }
+
+            /// <inheritdoc cref="IDisposable"/>
+            public void Dispose()
+            {
+                m_Controller.Release();
             }
         }
     }


### PR DESCRIPTION
Provide a more convenient, and safer, way to acquire `AccessControlledValue`/`AccessController` when being used synchronously.

### What is the current behaviour?

When working with `AccessControlledValue`/`AccessController` in a synchronous context the developer must follow the pattern of:
1. Acquire
2. Use
3. Release

It's easy to forget to release and the code is very verbose for what is often a quick use operation (lookup check, append/remove, etc..)

### What is the new behaviour?

Developers can now call `AcquireWithHandle()` to get a readonly container that is `IDisposable`. This allows us to leverage the `using` keyword for quick and easy access.

**Example:**
``` csharp
using var lookup = IDToEntityLookup.AcquireWithHandle(AccessType.SharedRead);
lookup.Value.ContainsKey(someKey);

// lookup will be automatically released when it falls out of scope on the stack.
```

### What issues does this resolve?
 - None

### What PRs does this depend on?
<!-- List PRs in other repos that need to be merged before this one -->
 - #127 

### Does this introduce a breaking change?
 - [ ] Yes <!-- If so, what are the migration considerations? -->
 - [x] No
