### PR TITLE
Outside Interaction with Task Driver System

### DIFF
--- a/Scripts/Runtime/Entities/TaskDriver/AbstractTaskDriver.cs
+++ b/Scripts/Runtime/Entities/TaskDriver/AbstractTaskDriver.cs
@@ -7,6 +7,7 @@ using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
 using Unity.Entities;
+using Unity.Jobs;
 
 namespace Anvil.Unity.DOTS.Entities.TaskDriver
 {
@@ -227,6 +228,90 @@ namespace Anvil.Unity.DOTS.Entities.TaskDriver
 
 
         //TODO: #73 - Implement other job types
+        
+        //*************************************************************************************************************
+        // EXTERNAL USAGE
+        //*************************************************************************************************************
+        
+        /// <summary>
+        /// Gets a <see cref="CancelCompleteReader"/> for use in a job outside the Task Driver context.
+        /// Requires a call to <see cref="ReleaseCancelCompleteReaderAsync"/> after scheduling the job.
+        /// </summary>
+        /// <returns>The <see cref="CancelCompleteReader"/></returns>
+        public CancelCompleteReader AcquireCancelCompleteReaderAsync()
+        {
+            return TaskSet.AcquireCancelCompleteReaderAsync();
+        }
+        
+        /// <summary>
+        /// Allows other jobs to use the underlying data for the <see cref="CancelCompleteReader"/>
+        /// and ensures data integrity across those other usages.
+        /// </summary>
+        /// <param name="dependsOn">The <see cref="JobHandle"/> that used this data.</param>
+        public void ReleaseCancelCompleteReaderAsync(JobHandle dependsOn)
+        {
+            TaskSet.ReleaseCancelCompleteReaderAsync(dependsOn);
+        }
+        
+        /// <summary>
+        /// Gets a <see cref="CancelCompleteReader"/> for use on the main thread outside the Task Driver
+        /// context.
+        /// Requires a call to <see cref="ReleaseCancelCompleteReader"/> when done.
+        /// </summary>
+        /// <returns>The <see cref="CancelCompleteReader"/></returns>
+        public CancelCompleteReader AcquireCancelCompleteReader()
+        {
+            return TaskSet.AcquireCancelCompleteReader();
+        }
+        
+        /// <summary>
+        /// Allows other jobs or code to use to underlying data for the <see cref="CancelCompleteReader"/>
+        /// and ensures data integrity across those other usages.
+        /// </summary>
+        public void ReleaseCancelCompleteReader()
+        {
+            TaskSet.ReleaseCancelCompleteReader();
+        }
+        
+        /// <summary>
+        /// Gets a <see cref="CancelRequestsWriter"/> for use in a job outside the Task Driver context.
+        /// Requires a call to <see cref="ReleaseCancelRequestsWriterAsync"/> after scheduling the job.
+        /// </summary>
+        /// <returns>The <see cref="CancelRequestsWriter"/></returns>
+        public CancelRequestsWriter AcquireCancelRequestsWriterAsync()
+        {
+            return TaskSet.AcquireCancelRequestsWriterAsync();
+        }
+        
+        /// <summary>
+        /// Allows other jobs to use the underlying data for the <see cref="CancelRequestsWriter"/>
+        /// and ensures data integrity across those other usages.
+        /// </summary>
+        /// <param name="dependsOn">The <see cref="JobHandle"/> that used this data.</param>
+        public void ReleaseCancelRequestsWriterAsync(JobHandle dependsOn)
+        {
+            TaskSet.ReleaseCancelRequestsWriterAsync(dependsOn);
+        }
+        
+        /// <summary>
+        /// Gets a <see cref="CancelRequestsWriter"/> for use on the main thread outside the Task Driver
+        /// context.
+        /// Requires a call to <see cref="ReleaseCancelRequestsWriter"/> when done.
+        /// </summary>
+        /// <returns>The <see cref="CancelRequestsWriter"/></returns>
+        public CancelRequestsWriter AcquireCancelRequestsWriter()
+        {
+            return TaskSet.AcquireCancelRequestsWriter();
+        }
+        
+        /// <summary>
+        /// Allows other jobs or code to use to underlying data for the <see cref="CancelRequestsWriter"/>
+        /// and ensures data integrity across those other usages.
+        /// </summary>
+        public void ReleaseCancelRequestsWriter()
+        {
+            TaskSet.ReleaseCancelRequestsWriter();
+        }
 
         //*************************************************************************************************************
         // HARDENING

--- a/Scripts/Runtime/Entities/TaskDriver/TaskSet/TaskData/DataStream/Cancellation/CancelCompleteDataStream.cs
+++ b/Scripts/Runtime/Entities/TaskDriver/TaskSet/TaskData/DataStream/Cancellation/CancelCompleteDataStream.cs
@@ -1,5 +1,6 @@
 using Anvil.Unity.DOTS.Data;
 using Anvil.Unity.DOTS.Jobs;
+using System.Runtime.CompilerServices;
 using Unity.Jobs;
 
 namespace Anvil.Unity.DOTS.Entities.TaskDriver
@@ -33,25 +34,53 @@ namespace Anvil.Unity.DOTS.Entities.TaskDriver
             ActiveArrayData = m_DataSource.CreateActiveArrayData(TaskSetOwner, CancelRequestBehaviour.Ignore);
             ScheduleInfo = ActiveArrayData.ScheduleInfo;
         }
-
+        
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public JobHandle AcquireActiveAsync(AccessType accessType)
         {
             return ActiveArrayData.AcquireAsync(accessType);
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void ReleaseActiveAsync(JobHandle dependsOn)
         {
             ActiveArrayData.ReleaseAsync(dependsOn);
         }
         
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void AcquireActive(AccessType accessType)
+        {
+            ActiveArrayData.Acquire(accessType);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void ReleaseActive()
+        {
+            ActiveArrayData.Release();
+        }
+        
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public JobHandle AcquirePendingAsync(AccessType accessType)
         {
             return m_DataSource.AcquirePendingAsync(accessType);
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void ReleasePendingAsync(JobHandle dependsOn)
         {
             m_DataSource.ReleasePendingAsync(dependsOn);
+        }
+        
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void AcquirePending(AccessType accessType)
+        {
+            m_DataSource.AcquirePendingAsync(accessType);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void ReleasePending()
+        {
+            m_DataSource.ReleasePending();
         }
         
         public CancelCompleteReader CreateCancelCompleteReader()

--- a/Scripts/Runtime/Entities/TaskDriver/TaskSet/TaskData/DataStream/Cancellation/CancelRequestsDataStream.cs
+++ b/Scripts/Runtime/Entities/TaskDriver/TaskSet/TaskData/DataStream/Cancellation/CancelRequestsDataStream.cs
@@ -1,4 +1,5 @@
 using Anvil.Unity.DOTS.Jobs;
+using System.Runtime.CompilerServices;
 using Unity.Jobs;
 
 namespace Anvil.Unity.DOTS.Entities.TaskDriver
@@ -20,15 +21,29 @@ namespace Anvil.Unity.DOTS.Entities.TaskDriver
 
             ActiveLookupData = m_DataSource.CreateActiveLookupData(TaskSetOwner);
         }
-
+        
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public JobHandle AcquirePendingAsync(AccessType accessType)
         {
             return m_DataSource.AcquirePendingAsync(accessType);
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void ReleasePendingAsync(JobHandle dependsOn)
         {
             m_DataSource.ReleasePendingAsync(dependsOn);
+        }
+        
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void AcquirePending(AccessType accessType)
+        {
+            m_DataSource.AcquirePending(accessType);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void ReleasePending()
+        {
+            m_DataSource.ReleasePending();
         }
 
         public CancelRequestsWriter CreateCancelRequestsWriter()

--- a/Scripts/Runtime/Entities/TaskDriver/TaskSet/TaskData/DataStream/DataSource/AbstractDataSource.cs
+++ b/Scripts/Runtime/Entities/TaskDriver/TaskSet/TaskData/DataStream/DataSource/AbstractDataSource.cs
@@ -5,6 +5,7 @@ using Anvil.Unity.DOTS.Jobs;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Runtime.CompilerServices;
 using Unity.Collections;
 using Unity.Jobs;
 
@@ -76,14 +77,28 @@ namespace Anvil.Unity.DOTS.Entities.TaskDriver
             return activeLookupData;
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public JobHandle AcquirePendingAsync(AccessType accessType)
         {
             return PendingData.AcquireAsync(accessType);
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void ReleasePendingAsync(JobHandle dependsOn)
         {
             PendingData.ReleaseAsync(dependsOn);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void AcquirePending(AccessType accessType)
+        {
+            PendingData.Acquire(accessType);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void ReleasePending()
+        {
+            PendingData.Release();
         }
 
         public void Harden()

--- a/Scripts/Runtime/Entities/TaskDriver/TaskSet/TaskData/DataStream/DataSource/Data/AbstractData.cs
+++ b/Scripts/Runtime/Entities/TaskDriver/TaskSet/TaskData/DataStream/DataSource/Data/AbstractData.cs
@@ -55,5 +55,17 @@ namespace Anvil.Unity.DOTS.Entities.TaskDriver
         {
             m_AccessController.ReleaseAsync(releaseAccessDependency);
         }
+        
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Acquire(AccessType accessType)
+        { 
+            m_AccessController.Acquire(accessType);
+        }
+        
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Release()
+        {
+            m_AccessController.Release();
+        }
     }
 }

--- a/Scripts/Runtime/Entities/TaskDriver/TaskSet/TaskData/DataStream/IAbstractDataStream.cs
+++ b/Scripts/Runtime/Entities/TaskDriver/TaskSet/TaskData/DataStream/IAbstractDataStream.cs
@@ -1,3 +1,5 @@
+using Unity.Jobs;
+
 namespace Anvil.Unity.DOTS.Entities.TaskDriver
 {
     /// <summary>
@@ -7,7 +9,55 @@ namespace Anvil.Unity.DOTS.Entities.TaskDriver
     public interface IAbstractDataStream<TInstance> : IAbstractDataStream
         where TInstance : unmanaged, IEntityProxyInstance
     {
+        /// <summary>
+        /// Gets a <see cref="DataStreamActiveReader{TInstance}"/> for use in a job outside the Task Driver context.
+        /// Requires a call to <see cref="ReleaseActiveReaderAsync"/> after scheduling the job.
+        /// </summary>
+        /// <returns>The <see cref="DataStreamActiveReader{TInstance}"/></returns>
+        public DataStreamActiveReader<TInstance> AcquireActiveReaderAsync();
+        /// <summary>
+        /// Allows other jobs to use the underlying data for the <see cref="DataStreamActiveReader{TInstance}"/>
+        /// and ensures data integrity across those other usages.
+        /// </summary>
+        /// <param name="dependsOn">The <see cref="JobHandle"/> that used this data.</param>
+        public void ReleaseActiveReaderAsync(JobHandle dependsOn);
+        /// <summary>
+        /// Gets a <see cref="DataStreamActiveReader{TInstance}"/> for use on the main thread outside the Task Driver
+        /// context.
+        /// Requires a call to <see cref="ReleaseActiveReader"/> when done.
+        /// </summary>
+        /// <returns>The <see cref="DataStreamActiveReader{TInstance}"/></returns>
+        public DataStreamActiveReader<TInstance> AcquireActiveReader();
+        /// <summary>
+        /// Allows other jobs or code to use to underlying data for the <see cref="DataStreamActiveReader{TInstance}"/>
+        /// and ensures data integrity across those other usages.
+        /// </summary>
+        public void ReleaseActiveReader();
         
+        /// <summary>
+        /// Gets a <see cref="DataStreamPendingWriter{TInstance}"/> for use in a job outside the Task Driver context.
+        /// Requires a call to <see cref="ReleasePendingWriterAsync"/> after scheduling the job.
+        /// </summary>
+        /// <returns>The <see cref="DataStreamPendingWriter{TInstance}"/></returns>
+        public DataStreamPendingWriter<TInstance> AcquirePendingWriterAsync();
+        /// <summary>
+        /// Allows other jobs to use the underlying data for the <see cref="DataStreamPendingWriter{TInstance}"/>
+        /// and ensures data integrity across those other usages.
+        /// </summary>
+        /// <param name="dependsOn">The <see cref="JobHandle"/> that used this data.</param>
+        public void ReleasePendingWriterAsync(JobHandle dependsOn);
+        /// <summary>
+        /// Gets a <see cref="DataStreamPendingWriter{TInstance}"/> for use on the main thread outside the Task Driver
+        /// context.
+        /// Requires a call to <see cref="ReleasePendingWriter"/> when done.
+        /// </summary>
+        /// <returns>The <see cref="DataStreamPendingWriter{TInstance}"/></returns>
+        public DataStreamPendingWriter<TInstance> AcquirePendingWriter();
+        /// <summary>
+        /// Allows other jobs or code to use to underlying data for the <see cref="DataStreamPendingWriter{TInstance}"/>
+        /// and ensures data integrity across those other usages.
+        /// </summary>
+        public void ReleasePendingWriter();
     }
     
     

--- a/Scripts/Runtime/Entities/TaskDriver/TaskSet/TaskData/JobDataInteraction/DataStreamPendingWriter.cs
+++ b/Scripts/Runtime/Entities/TaskDriver/TaskSet/TaskData/JobDataInteraction/DataStreamPendingWriter.cs
@@ -54,7 +54,7 @@ namespace Anvil.Unity.DOTS.Entities.TaskDriver
         }
 
         /// <summary>
-        /// Called once per thread to allow for initialization of state in the job
+        /// Call once to initialize the state of this writer for the thread it is running on.
         /// </summary>
         /// <remarks>
         /// In most cases this will be called automatically by the Anvil Job type. If using this in a vanilla Unity
@@ -66,6 +66,16 @@ namespace Anvil.Unity.DOTS.Entities.TaskDriver
             Debug_EnsureInitThreadOnlyCalledOnce();
 
             m_LaneIndex = ParallelAccessUtil.CollectionIndexForThread(nativeThreadIndex);
+            m_PendingLaneWriter = m_PendingWriter.AsLaneWriter(m_LaneIndex);
+        }
+        
+        /// <summary>
+        /// Call once to initialize the state of this writer for main thread usage.
+        /// </summary>
+        public void InitForMainThread()
+        {
+            Debug_EnsureInitThreadOnlyCalledOnce();
+            m_LaneIndex = ParallelAccessUtil.CollectionIndexForMainThread();
             m_PendingLaneWriter = m_PendingWriter.AsLaneWriter(m_LaneIndex);
         }
 
@@ -88,6 +98,30 @@ namespace Anvil.Unity.DOTS.Entities.TaskDriver
                                                                                 m_TaskSetOwnerID,
                                                                                 m_ActiveID,
                                                                                 ref instance));
+        }
+
+        /// <summary>
+        /// Adds the instance to the <see cref="IAbstractDataStream{TInstance}"/>'s
+        /// underlying pending collection to be added the next time the data is consolidated.
+        /// </summary>
+        /// <param name="instance">The <see cref="IEntityProxyInstance"/></param>
+        /// <param name="laneIndex">
+        /// The collection index to use based on the thread this writer is being
+        /// used on. <see cref="ParallelAccessUtil"/> to get the correct index.
+        /// </param>
+        public void Add(TInstance instance, int laneIndex)
+        {
+            Add(ref instance, laneIndex);
+        }
+
+        /// <inheritdoc cref="Add(TInstance, int)"/>
+        public void Add(ref TInstance instance, int laneIndex)
+        {
+            m_PendingWriter.AsLaneWriter(laneIndex)
+                           .Write(new EntityProxyInstanceWrapper<TInstance>(instance.Entity,
+                                                                            m_TaskSetOwnerID,
+                                                                            m_ActiveID,
+                                                                            ref instance));
         }
 
 
@@ -127,7 +161,7 @@ namespace Anvil.Unity.DOTS.Entities.TaskDriver
 #if ENABLE_UNITY_COLLECTIONS_CHECKS
             if (m_State == WriterState.Uninitialized)
             {
-                throw new InvalidOperationException($"{nameof(InitForThread)} must be called first before attempting to add an element.");
+                throw new InvalidOperationException($"{nameof(InitForThread)} or {nameof(InitForMainThread)} must be called first before attempting to add an element. Or call {nameof(Add)} with the explicit lane index.");
             }
 #endif
         }

--- a/Scripts/Runtime/Entities/TaskDriver/TaskSet/TaskSet.cs
+++ b/Scripts/Runtime/Entities/TaskDriver/TaskSet/TaskSet.cs
@@ -1,10 +1,12 @@
 using Anvil.CSharp.Collections;
 using Anvil.CSharp.Core;
+using Anvil.Unity.DOTS.Jobs;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using Unity.Collections;
 using Unity.Entities;
+using Unity.Jobs;
 
 namespace Anvil.Unity.DOTS.Entities.TaskDriver
 {
@@ -214,6 +216,51 @@ namespace Anvil.Unity.DOTS.Entities.TaskDriver
             {
                 taskDriver.TaskSet.AddCancelRequestContextsTo(contexts);
             }
+        }
+        
+        
+        public CancelCompleteReader AcquireCancelCompleteReaderAsync()
+        {
+            CancelCompleteDataStream.AcquireActiveAsync(AccessType.SharedRead);
+            return CancelCompleteDataStream.CreateCancelCompleteReader();
+        }
+
+        public void ReleaseCancelCompleteReaderAsync(JobHandle dependsOn)
+        {
+            CancelCompleteDataStream.ReleaseActiveAsync(dependsOn);
+        }
+
+        public CancelCompleteReader AcquireCancelCompleteReader()
+        {
+            CancelCompleteDataStream.AcquireActive(AccessType.SharedRead);
+            return CancelCompleteDataStream.CreateCancelCompleteReader();
+        }
+
+        public void ReleaseCancelCompleteReader()
+        {
+            CancelCompleteDataStream.ReleaseActive();
+        }
+
+        public CancelRequestsWriter AcquireCancelRequestsWriterAsync()
+        {
+            CancelRequestsDataStream.AcquirePendingAsync(AccessType.SharedWrite);
+            return CancelRequestsDataStream.CreateCancelRequestsWriter();
+        }
+
+        public void ReleaseCancelRequestsWriterAsync(JobHandle dependsOn)
+        {
+            CancelRequestsDataStream.ReleasePendingAsync(dependsOn);
+        }
+
+        public CancelRequestsWriter AcquireCancelRequestsWriter()
+        {
+            CancelRequestsDataStream.AcquirePending(AccessType.SharedWrite);
+            return CancelRequestsDataStream.CreateCancelRequestsWriter();
+        }
+
+        public void ReleaseCancelRequestsWriter()
+        {
+            CancelRequestsDataStream.ReleasePending();
         }
 
         //*************************************************************************************************************

--- a/Scripts/Runtime/Job/Util/ParallelAccessUtil.cs
+++ b/Scripts/Runtime/Job/Util/ParallelAccessUtil.cs
@@ -111,7 +111,7 @@ namespace Anvil.Unity.DOTS.Jobs
         public static int CollectionIndexForThread(int nativeThreadIndex)
         {
             DetectMultipleXThreads(nativeThreadIndex);
-            Debug.Assert(nativeThreadIndex is > 0 and <= JobsUtility.MaxJobThreadCount);
+            Debug_EnsureNativeThreadIndexIsValid(nativeThreadIndex);
             return math.min(nativeThreadIndex - 1, JOB_WORKER_MAXIMUM_COUNT.Data);
         }
 
@@ -129,7 +129,20 @@ namespace Anvil.Unity.DOTS.Jobs
             DetectMultipleXThreads(mainThreadIndex);
             return mainThreadIndex;
         }
+        
+        //*************************************************************************************************************
+        // SAFETY
+        //*************************************************************************************************************
 
+        [Conditional("ANVIL_DEBUG_SAFETY")]
+        private static void Debug_EnsureNativeThreadIndexIsValid(int nativeThreadIndex)
+        {
+            if (nativeThreadIndex is <= 0 or > JobsUtility.MaxJobThreadCount)
+            {
+                throw new InvalidOperationException($"Native Thread Index is {nativeThreadIndex}! Did you call {nameof(CollectionIndexForThread)} instead of {nameof(CollectionIndexForMainThread)}?");
+            }
+        }
+        
 
         [BurstDiscard]
         [Conditional("ANVIL_DEBUG_SAFETY_EXPENSIVE")]


### PR DESCRIPTION
Adding the ability to interact with the TaskDriver system easily from the outside. 
- Main Thread
- Other jobs

### What is the current behaviour?

You need to create jobs on the TaskDriver to populate the DataStreams by triggering off an `EntityQuery` or `NativeArray`. 

This can lead to indirection where you have a normal Entities job that exists solely to populate a trigger array to then get the data inside the TaskDriver.

### What is the new behaviour?

You can now directly get access to:
- `DataStreamActiveReader<TInstance>`
- `DataStreamPendingWriter<TInstance>`
- `CancelRequestsWriter`
- `CancelCompleteReader`

And use those in your jobs that are outside the Task Driver system. Access is handled for you but you must explicitly call `Release` where appropriate depending if you are accessing synchronously or on the main thread.

### What issues does this resolve?
- None - Just a bunch of annoyances @mbaker3 and @jkeon ran into during real world setup.

### What PRs does this depend on?
 - None

### Does this introduce a breaking change?
 - [ ] Yes
 - [x] No
