### PR TITLE
AbstractTaskDriver - Expose system reference to subclasses

### DIFF
--- a/Scripts/Runtime/Entities/TaskDriver/AbstractTaskDriver.cs
+++ b/Scripts/Runtime/Entities/TaskDriver/AbstractTaskDriver.cs
@@ -42,6 +42,11 @@ namespace Anvil.Unity.DOTS.Entities.TaskDriver
         internal AbstractTaskDriverSystem TaskDriverSystem { get; }
         internal TaskSet TaskSet { get; }
 
+        protected AbstractAnvilSystemBase System
+        {
+            get => TaskDriverSystem;
+        }
+
         AbstractTaskDriverSystem ITaskSetOwner.TaskDriverSystem
         {
             get => TaskDriverSystem;
@@ -76,7 +81,7 @@ namespace Anvil.Unity.DOTS.Entities.TaskDriver
             World = world;
             TaskDriverManagementSystem taskDriverManagementSystem = World.GetOrCreateSystem<TaskDriverManagementSystem>();
             m_PersistentDataSystem = World.GetOrCreateSystem<PersistentDataSystem>();
-            
+
             m_SubTaskDrivers = new List<AbstractTaskDriver>();
             TaskSet = new TaskSet(this);
 


### PR DESCRIPTION
Expose the system reference to implementations of `AbstractTaskDriver` to allow creating queries against it.

### What is the current behaviour?

`AbstractTaskDriver`'s system reference is kept internal and implementations.

### What is the new behaviour?

Added `AbstractTaskDriver.System` getter that provides a `SystemBase` reference for subclasses to work with.

### What issues does this resolve?
- None

### What PRs does this depend on?
<!-- List PRs in other repos that need to be merged before this one -->
 - None

### Does this introduce a breaking change?
 - [ ] Yes <!-- If so, what are the migration considerations? -->
 - [x] No
