### PR TITLE
Misc Helpers

### DIFF
--- a/Scripts/AssemblyInjections/Unity.Entities/EntityCleanupHelper.cs
+++ b/Scripts/AssemblyInjections/Unity.Entities/EntityCleanupHelper.cs
@@ -1,0 +1,9 @@
+using Unity.Entities;
+
+namespace Anvil.Unity.DOTS.Entities
+{
+    public static class EntityCleanupHelper
+    {
+        public static readonly ComponentType CLEAN_UP_ENTITY_COMPONENT_TYPE = ComponentType.ReadOnly<CleanupEntity>();
+    }
+}

--- a/Scripts/AssemblyInjections/Unity.Entities/EntityCleanupHelper.cs
+++ b/Scripts/AssemblyInjections/Unity.Entities/EntityCleanupHelper.cs
@@ -2,8 +2,15 @@ using Unity.Entities;
 
 namespace Anvil.Unity.DOTS.Entities
 {
+    /// <summary>
+    /// Helper class to detect when an Entity has entered a clean up state due to having
+    /// <see cref="ISystemStateComponentData"/> attached.
+    /// </summary>
     public static class EntityCleanupHelper
     {
+        /// <summary>
+        /// Provides the type of <see cref="CleanupEntity"/> so it can be used in queries outside the Unity assembly.
+        /// </summary>
         public static readonly ComponentType CLEAN_UP_ENTITY_COMPONENT_TYPE = ComponentType.ReadOnly<CleanupEntity>();
     }
 }

--- a/Scripts/AssemblyInjections/Unity.Entities/EntityCleanupHelper.cs.meta
+++ b/Scripts/AssemblyInjections/Unity.Entities/EntityCleanupHelper.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 03d5a4c4a97246a4ac98c550cdcdc3f4
+timeCreated: 1676404696

--- a/Scripts/Runtime/Entities/Util/ComponentTypeExtension.cs
+++ b/Scripts/Runtime/Entities/Util/ComponentTypeExtension.cs
@@ -1,0 +1,18 @@
+using Unity.Entities;
+
+namespace Anvil.Unity.DOTS.Entities
+{
+    public static class ComponentTypeExtension
+    {
+        public static ComponentType[] ToReadOnly(this ComponentType[] componentTypes)
+        {
+            ComponentType[] readOnlyTypes = new ComponentType[componentTypes.Length];
+            for (int i = 0; i < componentTypes.Length; ++i)
+            {
+                readOnlyTypes[i] = ComponentType.ReadOnly(componentTypes[i].TypeIndex);
+            }
+
+            return readOnlyTypes;
+        }
+    }
+}

--- a/Scripts/Runtime/Entities/Util/ComponentTypeExtension.cs
+++ b/Scripts/Runtime/Entities/Util/ComponentTypeExtension.cs
@@ -2,8 +2,22 @@ using Unity.Entities;
 
 namespace Anvil.Unity.DOTS.Entities
 {
+    /// <summary>
+    /// Helper methods when dealing with <see cref="ComponentTypes"/>
+    /// </summary>
     public static class ComponentTypeExtension
     {
+        /// <summary>
+        /// Converts an array of <see cref="ComponentType"/>s to be readonly.
+        /// </summary>
+        /// <remarks>
+        /// A component array created using typeof(ComponentType) will default all created <see cref="ComponentType"/>
+        /// to be readwrite. When generating a query from that array, the query access will be expensive since
+        /// Unity will think that all the components will be written to. This is useful for making a query
+        /// that uses all of those components but in a readonly context to limit blocking.
+        /// </remarks>
+        /// <param name="componentTypes">The array of <see cref="ComponentType"/> to convert</param>
+        /// <returns>An array of <see cref="ComponentType"/> that are all readonly</returns>
         public static ComponentType[] ToReadOnly(this ComponentType[] componentTypes)
         {
             ComponentType[] readOnlyTypes = new ComponentType[componentTypes.Length];

--- a/Scripts/Runtime/Entities/Util/ComponentTypeExtension.cs.meta
+++ b/Scripts/Runtime/Entities/Util/ComponentTypeExtension.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 2b8d67ebe7dc4f8697b9c68671a901f3
+timeCreated: 1676407168

--- a/Scripts/Runtime/Entities/Util/EntityManagerExtension.cs
+++ b/Scripts/Runtime/Entities/Util/EntityManagerExtension.cs
@@ -1,0 +1,12 @@
+using Unity.Entities;
+
+namespace Anvil.Unity.DOTS.Entities
+{
+    public static class EntityManagerExtension
+    {
+        public static bool IsValid(this EntityManager entityManager, Entity entity)
+        {
+            return entityManager.Exists(entity) && !entityManager.HasComponent(entity, EntityCleanupHelper.CLEAN_UP_ENTITY_COMPONENT_TYPE);
+        }
+    }
+}

--- a/Scripts/Runtime/Entities/Util/EntityManagerExtension.cs
+++ b/Scripts/Runtime/Entities/Util/EntityManagerExtension.cs
@@ -2,8 +2,24 @@ using Unity.Entities;
 
 namespace Anvil.Unity.DOTS.Entities
 {
+    /// <summary>
+    /// Helper methods for a <see cref="EntityManager"/>
+    /// </summary>
     public static class EntityManagerExtension
     {
+        /// <summary>
+        /// Similar to <see cref="EntityManager.Exists"/> but goes a bit further to detect if the <see cref="Entity"/>
+        /// is in a clean up state or not.
+        /// </summary>
+        /// <remarks>
+        /// It can be useful to keep a reference to an <see cref="Entity"/> in OO land and just check if it still
+        /// exists before using it. However, some Entities will have clean up components on them if they use
+        /// <see cref="ISystemStateComponentData"/>. The Entity will therefore still exist but not actually be able to
+        /// be used.
+        /// </remarks>
+        /// <param name="entityManager">The <see cref="EntityManager"/> the Entity is a part of.</param>
+        /// <param name="entity">The <see cref="Entity"/> to check</param>
+        /// <returns>True if the Entity exists and is not in a cleanup state. False otherwise</returns>
         public static bool IsValid(this EntityManager entityManager, Entity entity)
         {
             return entityManager.Exists(entity) && !entityManager.HasComponent(entity, EntityCleanupHelper.CLEAN_UP_ENTITY_COMPONENT_TYPE);

--- a/Scripts/Runtime/Entities/Util/EntityManagerExtension.cs.meta
+++ b/Scripts/Runtime/Entities/Util/EntityManagerExtension.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 6e83365a8a554c6396957ef8a80ea4ef
+timeCreated: 1677522490


### PR DESCRIPTION
Some miscellaneous helpers that are useful.

### What is the current behaviour?

These don't exist.

### What is the new behaviour?

Now they do. 
The docs are pretty self-explanatory but at a highlevel
- Expose the ability to get the type for `CleanupEntity` that is internal to Unity.
- Extension method for `EntityManager` to check if an Entity both exists and is NOT in a cleanup state.
- Extension method to convert an array of `ComponentType` to readonly.

### What issues does this resolve?
- None

### What PRs does this depend on?
 - None

### Does this introduce a breaking change?
 - [ ] Yes
 - [x] No
