### PR TITLE
Fixing SystemGroups for TaskDrivers

### DIFF
--- a/Scripts/Runtime/Entities/TaskDriver/AbstractTaskDriver.cs
+++ b/Scripts/Runtime/Entities/TaskDriver/AbstractTaskDriver.cs
@@ -62,7 +62,7 @@ namespace Anvil.Unity.DOTS.Entities.TaskDriver
         protected AbstractTaskDriver(World world)
         {
             World = world;
-            TaskDriverManagementSystem taskDriverManagementSystem = World.GetOrCreateSystem<TaskDriverManagementSystem>();
+            TaskDriverManagementSystem taskDriverManagementSystem = TaskDriverManagementSystem.GetOrCreateForWorld(world);
 
             m_SubTaskDrivers = new List<AbstractTaskDriver>();
             TaskSet = new TaskSet(this);

--- a/Scripts/Runtime/Entities/TaskDriver/AbstractTaskDriver.cs
+++ b/Scripts/Runtime/Entities/TaskDriver/AbstractTaskDriver.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using System.Reflection;
 using Unity.Entities;
 
 namespace Anvil.Unity.DOTS.Entities.TaskDriver
@@ -23,6 +24,7 @@ namespace Anvil.Unity.DOTS.Entities.TaskDriver
                                                ITaskSetOwner
     {
         private static readonly Type TASK_DRIVER_SYSTEM_TYPE = typeof(TaskDriverSystem<>);
+        private static readonly Type COMPONENT_SYSTEM_GROUP_TYPE = typeof(ComponentSystemGroup);
 
         private readonly List<AbstractTaskDriver> m_SubTaskDrivers;
         private readonly uint m_ID;
@@ -75,7 +77,8 @@ namespace Anvil.Unity.DOTS.Entities.TaskDriver
             {
                 TaskDriverSystem = (AbstractTaskDriverSystem)Activator.CreateInstance(taskDriverSystemType, World);
                 World.AddSystem(TaskDriverSystem);
-                World.GetOrCreateSystem<SimulationSystemGroup>().AddSystemToUpdateList(TaskDriverSystem);
+                ComponentSystemGroup systemGroup = GetSystemGroup();
+                systemGroup.AddSystemToUpdateList(TaskDriverSystem);
             }
 
             TaskDriverSystem.RegisterTaskDriver(this);
@@ -97,6 +100,26 @@ namespace Anvil.Unity.DOTS.Entities.TaskDriver
         public override string ToString()
         {
             return $"{GetType().GetReadableName()}|{m_ID}";
+        }
+
+        private ComponentSystemGroup GetSystemGroup()
+        {
+            Type systemGroupType = GetSystemGroupType();
+            if (!COMPONENT_SYSTEM_GROUP_TYPE.IsAssignableFrom(systemGroupType))
+            {
+                throw new InvalidOperationException($"Tried to get the {COMPONENT_SYSTEM_GROUP_TYPE.GetReadableName()} for {this} but {systemGroupType.GetReadableName()} is not a valid group type!");
+            }
+
+            return (ComponentSystemGroup)World.GetOrCreateSystem(systemGroupType);
+        }
+
+        private Type GetSystemGroupType()
+        {
+            Type type = GetType();
+            UpdateInGroupAttribute updateInGroupAttribute = type.GetCustomAttribute<UpdateInGroupAttribute>();
+            return updateInGroupAttribute == null
+                ? typeof(SimulationSystemGroup)
+                : updateInGroupAttribute.GroupType;
         }
 
         //*************************************************************************************************************

--- a/Scripts/Runtime/Entities/TaskDriver/TaskDriverManagementSystem.cs
+++ b/Scripts/Runtime/Entities/TaskDriver/TaskDriverManagementSystem.cs
@@ -14,6 +14,19 @@ namespace Anvil.Unity.DOTS.Entities.TaskDriver
     [UpdateInGroup(typeof(InitializationSystemGroup), OrderFirst = true)]
     internal partial class TaskDriverManagementSystem : AbstractAnvilSystemBase
     {
+        public static TaskDriverManagementSystem GetOrCreateForWorld(World world)
+        {
+            TaskDriverManagementSystem taskDriverManagementSystem = world.GetExistingSystem<TaskDriverManagementSystem>();
+            if (taskDriverManagementSystem == null)
+            {
+                taskDriverManagementSystem = new TaskDriverManagementSystem();
+                world.AddSystem(taskDriverManagementSystem);
+                world.GetOrCreateSystem<InitializationSystemGroup>().AddSystemToUpdateList(taskDriverManagementSystem);
+            }
+
+            return taskDriverManagementSystem;
+        }
+        
         private readonly Dictionary<Type, IDataSource> m_EntityProxyDataSourcesByType;
         private readonly HashSet<AbstractTaskDriver> m_AllTaskDrivers;
         private readonly HashSet<AbstractTaskDriverSystem> m_AllTaskDriverSystems;


### PR DESCRIPTION
When using TaskDrivers in a project, there may be a desire to have TaskDrivers and their systems update in a custom group.

This change allows for the `UpdateInGroup` attribute to be used on a TaskDriver.

Additionally, in a multi-world setup, additional worlds may have the `TaskDriverManagementSystem` created but it won't be added to the update list. We now ensure that it is properly created and added to the update list for any world it is a part of.


### What issues does this resolve?
- None

### What PRs does this depend on?
 - None

### Does this introduce a breaking change?
 - [ ] Yes
 - [x] No
