### PR TITLE
AbstractJobConfig - Log and Attempt to resolve duplicate requires

### DIFF
--- a/Scripts/Runtime/Entities/TaskDriver/TaskSet/Job/JobConfig/AbstractJobConfig.cs
+++ b/Scripts/Runtime/Entities/TaskDriver/TaskSet/Job/JobConfig/AbstractJobConfig.cs
@@ -110,11 +110,38 @@ namespace Anvil.Unity.DOTS.Entities.TaskDriver
 
         protected void AddAccessWrapper(AbstractAccessWrapper accessWrapper)
         {
-            Debug_EnsureWrapperValidity(accessWrapper.ID);
             Debug_EnsureWrapperUsage(accessWrapper);
 
-            m_AccessWrappers.Add(accessWrapper.ID, accessWrapper);
+            if (!m_AccessWrappers.TryAdd(accessWrapper.ID, accessWrapper))
+            {
+                Logger.Error($"Trying to require {accessWrapper.ID.AccessWrapperType.GetReadableName()} data for {accessWrapper.ID.Usage} but it is already being used! Only require the data for the same usage once! Attempting to resolve...");
+                ResolveDuplicateAccessWrappers(accessWrapper);
+            }
         }
+
+        private void ResolveDuplicateAccessWrappers(AbstractAccessWrapper accessWrapper)
+        {
+            AbstractAccessWrapper existingAccessWrapper = m_AccessWrappers[accessWrapper.ID];
+
+            // If the existing access wrapper facilitates the needs of the new one then just keep the existing one.
+            if (existingAccessWrapper.AccessType.IsCompatibleWith(accessWrapper.AccessType))
+            {
+                accessWrapper.Dispose();
+            }
+            // If the new access wrapper facilitates the needs of the existing one then dispose the existing wrapper and
+            // use the new access wrapper.
+            else if (accessWrapper.AccessType.IsCompatibleWith(existingAccessWrapper.AccessType))
+            {
+                existingAccessWrapper.Dispose();
+                m_AccessWrappers[accessWrapper.ID] = accessWrapper;
+            }
+            // If there is no compatibility between the two requires error. The developer needs to fix this.
+            else
+            {
+                throw new Exception($"There is no compatibility between ${nameof(AccessType)} requires on the same type. See previous message for details.");
+            }
+        }
+
 
         //*************************************************************************************************************
         // CONFIGURATION - REQUIRED DATA - DATA STREAM
@@ -494,16 +521,6 @@ namespace Anvil.Unity.DOTS.Entities.TaskDriver
             if (!m_AccessWrappers.ContainsKey(id))
             {
                 throw new InvalidOperationException($"Job configured by {this} tried to access {id.AccessWrapperType.GetReadableName()} data for {id.Usage} but it wasn't found. Did you call the right Require function?");
-            }
-        }
-
-        [Conditional("ENABLE_UNITY_COLLECTIONS_CHECKS")]
-        private void Debug_EnsureWrapperValidity(JobConfigDataID id)
-        {
-            //Straight duplicate check
-            if (m_AccessWrappers.ContainsKey(id))
-            {
-                throw new InvalidOperationException($"{this} is trying to require {id.AccessWrapperType.GetReadableName()} data for {id.Usage} but it is already being used! Only require the data for the same usage once!");
             }
         }
 

--- a/Scripts/Runtime/Entities/TaskDriver/TaskSet/Job/Wrapper/AbstractAccessWrapper.cs
+++ b/Scripts/Runtime/Entities/TaskDriver/TaskSet/Job/Wrapper/AbstractAccessWrapper.cs
@@ -10,7 +10,7 @@ namespace Anvil.Unity.DOTS.Entities.TaskDriver
     {
         public JobConfigDataID ID { get; }
 
-        protected AccessType AccessType { get; }
+        internal AccessType AccessType { get; }
 
 
         protected AbstractAccessWrapper(AccessType accessType, AbstractJobConfig.Usage usage)

--- a/Scripts/Runtime/Job/AccessControl/AccessType.cs
+++ b/Scripts/Runtime/Job/AccessControl/AccessType.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace Anvil.Unity.DOTS.Jobs
 {
     /// <summary>
@@ -9,5 +11,38 @@ namespace Anvil.Unity.DOTS.Jobs
         SharedWrite,
         SharedRead,
         Disposal
+    }
+
+    /// <summary>
+    /// A collection of extensions for <see cref="AccessType"/>.
+    /// </summary>
+    public static class AccessTypeExtension
+    {
+        /// <summary>
+        /// Identifies whether the <see cref="AccessType"/> accommodates the operations of the supplied
+        /// <see cref="targetType"/>.
+        /// </summary>
+        /// <param name="type">The type to check for support of the other type's operations.</param>
+        /// <param name="targetType">The type to check for support of.</param>
+        /// <returns>True if <see cref="type"/> supports the operations required by <see cref="targetType"/>.</returns>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// Thrown if the access type is not yet supported by this method.
+        /// </exception>
+        /// <example>
+        /// An <see cref="AccessType"/> of <see cref="AccessType.SharedWrite"/> supports all of the operations needed
+        /// for <see cref="AccessType.SharedRead"/> access.
+        /// </example>
+        public static bool IsCompatibleWith(this AccessType type, AccessType targetType)
+        {
+            return type == targetType
+                || type switch
+                {
+                    AccessType.ExclusiveWrite => targetType is AccessType.SharedWrite or AccessType.SharedRead,
+                    AccessType.SharedWrite => targetType is AccessType.SharedRead,
+                    AccessType.SharedRead => false,
+                    AccessType.Disposal => false,
+                    _ => throw new ArgumentOutOfRangeException(nameof(type), type, null)
+                };
+        }
     }
 }


### PR DESCRIPTION
Implement a less disruptive outcome if multiple requires of the same type are set on a job config.

This improves the developer experience by allowing developers to continue their test and fix the configuration error later.

### What is the current behaviour?

The job config will throw an exception any time a duplicate require is identified.

### What is the new behaviour?

In situations where duplicate requires occur the config now logs an error describing the issue but then attempts to accommodate the request and continue execution. 
 - If the new require is the same as the existing require the new wrapper is disposed. We only need one.
 - If the requires are of different `AccessTypes` but one `AccessType` is a superset of the other `AccessType` then the wrapper for the superset access is kept and the other is destroyed. (Ex: Require `SharedRead` and `SharedWrite`. `SharedWrite` is kept and `SharedRead` disposed.)

### What issues does this resolve?
 - None?
    - @jkeon not sure if there is an existing issue created for improve this.

### What PRs does this depend on?
<!-- List PRs in other repos that need to be merged before this one -->
 - None

### Does this introduce a breaking change?
 - [ ] Yes <!-- If so, what are the migration considerations? -->
 - [x] No
