### PR TITLE
Adding UnsafeParallelHashMap equivalents

### DIFF
--- a/Scripts/AssemblyInjections/Unity.Collections/NativeParallelHashMapInternalExtension.cs
+++ b/Scripts/AssemblyInjections/Unity.Collections/NativeParallelHashMapInternalExtension.cs
@@ -1,6 +1,5 @@
 using System;
 using Unity.Collections;
-using Unity.Collections.LowLevel.Unsafe;
 
 namespace Anvil.Unity.Collections
 {
@@ -23,7 +22,7 @@ namespace Anvil.Unity.Collections
             where TKey : struct, IEquatable<TKey>
             where TValue : struct
         {
-            return map.m_HashMapData.m_AllocatorLabel.ToAllocator;
+            return map.m_HashMapData.GetAllocator();
         }
 
         /// <summary>
@@ -34,11 +33,11 @@ namespace Anvil.Unity.Collections
         /// <param name="result">The array to write the keys into.</param>
         /// <typeparam name="TKey">The key type.</typeparam>
         /// <typeparam name="TValue">The value type.</typeparam>
-        public static unsafe void GetKeyArray<TKey, TValue>(this NativeParallelHashMap<TKey, TValue> map, NativeArray<TKey> result)
+        public static void GetKeyArray<TKey, TValue>(this NativeParallelHashMap<TKey, TValue> map, NativeArray<TKey> result)
             where TKey : struct, IEquatable<TKey>
             where TValue : struct
         {
-            UnsafeParallelHashMapData.GetKeyArray(map.m_HashMapData.m_Buffer, result);
+            map.m_HashMapData.GetKeyArray(result);
         }
 
         /// <summary>
@@ -49,11 +48,11 @@ namespace Anvil.Unity.Collections
         /// <param name="result">The array to write the values into.</param>
         /// <typeparam name="TKey">The key type.</typeparam>
         /// <typeparam name="TValue">The value type.</typeparam>
-        public static unsafe void GetValueArray<TKey, TValue>(this NativeParallelHashMap<TKey, TValue> map, NativeArray<TValue> result)
+        public static void GetValueArray<TKey, TValue>(this NativeParallelHashMap<TKey, TValue> map, NativeArray<TValue> result)
             where TKey : struct, IEquatable<TKey>
             where TValue : struct
         {
-            UnsafeParallelHashMapData.GetValueArray(map.m_HashMapData.m_Buffer, result);
+            map.m_HashMapData.GetValueArray(result);
         }
 
         /// <summary>
@@ -64,11 +63,11 @@ namespace Anvil.Unity.Collections
         /// <param name="result">The array to write the key value pairs into.</param>
         /// <typeparam name="TKey">The key type</typeparam>
         /// <typeparam name="TValue">The value type</typeparam>
-        public static unsafe void GetKeyValueArrays<TKey, TValue>(this NativeParallelHashMap<TKey, TValue> map, NativeKeyValueArrays<TKey, TValue> result)
+        public static void GetKeyValueArrays<TKey, TValue>(this NativeParallelHashMap<TKey, TValue> map, NativeKeyValueArrays<TKey, TValue> result)
             where TKey : struct, IEquatable<TKey>
             where TValue : struct
         {
-            UnsafeParallelHashMapData.GetKeyValueArrays(map.m_HashMapData.m_Buffer, result);
+            map.m_HashMapData.GetKeyValueArrays(result);
         }
     }
 }

--- a/Scripts/AssemblyInjections/Unity.Collections/UnsafeParallelHashMapInternalExtension.cs
+++ b/Scripts/AssemblyInjections/Unity.Collections/UnsafeParallelHashMapInternalExtension.cs
@@ -1,0 +1,74 @@
+using System;
+using Unity.Collections;
+using Unity.Collections.LowLevel.Unsafe;
+
+namespace Anvil.Unity.Collections
+{
+    /// <summary>
+    /// A collection of extension methods for <see cref="UnsafeParallelHashMap{TKey,TValue}"/> that require internal
+    /// access to function.
+    /// </summary>
+    public static class UnsafeParallelHashMapInternalExtension
+    {
+        /// <summary>
+        /// Get the <see cref="Allocator"/> of a <see cref="UnsafeParallelHashMap{TKey,TValue}" />.
+        /// </summary>
+        /// <param name="map">
+        /// The <see cref="UnsafeParallelHashMap{TKey,TValue}" /> to get the <see cref="Allocator"/> of.
+        /// </param>
+        /// <typeparam name="TKey">The key type.</typeparam>
+        /// <typeparam name="TValue">The value type.</typeparam>
+        /// <returns>The <see cref="Allocator"/>.</returns>
+        public static Allocator GetAllocator<TKey, TValue>(this UnsafeParallelHashMap<TKey, TValue> map)
+            where TKey : struct, IEquatable<TKey>
+            where TValue : struct
+        {
+            return map.m_AllocatorLabel.ToAllocator;
+        }
+
+        /// <summary>
+        /// Writes the keys of a <see cref="UnsafeParallelHashMap{TKey,TValue}"/> to an existing
+        /// <see cref="NativeArray{T}"/>.
+        /// </summary>
+        /// <param name="map">The <see cref="UnsafeParallelHashMap{TKey,TValue}"/> to get the keys of.</param>
+        /// <param name="result">The array to write the keys into.</param>
+        /// <typeparam name="TKey">The key type.</typeparam>
+        /// <typeparam name="TValue">The value type.</typeparam>
+        public static unsafe void GetKeyArray<TKey, TValue>(this UnsafeParallelHashMap<TKey, TValue> map, NativeArray<TKey> result)
+            where TKey : struct, IEquatable<TKey>
+            where TValue : struct
+        {
+            UnsafeParallelHashMapData.GetKeyArray(map.m_Buffer, result);
+        }
+
+        /// <summary>
+        /// Writes the values of a <see cref="UnsafeParallelHashMap{TKey,TValue}"/> to an existing
+        /// <see cref="NativeArray{T}"/>.
+        /// </summary>
+        /// <param name="map">The <see cref="UnsafeParallelHashMap{TKey,TValue}"/> to get the values of.</param>
+        /// <param name="result">The array to write the values into.</param>
+        /// <typeparam name="TKey">The key type.</typeparam>
+        /// <typeparam name="TValue">The value type.</typeparam>
+        public static unsafe void GetValueArray<TKey, TValue>(this UnsafeParallelHashMap<TKey, TValue> map, NativeArray<TValue> result)
+            where TKey : struct, IEquatable<TKey>
+            where TValue : struct
+        {
+            UnsafeParallelHashMapData.GetValueArray(map.m_Buffer, result);
+        }
+
+        /// <summary>
+        /// Writes the key value pairs of a <see cref="UnsafeParallelHashMap{TKey,TValue}"/> to an existing
+        /// <see cref="NativeKeyValueArrays{TKey, TValue}"/>
+        /// </summary>
+        /// <param name="map">The <see cref="UnsafeParallelHashMap{TKey,TValue}"/> to get the key value pairs of.</param>
+        /// <param name="result">The array to write the key value pairs into.</param>
+        /// <typeparam name="TKey">The key type</typeparam>
+        /// <typeparam name="TValue">The value type</typeparam>
+        public static unsafe void GetKeyValueArrays<TKey, TValue>(this UnsafeParallelHashMap<TKey, TValue> map, NativeKeyValueArrays<TKey, TValue> result)
+            where TKey : struct, IEquatable<TKey>
+            where TValue : struct
+        {
+            UnsafeParallelHashMapData.GetKeyValueArrays(map.m_Buffer, result);
+        }
+    }
+}

--- a/Scripts/AssemblyInjections/Unity.Collections/UnsafeParallelHashMapInternalExtension.cs.meta
+++ b/Scripts/AssemblyInjections/Unity.Collections/UnsafeParallelHashMapInternalExtension.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: c081becc912e4bc381e0e8a5596886b1
+timeCreated: 1675967554

--- a/Scripts/Runtime/Data/Collections/Util/UnsafeParallelHashMapExtension.cs
+++ b/Scripts/Runtime/Data/Collections/Util/UnsafeParallelHashMapExtension.cs
@@ -1,0 +1,27 @@
+using System;
+using Unity.Collections.LowLevel.Unsafe;
+
+namespace Anvil.Unity.DOTS.Data
+{
+    /// <summary>
+    /// A collection of extension methods for <see cref="UnsafeParallelHashMap{TKey,TValue}"/>.
+    /// </summary>
+    public static class UnsafeParallelHashMapExtension
+    {
+        /// <summary>
+        /// Removes a key-value pair.
+        /// </summary>
+        /// <param name="map">The <see cref="UnsafeParallelHashMap{TKey,TValue}"/> to remove from.</param>
+        /// <param name="key">The key to remove.</param>
+        /// <param name="value">The value at the key that was removed</param>
+        /// <typeparam name="TKey">The key type.</typeparam>
+        /// <typeparam name="TValue">The value type.</typeparam>
+        /// <returns>True if a key-value pair was removed.</returns>
+        public static bool Remove<TKey, TValue>(this UnsafeParallelHashMap<TKey, TValue> map, TKey key, out TValue value)
+            where TKey : struct, IEquatable<TKey>
+            where TValue : struct
+        {
+            return map.TryGetValue(key, out value) && map.Remove(key);
+        }
+    }
+}

--- a/Scripts/Runtime/Data/Collections/Util/UnsafeParallelHashMapExtension.cs.meta
+++ b/Scripts/Runtime/Data/Collections/Util/UnsafeParallelHashMapExtension.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: f47911f3cce14e3092716f94394b4b13
+timeCreated: 1675968043


### PR DESCRIPTION
Just mimicking what already exists for `NativeParallelHashMap` but adding for `UnsafeParallelHashMap`

### What is the current behaviour?

Can't use some nice extensions for `NativeParallelHashMap` with `UnsafeParallelHashMap`

### What is the new behaviour?

Now we can! 
And made `NativeParallelHashMap` call the Unsafe ones where relevant.

### What issues does this resolve?
- None

### What PRs does this depend on?
 - None

### Does this introduce a breaking change?
 - [ ] Yes
 - [x] No
