### PR TITLE
Anvil PlayerLoop Phases For Everyone

### DIFF
--- a/Scripts/AssemblyInjections/Unity.Entities/DefaultWorldInitializationInternal.cs
+++ b/Scripts/AssemblyInjections/Unity.Entities/DefaultWorldInitializationInternal.cs
@@ -1,0 +1,19 @@
+using System;
+using Unity.Entities;
+
+public static class DefaultWorldInitializationInternal
+{
+    /// <inheritdoc cref="DefaultWorldInitialization.DefaultWorldInitialized"/>
+    public static event Action<World> DefaultWorldInitialized
+    {
+        add => DefaultWorldInitialization.DefaultWorldInitialized += value;
+        remove => DefaultWorldInitialization.DefaultWorldInitialized -= value;
+    }
+
+    /// <inheritdoc cref="DefaultWorldInitialization.DefaultWorldDestroyed"/>
+    public static event Action DefaultWorldDestroyed
+    {
+        add => DefaultWorldInitialization.DefaultWorldDestroyed += value;
+        remove => DefaultWorldInitialization.DefaultWorldDestroyed -= value;
+    }
+}

--- a/Scripts/AssemblyInjections/Unity.Entities/DefaultWorldInitializationInternal.cs.meta
+++ b/Scripts/AssemblyInjections/Unity.Entities/DefaultWorldInitializationInternal.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a9c6caf5185f74866b5fec2c6a190403
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/AssemblyInjections/Unity.Entities/ScriptBehaviourUpdateOrderInternal.cs
+++ b/Scripts/AssemblyInjections/Unity.Entities/ScriptBehaviourUpdateOrderInternal.cs
@@ -1,0 +1,51 @@
+using System;
+using Unity.Entities;
+using UnityEngine;
+using UnityEngine.LowLevel;
+
+/// <summary>
+/// A collection of methods that supplement <see cref="ScriptBehaviourUpdateOrder"/>'s functionality and require access
+/// to internal types/methods.
+/// </summary>
+public static class ScriptBehaviourUpdateOrderInternal
+{
+    /// <summary>
+    /// Given a <see cref="PlayerLoopSystem"/>, try to get the <see cref="ComponentSystemBase"/> associated.
+    /// (non-recursive)
+    /// NOTE: DO NOT use this class. Instead use <see cref="PlayerLoopUtil.TryGetSystemFromPlayerLoop"/>.
+    /// </summary>
+    /// <param name="playerLoopSystem">The <see cref="PlayerLoopSystem"/> to use.</param>
+    /// <param name="system">The <see cref="ComponentSystemBase"/> associated.</param>
+    /// <returns>
+    /// True if there is a system.
+    /// False if the provided player loop does not represent a system.
+    /// </returns>
+    /// <remarks>
+    /// This is required because
+    /// <see cref="ScriptBehaviourUpdateOrder.AppendSystemToPlayerLoop"/> wraps the update call in a dummy class to work
+    /// around a limitation with Mono (<see cref="ScriptBehaviourUpdateOrder.DummyDelegateWrapper"/>).
+    ///
+    /// The method will be removed and most of the logic moved to <see cref="PlayerLoopUtil.TryGetSystemFromPlayerLoop"/>
+    /// when Unity stops wrapping systems in <see cref="ScriptBehaviourUpdateOrder.DummyDelegateWrappper"/>.
+    ///
+    /// It should only be called by the <see cref="PlayerLoopUtil.TryGetSystemFromPlayerLoop"/> method.
+    /// </remarks>
+    public static bool TryGetSystemFromPlayerLoopSystem(ref PlayerLoopSystem playerLoopSystem, out ComponentSystemBase system)
+    {
+        if (playerLoopSystem.updateDelegate?.Target == null || !typeof(ComponentSystemBase).IsAssignableFrom(playerLoopSystem.type))
+        {
+            system = null;
+            return false;
+        }
+
+        var wrapper = playerLoopSystem.updateDelegate.Target as ScriptBehaviourUpdateOrder.DummyDelegateWrapper;
+        // If the wrapper is null then Unity has stopped wrapping component systems in DummyDelegateWrapper and we can
+        // move this method out into the non assembly injected/internal version of this class.
+        Debug.Assert(
+            wrapper != null,
+            $"Wrapper is null. Has Unity stopped wrapping top level systems in {nameof(ScriptBehaviourUpdateOrder.DummyDelegateWrapper)}?");
+
+        system = wrapper.System;
+        return true;
+    }
+}

--- a/Scripts/AssemblyInjections/Unity.Entities/ScriptBehaviourUpdateOrderInternal.cs.meta
+++ b/Scripts/AssemblyInjections/Unity.Entities/ScriptBehaviourUpdateOrderInternal.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d8890a4d0d6cb44a59dd67cb7328dd72
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/Runtime/Entities/Cache/WorldCache.cs
+++ b/Scripts/Runtime/Entities/Cache/WorldCache.cs
@@ -121,9 +121,9 @@ namespace Anvil.Unity.DOTS.Entities
             if (playerLoopSystem.updateDelegate != null
                 && COMPONENT_SYSTEM_GROUP_TYPE.IsAssignableFrom(playerLoopSystem.type)
                 && PlayerLoopUtil.IsPlayerLoopSystemPartOfWorld(ref playerLoopSystem, World)
-                && PlayerLoopUtil.TryGetSystemGroupFromPlayerLoopSystemNoChecks(ref playerLoopSystem, out ComponentSystemGroup group))
+                && PlayerLoopUtil.TryGetSystemFromPlayerLoopSystem(ref playerLoopSystem, out ComponentSystemBase group))
             {
-                ParseSystemGroup(null, group);
+                ParseSystemGroup(null, (ComponentSystemGroup)group);
             }
 
             //Phases won't have subsystems

--- a/Scripts/Runtime/Entities/Util/ComponentSystemBaseExtension.cs
+++ b/Scripts/Runtime/Entities/Util/ComponentSystemBaseExtension.cs
@@ -1,7 +1,9 @@
 using Anvil.Unity.DOTS.Data;
+using System.Collections.Generic;
 using Unity.Collections;
 using Unity.Entities;
 using Unity.Jobs;
+using UnityEngine;
 
 namespace Anvil.Unity.DOTS.Entities
 {
@@ -133,6 +135,26 @@ namespace Anvil.Unity.DOTS.Entities
             };
 
             return job.Schedule(dependsOn);
+        }
+
+        public static bool TryFindParentGroup(this ComponentSystemGroup system, out ComponentSystemGroup group)
+        {
+            var worldSystems = system.World.Systems;
+            foreach (ComponentSystemBase worldSystem in worldSystems)
+            {
+                if (worldSystem is ComponentSystemGroup worldGroup)
+                {
+                    Debug.Assert(worldGroup.Systems is List<ComponentSystemBase>);
+                    if ((worldGroup.Systems as List<ComponentSystemBase>).Contains(system))
+                    {
+                        group = worldGroup;
+                        return true;
+                    }
+                }
+            }
+
+            group = null;
+            return false;
         }
     }
 }

--- a/Scripts/Runtime/Entities/Util/PlayerLoopUtil.cs
+++ b/Scripts/Runtime/Entities/Util/PlayerLoopUtil.cs
@@ -69,7 +69,7 @@ namespace Anvil.Unity.DOTS.Entities
                 return true;
             }
 
-            // Recursively check each subsystem's subsystems the system.
+            // Recursively check each subsystem's subsystems for system.
             for (int i = 0; i < playerLoop.subSystemList.Length; i++)
             {
                 PlayerLoopSystem playerLoopSubSystem = playerLoop.subSystemList[i];


### PR DESCRIPTION
This is a replacement/alternate approach to what was proposed in #166. If this is accepted/merged then the other PR should be deleted/closed.

This PR exposes the anvil player loop phases/types `PostUpdate_Anvil`/`PostInitialization_Anvil` and adds the ability to safely add `ComponentSystemGroup`s to them.

Included in this work are a number of related tasks:
 - Utility methods for checking for the existence of systems in the player loop.
 - Leveraging assembly injection a system instance may be fetched from a `PlayerLoopSystem` working around the wrapper object Unity has in place for their own fix.
    - A side effect of this change is that reflection is no longer required for any of the `PlayerUtils` functionality making #28 redundant.

#### Tag Alongs
 - Expose the internal events `DefaultWorldInitialization.DefaultWorldInitialized` and `DefaultWorldInitialization.DefaultWorldDestroyed`


### What is the current behaviour?

 - There is no way for applications to easily add their own `ComponentSystemGroup` instances to the Anvil player loop phases (or any other player loop phase for that matter)
   - Developers also have to be very careful that any groups they do add are only added once and have not already been instantiated.
 - There is no way to check if an instance of a `ComponentSystemBase` has already been added to a player loop

The proposed solution in #166 addressed some of these challenges by hijacking the `*CommandBufferSystemGroup_Anvil` groups but this was not very flexible and undermined the intent of those groups to focus on main thread processing after all other worlds had scheduled their jobs.

### What is the new behaviour?

Add `ScriptBehaviourUpdateOrderInternal.TryFindPlayerLoopSystemByType` - A utility method to get system from a `PlayerLoopSystem`
    - Uses assembly injection to allow user code to find an instance of a system in a player loop.
    - This is required because Unity wraps all `ComponentSystemBase` instances added via `ScriptBehaviourUpdateOrder.AppendSystemToPlayerLoop` in a dummy type to overcome a limitation with Mono. See comments on the method for details.

Add `ComponentSystemBaseExtension` - Create extension method to try and find the parent group of a system
   - This is a brute force approach. It's not performant but the current use cases aren't performance critical situations.

`PlayerLoopUtil`
 - Remove need for reflection now that we have `ScriptBehaviourUpdateOrderInternal` to do the work
 - Remove group specific methods since they're basically just casting on the system versions of the methods
 - Make naming consistent
    - "PlayerLoop" for recursive evaluations
    - "PlayerLoopSystem" for single level evaluations
 - Add `IsInPlayerLoop` - Checks whether a `ComponentSystemBase` exists anywhere in the `PlayerLoopSystem`'s tree
 - Add `IsInPlayerLoopSystem` - Checks whether a `ComponentSystemBase` exists in a given `PlayerLoopSystem`
 - Add `IsSubsystemOfPlayerLoopSystem` - Checks whether a `ComponentSystemBase` is a subsystem of a `PlayerLoopSystem`
 - Add `TryFindPlayerLoopSystemByType` - A proxy for ScriptBehaviourUpdateOrderInternal.TryFindPlayerLoopSystemByType. This is the method that should be used since the internal version will be removed when Unity fixes their work around.
 - Add `NO_PLAYER_LOOP` to represent no player loop found for the `Try*` methods

`WorldUtil`
 - Make `PostUpdate_Anvil` and `PostInitialization_Anvil` public types with internal constructors.
    - This allows application code to add top level groups to the player loop phases
 - Define a constant for default World groups that unity defines (`DEFAULT_TOP_LEVEL_GROUPS`)
 - Rename `AddTopLevelGroupsToCurrentPlayerLoop` to `SetupTopLevelGroupsInCurrentPlayerLoop`
    -  This reflects the new ability for this method to handle migrating an existing `ComponentSystemGroup` instances out of their existing parent group and into the `PlayerLoop` as a top level group.
    - This method is now more robust and emits a warning if the group already exists as a top layer group
    - This allows more flexible usage by application code.

Expose `DefaultWorldInitialization.DefaultWorldInitialized` and `DefaultWorldInitialization.DefaultWorldDestroyed` via `DefaultWorldInitializationInternal` using Assembly injection.


### What issues does this resolve?
 - Close: #28 - now redundant
 - Close: #166 - A replacement for the suggested approach

### What PRs does this depend on?
 - None

### Does this introduce a breaking change?
 - [x] Yes
    - Rename any use of `WorldUtil.AddTopLevelGroupsToCurrentPlayerLoop` to `WorldUtil.SetupTopLevelGroupsInCurrentPlayerLoop`
    - Rename any use of `PlayerLoopUtil.TryGetSystemGroupFromPlayerLoopSystemNoChecks` to `PlayerLoopUtil.TryGetSystemFromPlayerLoopSystem` and perform your own type check to ensure you're getting a group.
 - [ ] No
