### PR TITLE
Adding EntityLifecycleSystem and associated functionality

### DIFF
--- a/Scripts/Runtime/Entities/Lifecycle/AbstractEntityLifecycleSystem.cs
+++ b/Scripts/Runtime/Entities/Lifecycle/AbstractEntityLifecycleSystem.cs
@@ -163,6 +163,7 @@ namespace Anvil.Unity.DOTS.Entities
 
             //Then we can run the filter passes on created and destroyed in parallel
             dependsOn = JobHandle.CombineDependencies(
+                dependsOn,
                 UpdateCreationAsync(dependsOn),
                 UpdateDestructionAsync(dependsOn));
 

--- a/Scripts/Runtime/Entities/Lifecycle/AbstractEntityLifecycleSystem.cs
+++ b/Scripts/Runtime/Entities/Lifecycle/AbstractEntityLifecycleSystem.cs
@@ -1,0 +1,226 @@
+using Anvil.CSharp.Collections;
+using System.Collections.Generic;
+using Unity.Burst;
+using Unity.Collections;
+using Unity.Entities;
+using Unity.Jobs;
+
+namespace Anvil.Unity.DOTS.Entities
+{
+    //By default, we'll assume that all spawning/destroying happens in the Initialization Phase
+    [UpdateInGroup(typeof(PostInitialization_Anvil), OrderLast = true)]
+    public abstract partial class AbstractEntityLifecycleSystem : AbstractAnvilSystemBase
+    {
+        private readonly List<EntityLifecycleGroup> m_EntityLifecycleGroups;
+
+        private NativeList<int> m_State;
+        private NativeList<Entity> m_CreatedEntities;
+        private NativeList<Entity> m_DestroyedEntities;
+
+        private NativeArray<EntityLifecycleFilteredGroup> m_CreationFilteredGroups;
+        private NativeArray<EntityLifecycleFilteredGroup> m_DestructionFilteredGroups;
+        private NativeArray<JobHandle> m_Dependencies;
+
+        private bool m_IsInitialized;
+
+        protected AbstractEntityLifecycleSystem()
+        {
+            m_EntityLifecycleGroups = new List<EntityLifecycleGroup>();
+        }
+
+        protected override void OnCreate()
+        {
+            base.OnCreate();
+            m_State = new NativeList<int>(ChunkUtil.MaxElementsPerChunk<Entity>(), Allocator.Persistent);
+            m_CreatedEntities = new NativeList<Entity>(ChunkUtil.MaxElementsPerChunk<Entity>(), Allocator.Persistent);
+            m_DestroyedEntities = new NativeList<Entity>(ChunkUtil.MaxElementsPerChunk<Entity>(), Allocator.Persistent);
+        }
+
+        protected override void OnDestroy()
+        {
+            m_State.Dispose();
+            m_CreatedEntities.Dispose();
+            m_DestroyedEntities.Dispose();
+
+            if (m_CreationFilteredGroups.IsCreated)
+            {
+                m_CreationFilteredGroups.Dispose();
+            }
+            if (m_DestructionFilteredGroups.IsCreated)
+            {
+                m_DestructionFilteredGroups.Dispose();
+            }
+            if (m_Dependencies.IsCreated)
+            {
+                m_Dependencies.Dispose();
+            }
+            
+            m_EntityLifecycleGroups.DisposeAllAndTryClear();
+
+            base.OnDestroy();
+        }
+
+        protected override void OnStartRunning()
+        {
+            base.OnStartRunning();
+            if (m_IsInitialized)
+            {
+                return;
+            }
+            m_IsInitialized = true;
+            Harden();
+        }
+        
+        /// <summary>
+        /// Creates a new <see cref="IReadOnlyEntityLifecycleGroup"/> based on the passed in <see cref="ComponentType"/>
+        /// </summary>
+        /// <remarks>
+        /// Note that the limits on <see cref="EntityQueryMask"/> are relevant since each group creates its own
+        /// EntityQueryMask under the hood. Each entity is compared via the mask for however many groups there are
+        /// </remarks>
+        /// <param name="queryComponentTypes">
+        /// The types of components to construct an <see cref="EntityQueryMask"/>
+        /// </param>
+        /// <returns>
+        /// An instance of <see cref="IReadOnlyEntityLifecycleGroup"/> to use in future jobs/processing.
+        /// </returns>
+        public IReadOnlyEntityLifecycleGroup CreateEntityLifecycleGroup(params ComponentType[] queryComponentTypes)
+        {
+            EntityLifecycleGroup entityLifecycleGroup = new EntityLifecycleGroup(this, queryComponentTypes);
+            m_EntityLifecycleGroups.Add(entityLifecycleGroup);
+            return entityLifecycleGroup;
+        }
+
+        private void Harden()
+        {
+            int groupCount = m_EntityLifecycleGroups.Count;
+            m_CreationFilteredGroups = new NativeArray<EntityLifecycleFilteredGroup>(groupCount, Allocator.Persistent);
+            m_DestructionFilteredGroups = new NativeArray<EntityLifecycleFilteredGroup>(groupCount, Allocator.Persistent);
+            m_Dependencies = new NativeArray<JobHandle>(groupCount + 1, Allocator.Persistent);
+
+            for (int i = 0; i < groupCount; ++i)
+            {
+                EntityLifecycleGroup entityLifecycleGroup = m_EntityLifecycleGroups[i];
+                m_CreationFilteredGroups[i] = entityLifecycleGroup.CreationFilteredGroup;
+                m_DestructionFilteredGroups[i] = entityLifecycleGroup.DestructionFilteredGroup;
+            }
+        }
+
+        protected override void OnUpdate()
+        {
+            Dependency = UpdateAsync(Dependency);
+        }
+
+
+        private JobHandle UpdateAsync(JobHandle dependsOn)
+        {
+            //First we need to get the list of created and destroyed entities
+            dependsOn = JobHandle.CombineDependencies(
+                dependsOn,
+                EntityManager.GetCreatedAndDestroyedEntitiesAsync(
+                    m_State,
+                    m_CreatedEntities,
+                    m_DestroyedEntities));
+
+            //Then we can run the filter passes on created and destroyed in parallel
+            dependsOn = JobHandle.CombineDependencies(
+                UpdateCreationAsync(dependsOn),
+                UpdateDestructionAsync(dependsOn));
+
+            return dependsOn;
+        }
+
+        private JobHandle UpdateCreationAsync(JobHandle dependsOn)
+        {
+            //Get access to all the filtered collections
+            for (int i = 0; i < m_EntityLifecycleGroups.Count; ++i)
+            {
+                m_Dependencies[i] = m_EntityLifecycleGroups[i].AcquireCreationForUpdate();
+            }
+            m_Dependencies[^1] = dependsOn;
+
+            //Run the creation filter job
+            FilterJob creationFilterJob = new FilterJob(
+                m_CreatedEntities,
+                m_CreationFilteredGroups);
+            dependsOn = creationFilterJob.Schedule(dependsOn);
+
+            //Release access so downstream readers can react
+            for (int i = 0; i < m_EntityLifecycleGroups.Count; ++i)
+            {
+                m_EntityLifecycleGroups[i].ReleaseCreationAsync(dependsOn);
+            }
+            return dependsOn;
+        }
+
+        private JobHandle UpdateDestructionAsync(JobHandle dependsOn)
+        {
+            //Get access to all the filtered collections
+            for (int i = 0; i < m_EntityLifecycleGroups.Count; ++i)
+            {
+                m_Dependencies[i] = m_EntityLifecycleGroups[i].AcquireDestructionForUpdate();
+            }
+            m_Dependencies[^1] = dependsOn;
+
+            //Run the destruction job
+            FilterJob destructionFilterJob = new FilterJob(
+                m_DestroyedEntities,
+                m_DestructionFilteredGroups);
+            dependsOn = destructionFilterJob.Schedule(dependsOn);
+
+            //Release access so downstream readers can react
+            for (int i = 0; i < m_EntityLifecycleGroups.Count; ++i)
+            {
+                m_EntityLifecycleGroups[i].ReleaseDestructionAsync(dependsOn);
+            }
+            return dependsOn;
+        }
+
+        //*************************************************************************************************************
+        // JOBS
+        //*************************************************************************************************************
+
+        [BurstCompile]
+        private struct FilterJob : IJob
+        {
+            [ReadOnly] private readonly NativeList<Entity> m_CandidateEntities;
+            private NativeArray<EntityLifecycleFilteredGroup> m_FilteredGroups;
+
+            public FilterJob(
+                NativeList<Entity> candidateEntities,
+                NativeArray<EntityLifecycleFilteredGroup> filteredGroups)
+            {
+                m_CandidateEntities = candidateEntities;
+                m_FilteredGroups = filteredGroups;
+            }
+
+            public void Execute()
+            {
+                //Clear the groups from whatever was written the last frame so we have a blank slate
+                for (int i = 0; i < m_FilteredGroups.Length; ++i)
+                {
+                    m_FilteredGroups[i].FilteredEntities.Clear();
+                }
+
+                //For each candidate, see if it matches any of our filters
+                for (int i = 0; i < m_CandidateEntities.Length; ++i)
+                {
+                    FilterEntity(m_CandidateEntities[i]);
+                }
+            }
+
+            private void FilterEntity(Entity entity)
+            {
+                for (int i = 0; i < m_FilteredGroups.Length; ++i)
+                {
+                    EntityLifecycleFilteredGroup filteredGroup = m_FilteredGroups[i];
+                    if (!filteredGroup.Mask.Matches(entity))
+                    {
+                        continue;
+                    }
+                    filteredGroup.FilteredEntities.Add(entity);
+                }
+            }
+        }
+    }
+}

--- a/Scripts/Runtime/Entities/Lifecycle/AbstractEntityLifecycleSystem.cs.meta
+++ b/Scripts/Runtime/Entities/Lifecycle/AbstractEntityLifecycleSystem.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 11ac4b9fab3a4e269b28c75def061bcd
+timeCreated: 1679926112

--- a/Scripts/Runtime/Entities/Lifecycle/EntityLifecycleFilteredGroup.cs
+++ b/Scripts/Runtime/Entities/Lifecycle/EntityLifecycleFilteredGroup.cs
@@ -1,0 +1,19 @@
+using Unity.Collections;
+using Unity.Collections.LowLevel.Unsafe;
+using Unity.Entities;
+
+namespace Anvil.Unity.DOTS.Entities
+{
+    [BurstCompatible]
+    internal readonly struct EntityLifecycleFilteredGroup
+    {
+        public readonly EntityQueryMask Mask;
+        public readonly UnsafeList<Entity> FilteredEntities;
+
+        public EntityLifecycleFilteredGroup(EntityQueryMask mask, UnsafeList<Entity> filteredEntities)
+        {
+            Mask = mask;
+            FilteredEntities = filteredEntities;
+        }
+    }
+}

--- a/Scripts/Runtime/Entities/Lifecycle/EntityLifecycleFilteredGroup.cs.meta
+++ b/Scripts/Runtime/Entities/Lifecycle/EntityLifecycleFilteredGroup.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 6f6c43190aff4f028dc39bca24f9a3bd
+timeCreated: 1679942041

--- a/Scripts/Runtime/Entities/Lifecycle/EntityLifecycleGroup.cs
+++ b/Scripts/Runtime/Entities/Lifecycle/EntityLifecycleGroup.cs
@@ -1,0 +1,102 @@
+using Anvil.CSharp.Core;
+using Anvil.Unity.DOTS.Jobs;
+using Unity.Collections;
+using Unity.Collections.LowLevel.Unsafe;
+using Unity.Entities;
+using Unity.Jobs;
+
+namespace Anvil.Unity.DOTS.Entities
+{
+    internal class EntityLifecycleGroup : AbstractAnvilBase,
+                                          IReadOnlyEntityLifecycleGroup
+    {
+        private readonly AccessControlledValue<UnsafeList<Entity>> m_CreatedEntities;
+        private readonly AccessControlledValue<UnsafeList<Entity>> m_DestroyedEntities;
+
+        public EntityLifecycleFilteredGroup CreationFilteredGroup { get; }
+        public EntityLifecycleFilteredGroup DestructionFilteredGroup { get; }
+
+        public EntityLifecycleGroup(AbstractAnvilSystemBase owningSystem, params ComponentType[] queryComponents)
+        {
+            EntityQuery entityQuery = owningSystem.GetEntityQuery(queryComponents);
+            EntityQueryMask entityQueryMask = entityQuery.GetEntityQueryMask();
+            
+            UnsafeList<Entity> creationList = new UnsafeList<Entity>(
+                ChunkUtil.MaxElementsPerChunk<Entity>(),
+                Allocator.Persistent);
+            m_CreatedEntities = new AccessControlledValue<UnsafeList<Entity>>(creationList);
+            CreationFilteredGroup = new EntityLifecycleFilteredGroup(entityQueryMask, creationList);
+
+
+            UnsafeList<Entity> destructionList = new UnsafeList<Entity>(
+                ChunkUtil.MaxElementsPerChunk<Entity>(),
+                Allocator.Persistent);
+            m_DestroyedEntities = new AccessControlledValue<UnsafeList<Entity>>(destructionList);
+            DestructionFilteredGroup = new EntityLifecycleFilteredGroup(entityQueryMask, destructionList);
+        }
+
+        protected override void DisposeSelf()
+        {
+            m_CreatedEntities.Dispose();
+            m_DestroyedEntities.Dispose();
+            base.DisposeSelf();
+        }
+        
+        //*************************************************************************************************************
+        // INTERNAL ACQUIRE/RELEASE FOR UPDATE
+        //*************************************************************************************************************
+
+        public JobHandle AcquireCreationForUpdate()
+        {
+            //No need to actually use the returned value since it's been baked into the CreationFilteredGroup
+            return m_CreatedEntities.AcquireAsync(AccessType.ExclusiveWrite, out UnsafeList<Entity> _);
+        }
+
+        public JobHandle AcquireDestructionForUpdate()
+        {
+            //No need to actually use the returned value since it's been baked into the DestructionFilteredGroup
+            return m_DestroyedEntities.AcquireAsync(AccessType.ExclusiveWrite, out UnsafeList<Entity> _);
+        }
+
+        //*************************************************************************************************************
+        // PUBLIC ACQUIRE/RELEASE - IReadOnlyEntityLifecycleGroup
+        //*************************************************************************************************************
+        
+        /// <inheritdoc cref="IReadOnlyEntityLifecycleGroup.AcquireCreationAsync"/>
+        public JobHandle AcquireCreationAsync(out UnsafeList<Entity> createdEntities)
+        {
+            return m_CreatedEntities.AcquireAsync(AccessType.SharedRead, out createdEntities);
+        }
+
+        /// <inheritdoc cref="IReadOnlyEntityLifecycleGroup.ReleaseCreationAsync"/>
+        public void ReleaseCreationAsync(JobHandle dependsOn)
+        {
+            m_CreatedEntities.ReleaseAsync(dependsOn);
+        }
+
+        /// <inheritdoc cref="IReadOnlyEntityLifecycleGroup.AcquireCreation"/>
+        public AccessControlledValue<UnsafeList<Entity>>.AccessHandle AcquireCreation()
+        {
+            return m_CreatedEntities.AcquireWithHandle(AccessType.SharedRead);
+        }
+
+        /// <inheritdoc cref="IReadOnlyEntityLifecycleGroup.AcquireDestructionAsync"/>
+        public JobHandle AcquireDestructionAsync(out UnsafeList<Entity> destroyedEntities)
+        {
+            return m_DestroyedEntities.AcquireAsync(AccessType.SharedRead, out destroyedEntities);
+        }
+
+        /// <inheritdoc cref="IReadOnlyEntityLifecycleGroup.ReleaseDestructionAsync"/>
+        public void ReleaseDestructionAsync(JobHandle dependsOn)
+        {
+            m_DestroyedEntities.ReleaseAsync(dependsOn);
+        }
+
+        /// <inheritdoc cref="IReadOnlyEntityLifecycleGroup.AcquireDestruction"/>
+        public AccessControlledValue<UnsafeList<Entity>>.AccessHandle AcquireDestruction()
+        {
+            return m_DestroyedEntities.AcquireWithHandle(AccessType.SharedRead);
+        }
+        
+    }
+}

--- a/Scripts/Runtime/Entities/Lifecycle/EntityLifecycleGroup.cs.meta
+++ b/Scripts/Runtime/Entities/Lifecycle/EntityLifecycleGroup.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 82490e999e2b4a6eb039fb293b6dd7d9
+timeCreated: 1679938317

--- a/Scripts/Runtime/Entities/Lifecycle/IReadOnlyEntityLifecycleGroup.cs
+++ b/Scripts/Runtime/Entities/Lifecycle/IReadOnlyEntityLifecycleGroup.cs
@@ -1,0 +1,62 @@
+using Anvil.Unity.DOTS.Jobs;
+using Unity.Collections.LowLevel.Unsafe;
+using Unity.Entities;
+using Unity.Jobs;
+
+namespace Anvil.Unity.DOTS.Entities
+{
+    /// <summary>
+    /// Provides access to Entities that were created or destroyed this frame.
+    /// </summary>
+    /// <remarks>
+    /// This applies to both Entities that were created or destroyed explicitly or that have been imported/evicted
+    /// to the world. Ex. Entities that move from World A to World B will count as destruction in World B and
+    /// Creation in World A.
+    /// </remarks>
+    public interface IReadOnlyEntityLifecycleGroup
+    {
+        /// <summary>
+        /// Gets access to the read only list of created entities for this frame for use in a job.
+        /// </summary>
+        /// <param name="createdEntities">The list of entities created or imported this frame.</param>
+        /// <returns>The <see cref="JobHandle"/> dependency to wait on</returns>
+        public JobHandle AcquireCreationAsync(out UnsafeList<Entity> createdEntities);
+        
+        /// <summary>
+        /// Lets the underlying collection know when the jobs that were accessing it will be complete.
+        /// </summary>
+        /// <param name="dependsOn">
+        /// The <see cref="JobHandle"/> that signifies the end of interaction with the
+        /// collection.
+        /// </param>
+        public void ReleaseCreationAsync(JobHandle dependsOn);
+        
+        /// <summary>
+        /// Gets access to the read only list of created or imported entities for this frame for use on the main thread.
+        /// </summary>
+        /// <returns>An AccessHandle to interact with.</returns>
+        public AccessControlledValue<UnsafeList<Entity>>.AccessHandle AcquireCreation();
+        
+        /// <summary>
+        /// Gets access to the read only list of destroyed entities for this frame for use in a job.
+        /// </summary>
+        /// <param name="destroyedEntities">The list of entities destroyed or evicted this frame.</param>
+        /// <returns>The <see cref="JobHandle"/> dependency to wait on</returns>
+        public JobHandle AcquireDestructionAsync(out UnsafeList<Entity> destroyedEntities);
+        
+        /// <summary>
+        /// Lets the underlying collection know when the jobs that were accessing it will be complete.
+        /// </summary>
+        /// <param name="dependsOn">
+        /// The <see cref="JobHandle"/> that signifies the end of interaction with the
+        /// collection.
+        /// </param>
+        public void ReleaseDestructionAsync(JobHandle dependsOn);
+        
+        /// <summary>
+        /// Gets access to the read only list of destroyed or evicted entities for this frame for use on the main thread.
+        /// </summary>
+        /// <returns>An AccessHandle to interact with.</returns>
+        public AccessControlledValue<UnsafeList<Entity>>.AccessHandle AcquireDestruction();
+    }
+}

--- a/Scripts/Runtime/Entities/Lifecycle/IReadOnlyEntityLifecycleGroup.cs.meta
+++ b/Scripts/Runtime/Entities/Lifecycle/IReadOnlyEntityLifecycleGroup.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 1fd7e4f53a8f49a09c9b7653f91b4284
+timeCreated: 1679943627


### PR DESCRIPTION
Providing an easy way to know when Entities have been created/imported or destroyed/evicted.

### What is the current behaviour?

We have to manually construct some queries and do some housekeeping to find new entities that we haven't already seen before or figure out that other entities have been destroyed. 

### What is the new behaviour?

Turns out Unity has a special function called `EntityManager.GetCreatedAndDestroyedEntitiesAsync`

End users can extend the `AbstractEntityLifecycleSystem` to slot it into their app's structural changes flow. From there, they can register different `Masks` of components to create `IReadOnlyEntityLifecycleGroup`s to be able to get Created/Imported and Destroyed/Evicted entities of that type per frame. 

This makes having downstream work like updating lookups or validating state MUCH easier and more efficient. 

### Wait... Reall...

YES! I wasn't sure how it was going to work either, but I tested and `EntityManager.GetCreatedAndDestroyedEntitiesAsync` returns both Created/Imported as well as Destroyed/Evicted. 

If a bunch of entities move from WorldA to WorldB, the we'll get those entities as Destroyed in WorldA and then we'll get them as Created in WorldB. 

This actually is nicer and lets the code have a singular path since pretty much everything is from the World's perspective anyway!

### What issues does this resolve?
- None

### What PRs does this depend on?
 - None

### Does this introduce a breaking change?
 - [ ] Yes
 - [x] No
