### PR TITLE
WorldUtil - Always emit sorting warning message

### DIFF
--- a/Scripts/Runtime/Entities/Util/WorldUtil.cs
+++ b/Scripts/Runtime/Entities/Util/WorldUtil.cs
@@ -255,16 +255,13 @@ namespace Anvil.Unity.DOTS.Entities
             MoveSystemFromToGroup<EndInitializationEntityCommandBufferSystem, InitializationSystemGroup, EndInitializationCommandBufferSystemGroup_Anvil>(world);
             MoveSystemFromToGroup<EndSimulationEntityCommandBufferSystem, SimulationSystemGroup, EndSimulationCommandBufferSystemGroup_Anvil>(world);
 
+            Log.GetStaticLogger(typeof(WorldUtil)).Warning($"Optimizing world '{world.Name}' for multi world execution. From this point forward, when sorting {nameof(SimulationSystemGroup)} warnings will be emitted for systems trying to position against {nameof(EndSimulationEntityCommandBufferSystem)}. This is expected.");
             // Suppress the logging during sort so we don't see complaints about systems that position themselves based on
             // the systems that we're moving. So far, the configured above are at the end of the group and don't cause issues
             // aside from the warnings. (dependent systems end up in the right place anyway)
             try
             {
-#if LOG_VERBOSE
-                UnityEngine.Debug.LogWarning($"Sorting {nameof(PlayerLoopSystem)}s. Warning expected with systems trying to position against ${nameof(EndSimulationEntityCommandBufferSystem)}");
-#else
                 Log.SuppressLogging = true;
-#endif
                 SortAllGroupsInWorld(world);
             }
             finally


### PR DESCRIPTION
When optimizing worlds the sorting warning message is now always emitted. This communicates to the developer that sorting certain system groups will now always emit a warning post optimization. 

This message is useful since the sort warnings can come up after optimizing the world and the reason isn't immediately obvious.

Maybe someday we can have better log filtering and prevent this warning spam but for now it's better to inform developers about what to expect.

### What is the current behaviour?

Warning message when optimizing worlds is only emitted when `LOG_VERBOSE` is enabled.
The message also only communicates the immediately expected warnings.

### What is the new behaviour?

Warning message is always emitted when optimizing worlds.
The message communicates that all sort operations on the originating group will trigger the warnings

### What issues does this resolve?
 - None

### What PRs does this depend on?
<!-- List PRs in other repos that need to be merged before this one -->
 - None

### Does this introduce a breaking change?
 - [ ] Yes <!-- If so, what are the migration considerations? -->
 - [x] No
