### PR TITLE
CDFEReader/Writer - Add HasComponent

### DIFF
--- a/Scripts/Runtime/Entities/TaskDriver/TaskSet/TaskData/JobDataInteraction/CDFEReader.cs
+++ b/Scripts/Runtime/Entities/TaskDriver/TaskSet/TaskData/JobDataInteraction/CDFEReader.cs
@@ -18,7 +18,7 @@ namespace Anvil.Unity.DOTS.Entities.TaskDriver
         {
             m_CDFE = system.GetComponentDataFromEntity<T>(true);
         }
-        
+
         /// <summary>
         /// Gets the <typeparamref name="T"/> that corresponds to the passed <see cref="Entity"/>
         /// </summary>
@@ -27,5 +27,8 @@ namespace Anvil.Unity.DOTS.Entities.TaskDriver
         {
             get => m_CDFE[entity];
         }
+
+        /// <inheritdoc cref="ComponentDataFromEntity{T}.HasComponent"/>
+        public bool HasComponent(Entity entity) => m_CDFE.HasComponent(entity);
     }
 }

--- a/Scripts/Runtime/Entities/TaskDriver/TaskSet/TaskData/JobDataInteraction/CDFEWriter.cs
+++ b/Scripts/Runtime/Entities/TaskDriver/TaskSet/TaskData/JobDataInteraction/CDFEWriter.cs
@@ -14,7 +14,7 @@ namespace Anvil.Unity.DOTS.Entities.TaskDriver
     /// <see cref="NativeDisableContainerSafetyRestrictionAttribute"/> applied meaning that Unity will not issue
     /// safety warnings when using it in jobs. This is because there might be many jobs of the same type but
     /// representing different <see cref="AbstractTaskDriver"/>s and Unity's safety system gets upset if you straddle
-    /// across the jobs. 
+    /// across the jobs.
     /// </remarks>
     /// <typeparam name="T">The type of <see cref="IComponentData"/> to update.</typeparam>
     [BurstCompatible]
@@ -37,5 +37,8 @@ namespace Anvil.Unity.DOTS.Entities.TaskDriver
             get => m_CDFE[entity];
             set => m_CDFE[entity] = value;
         }
+
+        /// <inheritdoc cref="ComponentDataFromEntity{T}.HasComponent"/>
+        public bool HasComponent(Entity entity) => m_CDFE.HasComponent(entity);
     }
 }


### PR DESCRIPTION
Expose `HasComponent` method on the `CDFEReader/Writer`

### What is the current behaviour?

There is no way to check if an entity has a component like you can with a raw CDFE.

### What is the new behaviour?

You can now call `HasComponent` on the CDFE reader and writer

### What issues does this resolve?
 - None

### What PRs does this depend on?
 - #160 

### Does this introduce a breaking change?
 - [ ] Yes <!-- If so, what are the migration considerations? -->
 - [x] No
