### PR TITLE
Exposing the Logger

### DIFF
--- a/Scripts/Runtime/Entities/TaskDriver/AbstractTaskDriver.cs
+++ b/Scripts/Runtime/Entities/TaskDriver/AbstractTaskDriver.cs
@@ -57,7 +57,11 @@ namespace Anvil.Unity.DOTS.Entities.TaskDriver
             }
         }
 
-
+        Logger ITaskSetOwner.TaskSetOwnerLogger
+        {
+            get => Logger;
+        }
+        
         protected AbstractTaskDriver(World world)
         {
             World = world;

--- a/Scripts/Runtime/Entities/TaskDriver/AbstractTaskDriver.cs
+++ b/Scripts/Runtime/Entities/TaskDriver/AbstractTaskDriver.cs
@@ -57,11 +57,6 @@ namespace Anvil.Unity.DOTS.Entities.TaskDriver
             }
         }
 
-        Logger ITaskSetOwner.TaskSetOwnerLogger
-        {
-            get => Logger;
-        }
-        
         protected AbstractTaskDriver(World world)
         {
             World = world;

--- a/Scripts/Runtime/Entities/TaskDriver/AbstractTaskDriver.cs
+++ b/Scripts/Runtime/Entities/TaskDriver/AbstractTaskDriver.cs
@@ -26,10 +26,10 @@ namespace Anvil.Unity.DOTS.Entities.TaskDriver
 
         private readonly List<AbstractTaskDriver> m_SubTaskDrivers;
         private readonly uint m_ID;
-        
+
         private bool m_IsHardened;
         private bool m_HasCancellableData;
-        
+
         /// <summary>
         /// Reference to the associated <see cref="World"/>
         /// </summary>
@@ -67,7 +67,7 @@ namespace Anvil.Unity.DOTS.Entities.TaskDriver
 
             Type taskDriverType = GetType();
             Type taskDriverSystemType = TASK_DRIVER_SYSTEM_TYPE.MakeGenericType(taskDriverType);
-            
+
             //If this is the first TaskDriver of this type, then the System will have been created for this World.
             TaskDriverSystem = (AbstractTaskDriverSystem)World.GetExistingSystem(taskDriverSystemType);
             //If not, then we will want to explicitly create it and ensure it is part of the lifecycle.
@@ -152,7 +152,7 @@ namespace Anvil.Unity.DOTS.Entities.TaskDriver
         //*************************************************************************************************************
         // JOB CONFIGURATION - DRIVER LEVEL
         //*************************************************************************************************************
-        
+
         /// <summary>
         /// Configures a Job that is triggered by instances being present in the passed in <see cref="IDriverDataStream{TInstance}"/>
         /// </summary>
@@ -170,7 +170,7 @@ namespace Anvil.Unity.DOTS.Entities.TaskDriver
                                                    scheduleJobFunction,
                                                    batchStrategy);
         }
-        
+
         /// <summary>
         /// Configures a Job that is triggered by <see cref="Entity"/> or <see cref="IComponentData"/> being
         /// present in the passed in <see cref="EntityQuery"/>
@@ -187,7 +187,7 @@ namespace Anvil.Unity.DOTS.Entities.TaskDriver
                                                    scheduleJobFunction,
                                                    batchStrategy);
         }
-        
+
         /// <summary>
         /// Configures a Job that is triggered by the cancellation of instances in this <see cref="AbstractTaskDriver"/>
         /// completing.
@@ -226,7 +226,7 @@ namespace Anvil.Unity.DOTS.Entities.TaskDriver
 
             //Harden our own TaskSet
             TaskSet.Harden();
-            
+
             //TODO: #138 - Can we consolidate this into the TaskSet and have TaskSets aware of parenting instead
             m_HasCancellableData = TaskSet.ExplicitCancellationCount > 0
                                 || TaskDriverSystem.HasCancellableData

--- a/Scripts/Runtime/Entities/TaskDriver/System/AbstractTaskDriverSystem.cs
+++ b/Scripts/Runtime/Entities/TaskDriver/System/AbstractTaskDriverSystem.cs
@@ -43,6 +43,10 @@ namespace Anvil.Unity.DOTS.Entities.TaskDriver
             }
         }
 
+        public Logger TaskSetOwnerLogger
+        {
+            get => Logger;
+        }
 
         protected AbstractTaskDriverSystem(World world)
         {

--- a/Scripts/Runtime/Entities/TaskDriver/System/AbstractTaskDriverSystem.cs
+++ b/Scripts/Runtime/Entities/TaskDriver/System/AbstractTaskDriverSystem.cs
@@ -21,7 +21,7 @@ namespace Anvil.Unity.DOTS.Entities.TaskDriver
         private bool m_HasCancellableData;
 
         public AbstractTaskDriverSystem TaskDriverSystem { get => this; }
-        
+
         //Note - This represents the World that was passed in by the TaskDriver during this system's construction.
         //Normally a system doesn't get a World until OnCreate is called and the System.World will return null. 
         //We need a valid World in the constructor so we get one and assign it to this property instead.
@@ -219,7 +219,7 @@ namespace Anvil.Unity.DOTS.Entities.TaskDriver
                 throw new InvalidOperationException($"Expected {this} to be Hardened but it hasn't yet!");
             }
         }
-        
+
         [Conditional("ENABLE_UNITY_COLLECTIONS_CHECKS")]
         private void Debug_EnsureWorldsAreTheSame()
         {

--- a/Scripts/Runtime/Entities/TaskDriver/System/AbstractTaskDriverSystem.cs
+++ b/Scripts/Runtime/Entities/TaskDriver/System/AbstractTaskDriverSystem.cs
@@ -43,11 +43,6 @@ namespace Anvil.Unity.DOTS.Entities.TaskDriver
             }
         }
 
-        public Logger TaskSetOwnerLogger
-        {
-            get => Logger;
-        }
-
         protected AbstractTaskDriverSystem(World world)
         {
             World = world;

--- a/Scripts/Runtime/Entities/TaskDriver/TaskSet/ITaskSetOwner.cs
+++ b/Scripts/Runtime/Entities/TaskDriver/TaskSet/ITaskSetOwner.cs
@@ -1,3 +1,4 @@
+using Anvil.CSharp.Logging;
 using System;
 using System.Collections.Generic;
 using Unity.Entities;
@@ -14,6 +15,8 @@ namespace Anvil.Unity.DOTS.Entities.TaskDriver
         public List<AbstractTaskDriver> SubTaskDrivers { get; }
         
         public bool HasCancellableData { get; }
+        
+        public Logger TaskSetOwnerLogger { get; }
 
         public void AddResolvableDataStreamsTo(Type type, List<AbstractDataStream> dataStreams);
     }

--- a/Scripts/Runtime/Entities/TaskDriver/TaskSet/ITaskSetOwner.cs
+++ b/Scripts/Runtime/Entities/TaskDriver/TaskSet/ITaskSetOwner.cs
@@ -1,4 +1,3 @@
-using Anvil.CSharp.Logging;
 using System;
 using System.Collections.Generic;
 using Unity.Entities;
@@ -15,8 +14,6 @@ namespace Anvil.Unity.DOTS.Entities.TaskDriver
         public List<AbstractTaskDriver> SubTaskDrivers { get; }
         
         public bool HasCancellableData { get; }
-        
-        public Logger TaskSetOwnerLogger { get; }
 
         public void AddResolvableDataStreamsTo(Type type, List<AbstractDataStream> dataStreams);
     }

--- a/Scripts/Runtime/Entities/TaskDriver/TaskSet/Job/JobConfig/AbstractJobConfig.cs
+++ b/Scripts/Runtime/Entities/TaskDriver/TaskSet/Job/JobConfig/AbstractJobConfig.cs
@@ -94,6 +94,7 @@ namespace Anvil.Unity.DOTS.Entities.TaskDriver
         /// <inheritdoc cref="IJobConfig.RunOnce"/>
         public IJobConfig RunOnce()
         {
+            IsEnabled = true;
             m_ShouldDisableAfterNextRun = true;
             return this;
         }

--- a/Scripts/Runtime/Entities/TaskDriver/TaskSet/Job/JobConfig/Interface/IJobConfig.cs
+++ b/Scripts/Runtime/Entities/TaskDriver/TaskSet/Job/JobConfig/Interface/IJobConfig.cs
@@ -18,10 +18,11 @@ namespace Anvil.Unity.DOTS.Entities.TaskDriver
 
         /// <summary>
         /// A configuration helper that will run this job only once.
-        /// After being run, it will set <see cref="IsEnabled"/> to false.
+        /// It will set <see cref="IsEnabled"/> to true, and then after being run,
+        /// it will set <see cref="IsEnabled"/> to false.
         /// </summary>
         /// <remarks>
-        /// This is useful for the initial setup jobs.
+        /// This is useful for the initial setup jobs or to run once after making some structural changes.
         /// </remarks>
         /// <returns>A reference to itself to continue chaining configuration methods</returns>
         public IJobConfig RunOnce();

--- a/Scripts/Runtime/Entities/TaskDriver/TaskSet/Job/JobData/AbstractJobData.cs
+++ b/Scripts/Runtime/Entities/TaskDriver/TaskSet/Job/JobData/AbstractJobData.cs
@@ -17,8 +17,6 @@ namespace Anvil.Unity.DOTS.Entities.TaskDriver
         /// Reference to the <see cref="World"/> this job will be running in.
         /// </summary>
         public World World { get; }
-        
-        public Logger TaskSetOwnerLogger { get; }
 
         /// <summary>
         /// Convenience helper to get the <see cref="TimeData"/> for delta time and other related functions.
@@ -27,9 +25,6 @@ namespace Anvil.Unity.DOTS.Entities.TaskDriver
         {
             get => ref World.Time;
         }
-
-        
-
 
         protected AbstractJobData(IJobConfig jobConfig)
         {
@@ -126,7 +121,7 @@ namespace Anvil.Unity.DOTS.Entities.TaskDriver
             EntityPersistentData<TData> persistentData = m_JobConfig.GetEntityPersistentData<TData>();
             return persistentData.CreateEntityPersistentDataReader();
         }
-        
+
         public EntityPersistentDataWriter<TData> GetEntityPersistentDataWriter<TData>()
             where TData : unmanaged
         {
@@ -140,7 +135,7 @@ namespace Anvil.Unity.DOTS.Entities.TaskDriver
             PersistentData<TData> persistentData = m_JobConfig.GetPersistentData<TData>();
             return persistentData.CreatePersistentDataWriter();
         }
-        
+
         public PersistentDataReader<TData> GetPersistentDataReader<TData>()
             where TData : unmanaged
         {

--- a/Scripts/Runtime/Entities/TaskDriver/TaskSet/Job/JobData/AbstractJobData.cs
+++ b/Scripts/Runtime/Entities/TaskDriver/TaskSet/Job/JobData/AbstractJobData.cs
@@ -1,3 +1,4 @@
+using Anvil.CSharp.Logging;
 using Unity.Collections;
 using Unity.Core;
 using Unity.Entities;
@@ -16,6 +17,8 @@ namespace Anvil.Unity.DOTS.Entities.TaskDriver
         /// Reference to the <see cref="World"/> this job will be running in.
         /// </summary>
         public World World { get; }
+        
+        public Logger TaskSetOwnerLogger { get; }
 
         /// <summary>
         /// Convenience helper to get the <see cref="TimeData"/> for delta time and other related functions.
@@ -24,6 +27,8 @@ namespace Anvil.Unity.DOTS.Entities.TaskDriver
         {
             get => ref World.Time;
         }
+
+        
 
 
         protected AbstractJobData(IJobConfig jobConfig)


### PR DESCRIPTION
Adding the ability to get the `Logger` instance from the `ITaskSetOwner` 
This is useful to be able to create a `BurstableLogger` inside a job without having to pass it in. 

```
//CONSTRUCTOR
            private UpdateTimersJob(UpdateJobData<Timer> jobData) : this()
            {
                m_DeltaTime = jobData.Time.DeltaTime;
                Debug_InitializeBurstableLogger(jobData);
            }

           //*************************************************************************************************************
            // LOGGING
            //*************************************************************************************************************

#if STATION_X_LOGGING_VERBOSE
            private BurstableLogger<FixedString64Bytes> m_BurstableLogger;
#endif

            [Conditional("STATION_X_LOGGING_VERBOSE")]
            private void Debug_InitializeBurstableLogger(AbstractJobData jobData)
            {
#if STATION_X_LOGGING_VERBOSE
                m_BurstableLogger = jobData.TaskSetOwnerLogger.AsBurstable<FixedString64Bytes>();
#endif
            }
```

### What issues does this resolve?
- None

### What PRs does this depend on?
 - None

### Does this introduce a breaking change?
 - [ ] Yes
 - [x] No

### Tag-Alongs
- Made the `RunOnce` function for JobConfigs able to be called after configuration in response to structural changes.
- Updated docs accordingly.
