### PR TITLE
Add DynamicBuffer.ElementAtReadOnly extension method

### DIFF
--- a/Scripts/Runtime/Entities/Util/DynamicBufferExtension.cs
+++ b/Scripts/Runtime/Entities/Util/DynamicBufferExtension.cs
@@ -1,0 +1,25 @@
+using Unity.Collections.LowLevel.Unsafe;
+using Unity.Entities;
+using Debug = UnityEngine.Debug;
+
+namespace Anvil.Unity.DOTS.Entities
+{
+    /// <summary>
+    /// A collection of extension methods for <see cref="DynamicBuffer{T}"/>
+    /// </summary>
+    public static class DynamicBufferExtension
+    {
+        /// <summary>
+        /// Return a read only reference to the element at index.
+        /// </summary>
+        /// <param name="buffer">The buffer to get the reference from.</param>
+        /// <param name="index">The zero-based index.</param>
+        /// <typeparam name="T">The data type stored in the buffer. Must be a value type.</typeparam>
+        /// <returns>A readonly reference to the element.</returns>
+        public static unsafe ref readonly T ElementAtReadOnly<T>(this DynamicBuffer<T> buffer, int index) where T : struct
+        {
+            Debug.Assert(index >= 0 && index < buffer.Length);
+            return ref UnsafeUtility.ArrayElementAsRef<T>(buffer.GetUnsafeReadOnlyPtr(), index);
+        }
+    }
+}

--- a/Scripts/Runtime/Entities/Util/DynamicBufferExtension.cs.meta
+++ b/Scripts/Runtime/Entities/Util/DynamicBufferExtension.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0d60db6990d914439b22909ce2127395
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Add an extension method to get an element from `DynamicBuffer<T>` by readonly reference.

### What is the current behaviour?

You can only get a read/write reference via `DynamicBuffer<T>`'s baked in `ElementAt` method.

### What is the new behaviour?

Developers can call `myBuffer.ElementAtReadOnly(index)` to get a `ref readonly` reference to the element without the write access safety check.

### What issues does this resolve?
- None

### What PRs does this depend on?
<!-- List PRs in other repos that need to be merged before this one -->
 - None

### Does this introduce a breaking change?
 - [ ] Yes <!-- If so, what are the migration considerations? -->
 - [x] No
