### PR TITLE
Entity Spawning - Clean Up

### DIFF
--- a/Scripts/Runtime/Entities/Lifecycle/EntitySpawnSystem.cs
+++ b/Scripts/Runtime/Entities/Lifecycle/EntitySpawnSystem.cs
@@ -19,7 +19,7 @@ namespace Anvil.Unity.DOTS.Entities
     /// <remarks>
     /// By default, this system updates in <see cref="SimulationSystemGroup"/> but can be configured by subclassing
     /// and using the <see cref="UpdateInGroupAttribute"/> to target a different group.
-    /// 
+    ///
     /// By default, this system uses the <see cref="EndSimulationEntityCommandBufferSystem"/> to playback the
     /// generated <see cref="EntityCommandBuffer"/>s. This can be configured by subclassing and using the
     /// <see cref="UseCommandBufferSystemAttribute"/> to target a different <see cref="EntityCommandBufferSystem"/>
@@ -284,7 +284,7 @@ namespace Anvil.Unity.DOTS.Entities
 
         /// <summary>
         /// Spawns an <see cref="Entity"/> with the given definition immediately by cloning the passed in prototype
-        /// <see cref="Entity"/> and returns it immediately. 
+        /// <see cref="Entity"/> and returns it immediately.
         /// </summary>
         /// <remarks>
         /// This will not enable this system.
@@ -330,11 +330,12 @@ namespace Anvil.Unity.DOTS.Entities
 
             //All the active spawners that need to go this frame are given a chance to go ahead and run their spawn jobs
             int index = 0;
+
             foreach (IEntitySpawner entitySpawner in m_ActiveEntitySpawners)
             {
                 //Normally for each ECB created, you want to add the job handle for producer to the command buffer
                 //system. However, we know that all these handles will be combined, so we can just do one call at the
-                //end of the function. Creating here and passing into the Schedule function allows us to see the 
+                //end of the function. Creating here and passing into the Schedule function allows us to see the
                 //creation and AddJobHandleForProducer calls close by so we know we're adhering to the "pattern".
                 EntityCommandBuffer ecb = m_CommandBufferSystem.CreateCommandBuffer();
                 dependencies[index] = entitySpawner.Schedule(dependsOn, ref ecb, entityArchetypesLookup);

--- a/Scripts/Runtime/Entities/Lifecycle/EntitySpawnSystem.cs
+++ b/Scripts/Runtime/Entities/Lifecycle/EntitySpawnSystem.cs
@@ -325,8 +325,7 @@ namespace Anvil.Unity.DOTS.Entities
 
         private JobHandle ScheduleActiveEntitySpawners(JobHandle dependsOn)
         {
-            NativeArray<JobHandle> dependencies = new NativeArray<JobHandle>(m_ActiveEntitySpawners.Count + 1, Allocator.Temp, NativeArrayOptions.UninitializedMemory);
-            dependencies[^1] = m_EntityArchetypes.AcquireAsync(AccessType.SharedRead, out NativeParallelHashMap<long, EntityArchetype> entityArchetypesLookup);
+            NativeArray<JobHandle> dependencies = new NativeArray<JobHandle>(m_ActiveEntitySpawners.Count, Allocator.Temp, NativeArrayOptions.UninitializedMemory);
 
             //All the active spawners that need to go this frame are given a chance to go ahead and run their spawn jobs
             int index = 0;
@@ -338,12 +337,11 @@ namespace Anvil.Unity.DOTS.Entities
                 //end of the function. Creating here and passing into the Schedule function allows us to see the
                 //creation and AddJobHandleForProducer calls close by so we know we're adhering to the "pattern".
                 EntityCommandBuffer ecb = m_CommandBufferSystem.CreateCommandBuffer();
-                dependencies[index] = entitySpawner.Schedule(dependsOn, ref ecb, entityArchetypesLookup);
+                dependencies[index] = entitySpawner.Schedule(dependsOn, ref ecb);
                 index++;
             }
 
             dependsOn = JobHandle.CombineDependencies(dependencies);
-            m_EntityArchetypes.ReleaseAsync(dependsOn);
             m_CommandBufferSystem.AddJobHandleForProducer(dependsOn);
             return dependsOn;
         }

--- a/Scripts/Runtime/Entities/Lifecycle/JobInteraction/EntityPrototypeSpawnWriter.cs
+++ b/Scripts/Runtime/Entities/Lifecycle/JobInteraction/EntityPrototypeSpawnWriter.cs
@@ -81,7 +81,7 @@ namespace Anvil.Unity.DOTS.Entities
         public void SpawnDeferred(Entity prototype, ref TEntitySpawnDefinition definition, bool shouldDestroyPrototype)
         {
             Debug_EnsureCanAdd();
-            m_LaneWriter.Write(new EntityPrototypeDefinitionWrapper<TEntitySpawnDefinition>(prototype, ref definition));
+            m_LaneWriter.Write(new EntityPrototypeDefinitionWrapper<TEntitySpawnDefinition>(prototype, in definition));
             if (shouldDestroyPrototype)
             {
                 m_PrototypesToDestroyLaneWriter.Write(prototype);
@@ -95,7 +95,7 @@ namespace Anvil.Unity.DOTS.Entities
         /// <remarks>
         /// Useful when in a job that only operates on each index or Entity like Entities.ForEach.
         /// There is no opportunity to call <see cref="InitForThread"/> at the start and you can't call
-        /// it multiple times. 
+        /// it multiple times.
         /// </remarks>
         /// <param name="prototype">The prototype <see cref="Entity"/> to clone.</param>
         /// <param name="definition">The type of <see cref="IEntitySpawnDefinition"/> to spawn</param>
@@ -108,14 +108,14 @@ namespace Anvil.Unity.DOTS.Entities
         /// </param>
         public void SpawnDeferred(Entity prototype, TEntitySpawnDefinition definition, int laneIndex, bool shouldDestroyPrototype)
         {
-            SpawnDeferred(prototype, ref definition, laneIndex, shouldDestroyPrototype);
+            SpawnDeferred(prototype, in definition, laneIndex, shouldDestroyPrototype);
         }
 
         /// <inheritdoc cref="SpawnDeferred(Entity,TEntitySpawnDefinition,int,bool)"/>
-        public void SpawnDeferred(Entity prototype, ref TEntitySpawnDefinition definition, int laneIndex, bool shouldDestroyPrototype)
+        public void SpawnDeferred(Entity prototype, in TEntitySpawnDefinition definition, int laneIndex, bool shouldDestroyPrototype)
         {
             m_Writer.AsLaneWriter(laneIndex)
-                .Write(new EntityPrototypeDefinitionWrapper<TEntitySpawnDefinition>(prototype, ref definition));
+                .Write(new EntityPrototypeDefinitionWrapper<TEntitySpawnDefinition>(prototype, in definition));
             if (shouldDestroyPrototype)
             {
                 m_PrototypesToDestroyWriter.AsLaneWriter(laneIndex)

--- a/Scripts/Runtime/Entities/Lifecycle/Spawner/AbstractEntitySpawner.cs
+++ b/Scripts/Runtime/Entities/Lifecycle/Spawner/AbstractEntitySpawner.cs
@@ -80,8 +80,7 @@ namespace Anvil.Unity.DOTS.Entities
 
         public JobHandle Schedule(
             JobHandle dependsOn,
-            ref EntityCommandBuffer ecb,
-            NativeParallelHashMap<long, EntityArchetype> entityArchetypeLookup)
+            ref EntityCommandBuffer ecb)
         {
             JobHandle definitionsHandle = m_DefinitionsToSpawn.AcquireAsync(AccessType.ExclusiveWrite, out UnsafeTypedStream<T> definitions);
             dependsOn = JobHandle.CombineDependencies(definitionsHandle, dependsOn);

--- a/Scripts/Runtime/Entities/Lifecycle/Spawner/EntityPrototypeSpawner.cs
+++ b/Scripts/Runtime/Entities/Lifecycle/Spawner/EntityPrototypeSpawner.cs
@@ -6,6 +6,7 @@ using Unity.Burst;
 using Unity.Collections;
 using Unity.Entities;
 using Unity.Jobs;
+using UnityEngine;
 
 namespace Anvil.Unity.DOTS.Entities
 {
@@ -36,7 +37,7 @@ namespace Anvil.Unity.DOTS.Entities
 
         public void Spawn(Entity prototype, TEntitySpawnDefinition spawnDefinition, bool shouldDestroyPrototype)
         {
-            InternalSpawn(new EntityPrototypeDefinitionWrapper<TEntitySpawnDefinition>(prototype, ref spawnDefinition));
+            InternalSpawn(new EntityPrototypeDefinitionWrapper<TEntitySpawnDefinition>(prototype, in spawnDefinition));
             if (shouldDestroyPrototype)
             {
                 MarkPrototypeToBeDestroyed(prototype);
@@ -221,7 +222,7 @@ namespace Anvil.Unity.DOTS.Entities
 
         public EntityPrototypeDefinitionWrapper(
             Entity prototype,
-            ref TEntitySpawnDefinition entitySpawnDefinition)
+            in TEntitySpawnDefinition entitySpawnDefinition)
         {
             Prototype = prototype;
             EntitySpawnDefinition = entitySpawnDefinition;
@@ -229,6 +230,6 @@ namespace Anvil.Unity.DOTS.Entities
 
         public EntityPrototypeDefinitionWrapper(
             Entity prototype,
-            TEntitySpawnDefinition entitySpawnDefinition) : this(prototype, ref entitySpawnDefinition) { }
+            TEntitySpawnDefinition entitySpawnDefinition) : this(prototype, in entitySpawnDefinition) { }
     }
 }

--- a/Scripts/Runtime/Entities/Lifecycle/Spawner/IEntitySpawner.cs
+++ b/Scripts/Runtime/Entities/Lifecycle/Spawner/IEntitySpawner.cs
@@ -13,7 +13,6 @@ namespace Anvil.Unity.DOTS.Entities
 
         public JobHandle Schedule(
             JobHandle dependsOn,
-            ref EntityCommandBuffer ecb,
-            NativeParallelHashMap<long, EntityArchetype> entityArchetypeLookup);
+            ref EntityCommandBuffer ecb);
     }
 }


### PR DESCRIPTION
Cleaned up some implementation details in Entity spawning and removed unsued code.

### What is the current behaviour?

- EntitySpawnerSystem - The dependency on accessing the achretype lookup was not correctly applied to `dependsOn` before kicking off spawner jobs. Doesn't matter though because it's unused!
- Spawn descriptors are being passed by `ref` but are readonly so they should be passed by `in`

### What is the new behaviour?

- Archetype lookup is removed from execution and interfaces
- All instances of spawn descriptors are now passed with `in`
- Minor code style cleanup

### What issues does this resolve?

- None

### What PRs does this depend on?

 - None

### Does this introduce a breaking change?
- [x] Yes - Any passing of spawn descriptors into Anvil needs to be changed to use `in`
- [ ] No
