### PR TITLE
TransformUtil - Add AddMissingStandardComponents

### DIFF
--- a/Scripts/Editor/Tests/Entities/Transform/TransformUtilTests.cs
+++ b/Scripts/Editor/Tests/Entities/Transform/TransformUtilTests.cs
@@ -3,6 +3,7 @@ using Anvil.CSharp.Logging;
 using Anvil.Unity.Core;
 using Anvil.Unity.DOTS.Entities.Transform;
 using NUnit.Framework;
+using Unity.Entities;
 using Unity.Mathematics;
 using Unity.Transforms;
 using UnityEngine;
@@ -43,6 +44,63 @@ namespace Anvil.Unity.DOTS.Tests.Entities.Transform
         private static int EquivalencyWithTolerance(Rect a, Rect b)
         {
             return RectUtil.AreEquivalent(a, b) ? 0 : 1;
+        }
+
+        // ----- AddMissingStandardComponents ---- //
+        [Test]
+        public static void AddMissingStandardComponentsTest_NoComponents()
+        {
+            Assert.That(nameof(AddMissingStandardComponentsTest_NoComponents), Does.StartWith(nameof(TransformUtil.AddMissingStandardComponents) + "Test"));
+
+            using World world = new World(nameof(TransformUtilTests) + "World");
+            EntityManager entityManager = world.EntityManager;
+            Entity entity = entityManager.CreateEntity();
+
+            TransformUtil.AddMissingStandardComponents(entity, entityManager);
+
+            Assert.That(entityManager.GetComponentData<Translation>(entity).Value, Is.EqualTo(float3.zero));
+            Assert.That(entityManager.GetComponentData<Rotation>(entity).Value, Is.EqualTo(quaternion.identity));
+            Assert.That(entityManager.GetComponentData<Scale>(entity).Value, Is.EqualTo(1f));
+        }
+
+        [Test]
+        public static void AddMissingStandardComponentsTest_AllComponents()
+        {
+            Assert.That(nameof(AddMissingStandardComponentsTest_AllComponents), Does.StartWith(nameof(TransformUtil.AddMissingStandardComponents) + "Test"));
+
+            using World world = new World(nameof(TransformUtilTests) + "World");
+            EntityManager entityManager = world.EntityManager;
+            Entity entity = entityManager.CreateEntity(typeof(Translation), typeof(Rotation), typeof(Scale));
+
+            entityManager.SetComponentData(entity, new Translation(){Value = new float3(5f)});
+            entityManager.SetComponentData(entity, new Rotation(){Value = quaternion.Euler(45f, 45f, 0f)});
+            entityManager.SetComponentData(entity, new Scale(){Value = 5f});
+            TransformUtil.AddMissingStandardComponents(entity, entityManager);
+
+            Assert.That(entityManager.GetComponentData<Translation>(entity).Value, Is.EqualTo(new float3(5f)));
+            Assert.That(entityManager.GetComponentData<Rotation>(entity).Value, Is.EqualTo(quaternion.Euler(45f, 45f, 0f)));
+            Assert.That(entityManager.GetComponentData<Scale>(entity).Value, Is.EqualTo(5f));
+        }
+
+        [Test]
+        public static void AddMissingStandardComponentsTest_AllAltComponents()
+        {
+            Assert.That(nameof(AddMissingStandardComponentsTest_AllAltComponents), Does.StartWith(nameof(TransformUtil.AddMissingStandardComponents) + "Test"));
+
+            using World world = new World(nameof(TransformUtilTests) + "World");
+            EntityManager entityManager = world.EntityManager;
+            Entity entity = entityManager.CreateEntity(typeof(Translation), typeof(CompositeRotation), typeof(NonUniformScale));
+
+            entityManager.SetComponentData(entity, new Translation(){Value = new float3(5f)});
+            entityManager.SetComponentData(entity, new CompositeRotation(){Value = float4x4.RotateX(45f)});
+            entityManager.SetComponentData(entity, new NonUniformScale(){Value = new float3(1f, 2f, 3f)});
+            TransformUtil.AddMissingStandardComponents(entity, entityManager);
+
+            Assert.That(entityManager.GetComponentData<Translation>(entity).Value, Is.EqualTo(new float3(5f)));
+            Assert.That(entityManager.GetComponentData<CompositeRotation>(entity).Value, Is.EqualTo(float4x4.RotateX(45f)));
+            Assert.That(entityManager.GetComponentData<NonUniformScale>(entity).Value, Is.EqualTo(new float3(1f, 2f, 3f)));
+            Assert.That(entityManager.HasComponent<Rotation>(entity), Is.False);
+            Assert.That(entityManager.HasComponent<Scale>(entity), Is.False);
         }
 
         // ----- ConvertWorldToLocalPoint ----- //

--- a/Scripts/Runtime/Entities/Transform/TransformUtil.cs
+++ b/Scripts/Runtime/Entities/Transform/TransformUtil.cs
@@ -6,14 +6,16 @@ using Anvil.Unity.DOTS.Mathematics;
 using Anvil.Unity.Logging;
 using Unity.Burst;
 using Unity.Collections;
+using Unity.Entities;
 using Unity.Mathematics;
 using Unity.Transforms;
 using UnityEngine;
+using Debug = UnityEngine.Debug;
 
 namespace Anvil.Unity.DOTS.Entities.Transform
 {
     /// <summary>
-    /// A collection of utilities to help work with transforming values through matrices.
+    /// A collection of utilities to help work with and transforming values through matrices.
     /// </summary>
     [BurstCompile]
     public static class TransformUtil
@@ -23,6 +25,31 @@ namespace Anvil.Unity.DOTS.Entities.Transform
             get => new BurstableLogger<FixedString32Bytes>(string.Empty);
         }
 
+        /// <summary>
+        /// Adds any missing transform components to an <see cref="Entity"/> to express basic translation, rotation, and
+        /// scale. If a standard component isn't present it is added with an identity value.
+        /// </summary>
+        /// <param name="entity">The <see cref="Entity"/> to fill components on.</param>
+        /// <param name="entityManager">The <see cref="EntityManager"/> for the <see cref="Entity"/></param>
+        public static void AddMissingStandardComponents(Entity entity, EntityManager entityManager)
+        {
+            Debug.Assert(entityManager.Exists(entity));
+
+            if (!entityManager.HasComponent<Translation>(entity))
+            {
+                entityManager.AddComponentData(entity, new Translation() { Value = float3.zero });
+            }
+
+            if (!entityManager.HasComponent<Scale>(entity) && !entityManager.HasComponent<NonUniformScale>(entity))
+            {
+                entityManager.AddComponentData(entity, new Scale() { Value = 1 });
+            }
+
+            if (!entityManager.HasComponent<Rotation>(entity) && !entityManager.HasComponent<CompositeRotation>(entity))
+            {
+                entityManager.AddComponentData(entity, new Rotation() { Value = quaternion.identity });
+            }
+        }
 
         /// <summary>
         /// Converts a world position value to the local space expressed by a matrix.


### PR DESCRIPTION
Add a utility method to add a standard set of transform components to an `Entity` if those components are missing.

I'm open to changing the name of the method if you have a better idea.

### What is the current behaviour?

Unity's game object conversion system doesn't add transform components during conversion if those components are default values (Ex: Scale 1,1,1).

This can cause issues if there are systems that expect to modify or query these values at runtime.

### What is the new behaviour?

`TransformUtil.AddMissingStandardComponents` analyzes the components on an entity and adds any missing components with default values to ensure there are at least basic components for rotation, translation and uniform scale.

Although it is slightly more efficient to omit the values when they are default values having the components present makes for a much smoother development experience. Cutting out unused components is better suited to an optimization pass for high count archetypes.

This method is also suitable for use at runtime.

### What issues does this resolve?
 - None

### What PRs does this depend on?
 - None

### Does this introduce a breaking change?
 - [ ] Yes <!-- If so, what are the migration considerations? -->
 - [x] No
