### PR TITLE
Add additional methods to CDFEReader, CDFEWriter, EntityPersistentDataWriter

### DIFF
--- a/Scripts/Runtime/Entities/TaskDriver/TaskSet/TaskData/JobDataInteraction/CDFEReader.cs
+++ b/Scripts/Runtime/Entities/TaskDriver/TaskSet/TaskData/JobDataInteraction/CDFEReader.cs
@@ -13,11 +13,6 @@ namespace Anvil.Unity.DOTS.Entities.TaskDriver
     {
         [ReadOnly] private readonly ComponentDataFromEntity<T> m_CDFE;
 
-        internal CDFEReader(SystemBase system)
-        {
-            m_CDFE = system.GetComponentDataFromEntity<T>(true);
-        }
-
         /// <summary>
         /// Gets the <typeparamref name="T"/> that corresponds to the passed <see cref="Entity"/>
         /// </summary>
@@ -27,7 +22,16 @@ namespace Anvil.Unity.DOTS.Entities.TaskDriver
             get => m_CDFE[entity];
         }
 
+
+        internal CDFEReader(SystemBase system)
+        {
+            m_CDFE = system.GetComponentDataFromEntity<T>(true);
+        }
+
         /// <inheritdoc cref="ComponentDataFromEntity{T}.HasComponent"/>
         public bool HasComponent(Entity entity) => m_CDFE.HasComponent(entity);
+
+        /// <inheritdoc cref="ComponentDataFromEntity{T}.TryGetComponent"/>
+        public bool TryGetComponent(Entity entity, out T component) => m_CDFE.TryGetComponent(entity, out component);
     }
 }

--- a/Scripts/Runtime/Entities/TaskDriver/TaskSet/TaskData/JobDataInteraction/CDFEWriter.cs
+++ b/Scripts/Runtime/Entities/TaskDriver/TaskSet/TaskData/JobDataInteraction/CDFEWriter.cs
@@ -23,11 +23,6 @@ namespace Anvil.Unity.DOTS.Entities.TaskDriver
         [NativeDisableContainerSafetyRestriction] [NativeDisableParallelForRestriction]
         private ComponentDataFromEntity<T> m_CDFE;
 
-        internal CDFEWriter(SystemBase system)
-        {
-            m_CDFE = system.GetComponentDataFromEntity<T>(false);
-        }
-
         /// <summary>
         /// Gets/Sets the <typeparamref name="T"/> that corresponds to the passed <see cref="Entity"/>
         /// </summary>
@@ -38,7 +33,16 @@ namespace Anvil.Unity.DOTS.Entities.TaskDriver
             set => m_CDFE[entity] = value;
         }
 
+
+        internal CDFEWriter(SystemBase system)
+        {
+            m_CDFE = system.GetComponentDataFromEntity<T>(false);
+        }
+
         /// <inheritdoc cref="ComponentDataFromEntity{T}.HasComponent"/>
         public bool HasComponent(Entity entity) => m_CDFE.HasComponent(entity);
+
+        /// <inheritdoc cref="ComponentDataFromEntity{T}.TryGetComponent"/>
+        public bool TryGetComponent(Entity entity, out T component) => m_CDFE.TryGetComponent(entity, out component);
     }
 }

--- a/Scripts/Runtime/Entities/TaskDriver/TaskSet/TaskData/JobDataInteraction/EntityPersistentDataWriter.cs
+++ b/Scripts/Runtime/Entities/TaskDriver/TaskSet/TaskData/JobDataInteraction/EntityPersistentDataWriter.cs
@@ -10,16 +10,11 @@ namespace Anvil.Unity.DOTS.Entities.TaskDriver
     /// </summary>
     /// <typeparam name="TData">They type of <see cref="IEntityPersistentDataInstance"/> to write</typeparam>
     [BurstCompatible]
-    public struct EntityPersistentDataWriter<TData> 
+    public struct EntityPersistentDataWriter<TData>
         where TData : struct, IEntityPersistentDataInstance
     {
         [NativeDisableContainerSafetyRestriction] [NativeDisableParallelForRestriction]
         private UnsafeParallelHashMap<Entity, TData> m_Lookup;
-
-        internal EntityPersistentDataWriter(ref UnsafeParallelHashMap<Entity, TData> lookup)
-        {
-            m_Lookup = lookup;
-        }
 
         /// <summary>
         /// Gets or sets the data based on the <see cref="Entity"/>
@@ -30,5 +25,20 @@ namespace Anvil.Unity.DOTS.Entities.TaskDriver
             get => m_Lookup[entity];
             set => m_Lookup[entity] = value;
         }
+
+
+        internal EntityPersistentDataWriter(ref UnsafeParallelHashMap<Entity, TData> lookup)
+        {
+            m_Lookup = lookup;
+        }
+
+        /// <inheritdoc cref="UnsafeParallelHashMap{TKey,TValue}.Remove"/>
+        public bool Remove(Entity entity) => m_Lookup.Remove(entity);
+
+        /// <inheritdoc cref="UnsafeParallelHashMap{TKey,TValue}.TryGetValue"/>
+        public bool TryGet(Entity entity, out TData data) => m_Lookup.TryGetValue(entity, out data);
+
+        /// <inheritdoc cref="UnsafeParallelHashMap{TKey,TValue}.ContainsKey"/>
+        public bool Contains(Entity entity) => m_Lookup.ContainsKey(entity);
     }
 }


### PR DESCRIPTION
Add additional methods to `CDFEReader`, `CDFEWriter`, and `EntityPersistentDataWriter` to flesh out their functionality.

### What is the current behaviour?
`CDFEReader`, `CDFEWriter`, and `EntityPersistentDataWriter` are missing methods that are be expected on the built in on the built in types that they wrap. (Ex: `Contains`)

### What is the new behaviour?
Add the following methods:
- `CDFEReader.TryGetComponent()`
- `CDFEWriter.TryGetComponent()`
- `EntityPersistentDataWriter.Remove()`
- `EntityPersistentDataWriter.TryGet()`
- `EntityPersistentDataWriter.Contains()`

### What issues does this resolve?
- None

### What PRs does this depend on?
<!-- List PRs in other repos that need to be merged before this one -->
 - None

### Does this introduce a breaking change?
 - [ ] Yes <!-- If so, what are the migration considerations? -->
 - [x] No
