### PR TITLE
Access Wrapper Fix

### DIFF
--- a/Scripts/Runtime/Entities/TaskDriver/TaskSet/Job/JobConfig/AbstractJobConfig.cs
+++ b/Scripts/Runtime/Entities/TaskDriver/TaskSet/Job/JobConfig/AbstractJobConfig.cs
@@ -21,12 +21,16 @@ namespace Anvil.Unity.DOTS.Entities.TaskDriver
         {
             //Using in the general context (read or write)
             Default,
+
             //Using in an Updating context for data that can we resolved
             Update,
+
             //Using in the context where it can be written to via a resolve
             Resolve,
+
             //Using in the context for requesting a cancellation
             RequestCancel,
+
             //Using in the context for doing the work to cancel 
             Cancelling
         }
@@ -36,6 +40,7 @@ namespace Anvil.Unity.DOTS.Entities.TaskDriver
 
         private readonly string m_TypeString;
         private readonly Dictionary<JobConfigDataID, AbstractAccessWrapper> m_AccessWrappers;
+        private readonly HashSet<Type> m_PendingAccessWrapperTypes;
         private readonly List<AbstractAccessWrapper> m_SchedulingAccessWrappers;
 
         private NativeArray<JobHandle> m_AccessWrapperDependencies;
@@ -49,7 +54,7 @@ namespace Anvil.Unity.DOTS.Entities.TaskDriver
             get;
             set;
         }
-        
+
         internal ITaskSetOwner TaskSetOwner { get; }
 
 
@@ -59,6 +64,7 @@ namespace Anvil.Unity.DOTS.Entities.TaskDriver
             TaskSetOwner = taskSetOwner;
 
             m_AccessWrappers = new Dictionary<JobConfigDataID, AbstractAccessWrapper>();
+            m_PendingAccessWrapperTypes = new HashSet<Type>();
             m_SchedulingAccessWrappers = new List<AbstractAccessWrapper>();
         }
 
@@ -101,13 +107,22 @@ namespace Anvil.Unity.DOTS.Entities.TaskDriver
         {
             Debug_EnsureWrapperValidity(accessWrapper.ID);
             Debug_EnsureWrapperUsage(accessWrapper);
+
+            //Only allow one wrapper per type for DataStream Pending Access since they will all try to acquire/release
+            //the same DataSource instance.
+            if (accessWrapper is IDataStreamPendingAccessWrapper pendingAccessWrapper
+             && !m_PendingAccessWrapperTypes.Add(accessWrapper.ID.AccessWrapperType))
+            {
+                return;
+            }
+
             m_AccessWrappers.Add(accessWrapper.ID, accessWrapper);
         }
 
         //*************************************************************************************************************
         // CONFIGURATION - REQUIRED DATA - DATA STREAM
         //*************************************************************************************************************
-        
+
         public IJobConfig RequireDataStreamForWrite<TInstance>(IAbstractDataStream<TInstance> dataStream)
             where TInstance : unmanaged, IEntityProxyInstance
         {
@@ -131,21 +146,21 @@ namespace Anvil.Unity.DOTS.Entities.TaskDriver
         //*************************************************************************************************************
         // CONFIGURATION - REQUIRED DATA - GENERIC DATA
         //*************************************************************************************************************
-        
+
         public IJobConfig RequireGenericDataForRead<TData>(AccessControlledValue<TData> collection)
             where TData : struct
         {
             AddAccessWrapper(new GenericDataAccessWrapper<TData>(collection, AccessType.SharedRead, Usage.Default));
             return this;
         }
-        
+
         public IJobConfig RequireGenericDataForWrite<TData>(AccessControlledValue<TData> collection)
             where TData : struct
         {
             AddAccessWrapper(new GenericDataAccessWrapper<TData>(collection, AccessType.SharedWrite, Usage.Default));
             return this;
         }
-        
+
         public IJobConfig RequireGenericDataForExclusiveWrite<TData>(AccessControlledValue<TData> collection)
             where TData : struct
         {
@@ -156,12 +171,12 @@ namespace Anvil.Unity.DOTS.Entities.TaskDriver
         //*************************************************************************************************************
         // CONFIGURATION - REQUIRED DATA - ENTITY QUERY
         //*************************************************************************************************************
-        
+
         public IJobConfig RequireEntityNativeArrayFromQueryForRead(EntityQuery entityQuery)
         {
             return RequireEntityNativeArrayFromQueryForRead(new EntityQueryNativeArray(entityQuery));
         }
-        
+
         public IJobConfig RequireIComponentDataNativeArrayFromQueryForRead<T>(EntityQuery entityQuery)
             where T : struct, IComponentData
         {
@@ -192,7 +207,7 @@ namespace Anvil.Unity.DOTS.Entities.TaskDriver
             AddAccessWrapper(new CDFEAccessWrapper<T>(AccessType.SharedRead, Usage.Default, TaskSetOwner.TaskDriverSystem));
             return this;
         }
-        
+
         public IJobConfig RequireCDFEForWrite<T>()
             where T : struct, IComponentData
         {
@@ -203,7 +218,7 @@ namespace Anvil.Unity.DOTS.Entities.TaskDriver
         //*************************************************************************************************************
         // CONFIGURATION - REQUIRED DATA - DynamicBuffer
         //*************************************************************************************************************
-        
+
         public IJobConfig RequireDBFEForRead<T>()
             where T : struct, IBufferElementData
         {
@@ -211,7 +226,7 @@ namespace Anvil.Unity.DOTS.Entities.TaskDriver
 
             return this;
         }
-        
+
         public IJobConfig RequireDBFEForExclusiveWrite<T>()
             where T : struct, IBufferElementData
         {
@@ -259,7 +274,7 @@ namespace Anvil.Unity.DOTS.Entities.TaskDriver
             AddAccessWrapper(new PersistentDataAccessWrapper<PersistentData<TData>>(data, AccessType.SharedRead, Usage.Default));
             return this;
         }
-        
+
         public IJobConfig RequirePersistentDataForWrite<TData>(string id)
             where TData : unmanaged
         {
@@ -364,7 +379,7 @@ namespace Anvil.Unity.DOTS.Entities.TaskDriver
             DataStreamPendingAccessWrapper<TInstance> dataStreamAccessWrapper = GetAccessWrapper<DataStreamPendingAccessWrapper<TInstance>>(usage);
             return dataStreamAccessWrapper.DataStream;
         }
-        
+
         internal EntityProxyDataStream<TInstance> GetActiveDataStream<TInstance>(Usage usage)
             where TInstance : unmanaged, IEntityProxyInstance
         {
@@ -399,7 +414,7 @@ namespace Anvil.Unity.DOTS.Entities.TaskDriver
             PersistentDataAccessWrapper<EntityPersistentData<TData>> persistentDataAccessWrapper = GetAccessWrapper<PersistentDataAccessWrapper<EntityPersistentData<TData>>>(Usage.Default);
             return persistentDataAccessWrapper.PersistentData;
         }
-        
+
         internal PersistentData<TData> GetPersistentData<TData>()
             where TData : unmanaged
         {
@@ -496,7 +511,7 @@ namespace Anvil.Unity.DOTS.Entities.TaskDriver
             {
                 return;
             }
-            
+
             //TODO: #140 - Detect common configuration issues and let the developer know
 
             // //Access checks

--- a/Scripts/Runtime/Entities/TaskDriver/TaskSet/Job/JobConfig/AbstractJobConfig.cs
+++ b/Scripts/Runtime/Entities/TaskDriver/TaskSet/Job/JobConfig/AbstractJobConfig.cs
@@ -107,15 +107,7 @@ namespace Anvil.Unity.DOTS.Entities.TaskDriver
         {
             Debug_EnsureWrapperValidity(accessWrapper.ID);
             Debug_EnsureWrapperUsage(accessWrapper);
-
-            //Only allow one wrapper per type for DataStream Pending Access since they will all try to acquire/release
-            //the same DataSource instance.
-            if (accessWrapper is IDataStreamPendingAccessWrapper pendingAccessWrapper
-             && !m_PendingAccessWrapperTypes.Add(accessWrapper.ID.AccessWrapperType))
-            {
-                return;
-            }
-
+            
             m_AccessWrappers.Add(accessWrapper.ID, accessWrapper);
         }
 
@@ -299,6 +291,13 @@ namespace Anvil.Unity.DOTS.Entities.TaskDriver
 
             foreach (AbstractAccessWrapper wrapper in m_AccessWrappers.Values)
             {
+                //Only allow one wrapper per type for DataStream Pending Access since they will all try to acquire/release
+                //the same DataSource instance.
+                if (wrapper is IDataStreamPendingAccessWrapper pendingAccessWrapper
+                 && !m_PendingAccessWrapperTypes.Add(wrapper.ID.AccessWrapperType))
+                {
+                    continue;
+                }
                 m_SchedulingAccessWrappers.Add(wrapper);
             }
 

--- a/Scripts/Runtime/Entities/TaskDriver/TaskSet/Job/Wrapper/DataStreamPendingAccessWrapper.cs
+++ b/Scripts/Runtime/Entities/TaskDriver/TaskSet/Job/Wrapper/DataStreamPendingAccessWrapper.cs
@@ -3,7 +3,8 @@ using Unity.Jobs;
 
 namespace Anvil.Unity.DOTS.Entities.TaskDriver
 {
-    internal class DataStreamPendingAccessWrapper<T> : AbstractDataStreamAccessWrapper<T>
+    internal class DataStreamPendingAccessWrapper<T> : AbstractDataStreamAccessWrapper<T>,
+                                                       IDataStreamPendingAccessWrapper
         where T : unmanaged, IEntityProxyInstance
     {
         public DataStreamPendingAccessWrapper(EntityProxyDataStream<T> dataStream, 

--- a/Scripts/Runtime/Entities/TaskDriver/TaskSet/Job/Wrapper/DataStreamPendingCancelActiveAccessWrapper.cs
+++ b/Scripts/Runtime/Entities/TaskDriver/TaskSet/Job/Wrapper/DataStreamPendingCancelActiveAccessWrapper.cs
@@ -3,7 +3,8 @@ using Unity.Jobs;
 
 namespace Anvil.Unity.DOTS.Entities.TaskDriver
 {
-    internal class DataStreamPendingCancelActiveAccessWrapper<T> : AbstractDataStreamAccessWrapper<T>
+    internal class DataStreamPendingCancelActiveAccessWrapper<T> : AbstractDataStreamAccessWrapper<T>,
+                                                                   IDataStreamPendingAccessWrapper
         where T : unmanaged, IEntityProxyInstance
     {
         public DataStreamPendingCancelActiveAccessWrapper(EntityProxyDataStream<T> dataStream, AccessType accessType, AbstractJobConfig.Usage usage) : base(dataStream, accessType, usage)

--- a/Scripts/Runtime/Entities/TaskDriver/TaskSet/Job/Wrapper/IDataStreamPendingAccessWrapper.cs
+++ b/Scripts/Runtime/Entities/TaskDriver/TaskSet/Job/Wrapper/IDataStreamPendingAccessWrapper.cs
@@ -1,0 +1,9 @@
+namespace Anvil.Unity.DOTS.Entities.TaskDriver
+{
+    //Used to signify that this wrapper will want to write to a common DataSource. 
+    //We need to detect this so that we don't have multiple wrappers for that same DataSource as the 
+    //Acquire/Release flow will error when two or more wrappers call Acquire before calling Release.
+    internal interface IDataStreamPendingAccessWrapper
+    {
+    }
+}

--- a/Scripts/Runtime/Entities/TaskDriver/TaskSet/Job/Wrapper/IDataStreamPendingAccessWrapper.cs.meta
+++ b/Scripts/Runtime/Entities/TaskDriver/TaskSet/Job/Wrapper/IDataStreamPendingAccessWrapper.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 45f0ce31f3b64684a2c5eac225177f1d
+timeCreated: 1675709115


### PR DESCRIPTION
Fixing an Acquire/Release error when the same job requires writing to two or more DataStreams of the same type.

### What is the current behaviour?

AccessWrappers are created for the type and given the context of the instance that owns them.
When a job is scheduled, we loop through all the wrappers and `AcquireAsync` to ensure we have access to them.
We then schedule the job and then loop through all the wrappers again and `ReleaseAsync` to complete the cycle.

Because DataStreams share a DataSource all Write operations operate on the same underlying collection regardless of the instance that will use it. 

Ex. TaskDriverA with DataStream<TypeA> and TaskDriverB with DataStream<TypeA> will both write to a DataSource<TypeA>. Upon that DataSource's consolidation, the active instances will be written to the correct TaskDriver's instance of DataStream.

This results in two acquires in a row to the same underlying AccessController.

### What is the new behaviour?

When hardening the JobConfig, we only add the unique wrappers.

### What issues does this resolve?
- None

### What PRs does this depend on?
 - None

### Does this introduce a breaking change?
 - [ ] Yes
 - [x] No
