### PR TITLE
TransformUtil - Make logging burst compatible

### DIFF
--- a/Scripts/Runtime/Entities/Transform/TransformUtil.cs
+++ b/Scripts/Runtime/Entities/Transform/TransformUtil.cs
@@ -1,24 +1,28 @@
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
-using Anvil.CSharp.Logging;
 using Anvil.Unity.Core;
+using Anvil.Unity.DOTS.Logging;
 using Anvil.Unity.DOTS.Mathematics;
+using Anvil.Unity.Logging;
+using Unity.Burst;
+using Unity.Collections;
 using Unity.Mathematics;
 using Unity.Transforms;
 using UnityEngine;
-using Logger = Anvil.CSharp.Logging.Logger;
 
 namespace Anvil.Unity.DOTS.Entities.Transform
 {
     /// <summary>
     /// A collection of utilities to help work with transforming values through matrices.
     /// </summary>
+    [BurstCompile]
     public static class TransformUtil
     {
-        private static Logger Logger
+        private static BurstableLogger<FixedString32Bytes> Logger
         {
-            get => Log.GetStaticLogger(typeof(TransformUtil));
+            get => new BurstableLogger<FixedString32Bytes>(string.Empty);
         }
+
 
         /// <summary>
         /// Converts a world position value to the local space expressed by a matrix.
@@ -48,7 +52,7 @@ namespace Anvil.Unity.DOTS.Entities.Transform
             // If the matrix is invalid it cannot produce reliable transformations and the point is infinite
             if (!worldToLocalMtx.IsValidTransform())
             {
-                Logger.Error("This transform is invalid. Returning a signed infinite position.");
+                Logger.Error<FixedString128Bytes>("This transform is invalid. Returning a signed infinite position.");
                 return point.ToSignedInfinite();
             }
 
@@ -79,7 +83,7 @@ namespace Anvil.Unity.DOTS.Entities.Transform
             // If the matrix is invalid it cannot produce reliable transformations and the point is infinite
             if (!localToWorldMtx.IsValidTransform())
             {
-                Logger.Error("This transform is invalid. Returning a signed infinite position.");
+                Logger.Error<FixedString128Bytes>("This transform is invalid. Returning a signed infinite position.");
                 return point.ToSignedInfinite();
             }
 
@@ -220,7 +224,7 @@ namespace Anvil.Unity.DOTS.Entities.Transform
             // If the matrix is invalid cannot it produce reliable transformations and the scale is infinite
             if (!worldToLocalMtx.IsValidTransform())
             {
-                Logger.Error("This transform is invalid. Returning a signed infinite scale.");
+                Logger.Error<FixedString128Bytes>("This transform is invalid. Returning a signed infinite scale.");
                 return scale.ToSignedInfinite();
             }
 
@@ -262,7 +266,7 @@ namespace Anvil.Unity.DOTS.Entities.Transform
             // If the matrix is invalid cannot it produce reliable transformations and the scale is infinite
             if (!localToWorldMtx.IsValidTransform())
             {
-                Logger.Error("This transform is invalid. Returning a signed infinite scale.");
+                Logger.Error<FixedString128Bytes>("This transform is invalid. Returning a signed infinite scale.");
                 return scale.ToSignedInfinite();
             }
 
@@ -362,22 +366,14 @@ namespace Anvil.Unity.DOTS.Entities.Transform
 
         //TODO: #116 - Transforms with non-uniform scale operations are not currently supported.
         [Conditional("DEBUG")]
-        private static void EmitErrorIfNonUniformScale(
-            float3 scale,
-            [CallerMemberName] string callerMethodName = "",
-            [CallerFilePath] string callerFilePath = "",
-            [CallerLineNumber] int callerLineNumber = 0)
+        [UnityLogListener.Exclude]
+        private static void EmitErrorIfNonUniformScale(float3 scale)
         {
             scale = math.abs(scale);
             bool isUniform = scale.x.IsApproximately(scale.y) && scale.y.IsApproximately(scale.z);
             if (!isUniform)
             {
-                Logger.Error(
-                    "This conversion does not support transforms with non-uniform scaling.",
-                    callerMethodName,
-                    callerFilePath,
-                    callerLineNumber
-                    );
+                Logger.Error<FixedString128Bytes>("This conversion does not support transforms with non-uniform scaling.");
             }
         }
     }

--- a/Scripts/Runtime/Logging/BurstableLogger.cs
+++ b/Scripts/Runtime/Logging/BurstableLogger.cs
@@ -198,14 +198,17 @@ namespace Anvil.Unity.DOTS.Logging
         {
 #if UNITY_ASSERTIONS
             //Manually assert since Debug.Assert doesn't provide any useful information and does not support custom messages.
+
+            // Assume that message that was filled to capacity was truncated. It falsely errors when message length was
+            // exactly equal to capacity but it's the best we can do.
             if (message.Length == message.Capacity)
             {
-                UnityEngine.Debug.LogError($"The next logged message is too long and will be truncated. Consider using a larger FixedString type. MaxLength: {message.Capacity}");
+                UnityEngine.Debug.LogError($"The next logged message is too long and will be truncated. Consider using a larger FixedString type. MessageLength:{message.Length}, MaxLength: {message.Capacity}");
             }
 
             if (message.Length + MessagePrefix.Length > FixedString4096Bytes.UTF8MaxLengthInBytes)
             {
-                UnityEngine.Debug.LogError($"The next MessagePrefix + Message is larger than the largest fixed string({FixedString4096Bytes.UTF8MaxLengthInBytes}) and will be truncated. MessageLength:{message.Length} MessagePrefix: {MessagePrefix.Length}");
+                UnityEngine.Debug.LogError($"The next MessagePrefix + Message is larger than the largest fixed string({FixedString4096Bytes.UTF8MaxLengthInBytes}) and will be truncated. MessageLength:{message.Length}, MessagePrefix: {MessagePrefix.Length}");
             }
 #endif
         }


### PR DESCRIPTION
`TransformUtil` is now explicitly burst compatible.

#### Tag Alongs
 - `BurstableLogger` - Include more information in error log messages
 - `BurstableLogger` - Add comment to explain less than ideal "too long string" check.
(There are a surprising number of 64 and 61 character long log messages in `TransformUtil`)

### What is the current behaviour?

`TransformUtil` is mostly burst compatible but the log messages aren't particularly helpful in a bursted context.

### What is the new behaviour?

`TransformUtil` is now explicitly marked with `BurstCompile` and all logging goes through a `BurstableLogger` 

### What issues does this resolve?
 - None

### What PRs does this depend on?
 - #130 - Not really but it wasn't worth the time to rebase.

### Does this introduce a breaking change?
 - [ ] Yes <!-- If so, what are the migration considerations? -->
 - [x] No
