### PR TITLE
Allow systems to be ordered against TaskDriverSystems

### DIFF
--- a/Scripts/Runtime/Entities/TaskDriver/System/AbstractTaskDriverSystem.cs
+++ b/Scripts/Runtime/Entities/TaskDriver/System/AbstractTaskDriverSystem.cs
@@ -7,7 +7,8 @@ using Unity.Jobs;
 
 namespace Anvil.Unity.DOTS.Entities.TaskDriver
 {
-    internal abstract partial class AbstractTaskDriverSystem : AbstractAnvilSystemBase, ITaskSetOwner
+    //TODO: #188 - /// Document public API
+    public abstract partial class AbstractTaskDriverSystem : AbstractAnvilSystemBase, ITaskSetOwner
     {
         private static readonly NoOpJobConfig NO_OP_JOB_CONFIG = new NoOpJobConfig();
         private static readonly List<AbstractTaskDriver> EMPTY_SUB_TASK_DRIVERS = new List<AbstractTaskDriver>();
@@ -28,7 +29,14 @@ namespace Anvil.Unity.DOTS.Entities.TaskDriver
         //Normally a system doesn't get a World until OnCreate is called and the System.World will return null.
         //We need a valid World in the constructor so we get one and assign it to this property instead.
         public new World World { get; }
-        public TaskSet TaskSet { get; }
+
+        internal TaskSet TaskSet { get; }
+
+        TaskSet ITaskSetOwner.TaskSet
+        {
+            get => TaskSet;
+        }
+
         public uint ID { get; }
 
         public List<AbstractTaskDriver> SubTaskDrivers
@@ -96,7 +104,7 @@ namespace Anvil.Unity.DOTS.Entities.TaskDriver
             return new EntityProxyDataStream<TInstance>(taskDriver, dataStream);
         }
 
-        public EntityPersistentData<T> GetOrCreateEntityPersistentData<T>()
+        internal EntityPersistentData<T> GetOrCreateEntityPersistentData<T>()
             where T : unmanaged, IEntityPersistentDataInstance
         {
             EntityPersistentData<T> entityPersistentData = TaskSet.GetOrCreateEntityPersistentData<T>();
@@ -188,7 +196,10 @@ namespace Anvil.Unity.DOTS.Entities.TaskDriver
             m_BulkJobScheduler = new BulkJobScheduler<AbstractJobConfig>(jobConfigs.ToArray());
         }
 
-        public void AddResolvableDataStreamsTo(Type type, List<AbstractDataStream> dataStreams)
+        void ITaskSetOwner.AddResolvableDataStreamsTo(Type type, List<AbstractDataStream> dataStreams)
+            => AddResolvableDataStreamsTo(type, dataStreams);
+
+        internal void AddResolvableDataStreamsTo(Type type, List<AbstractDataStream> dataStreams)
         {
             TaskSet.AddResolvableDataStreamsTo(type, dataStreams);
             foreach (AbstractTaskDriver taskDriver in m_TaskDrivers)

--- a/Scripts/Runtime/Entities/TaskDriver/System/TaskDriverSystem.cs
+++ b/Scripts/Runtime/Entities/TaskDriver/System/TaskDriverSystem.cs
@@ -2,7 +2,8 @@ using Unity.Entities;
 
 namespace Anvil.Unity.DOTS.Entities.TaskDriver
 {
-    internal partial class TaskDriverSystem<TTaskDriverType> : AbstractTaskDriverSystem
+    //TODO: #188 - /// Document public API
+    public partial class TaskDriverSystem<TTaskDriverType> : AbstractTaskDriverSystem
         where TTaskDriverType : AbstractTaskDriver
     {
         public TaskDriverSystem(World world) : base(world) { }


### PR DESCRIPTION
Systems and task drivers could not be ordered on other task drivers. This is because `TaskDriverSystem<T>` was marked `internal`. This PR makes `TaskDriverSystem<T>` public.

**Note:** The changes are the bare minimum required to compile again after making the types public. @jkeon feel free to suggest visibility changes of other members that should be changed. If it's a larger effort I can create an issue for it.

### What is the current behaviour?

There is no way to order a system or `TaskDriverSystem` on another `TaskDriverSystem`.

### What is the new behaviour?

`TaskDriverSystem`s may be used to order against. Ex: `UpdateBefore(typeof(TaskDriverSystem<MyTaskDriver>))`

### What issues does this resolve?
 - None

### What PRs does this depend on?
<!-- List PRs in other repos that need to be merged before this one -->
 - None

### Does this introduce a breaking change?
 - [ ] Yes <!-- If so, what are the migration considerations? -->
 - [x] No
