### PR TITLE
ComponentSystemBaseExtension - Cleanup

### DIFF
--- a/Scripts/Runtime/Entities/Util/ComponentSystemBaseExtension.cs
+++ b/Scripts/Runtime/Entities/Util/ComponentSystemBaseExtension.cs
@@ -137,7 +137,13 @@ namespace Anvil.Unity.DOTS.Entities
             return job.Schedule(dependsOn);
         }
 
-        public static bool TryFindParentGroup(this ComponentSystemGroup system, out ComponentSystemGroup group)
+        /// <summary>
+        /// Attempts to find the parent <see cref="ComponentSystemGroup"/> of a <see cref="ComponentSystem"/>
+        /// </summary>
+        /// <param name="system">The system to find the parent of.</param>
+        /// <param name="group">The parent of the system</param>
+        /// <returns>True if a parent was found for the given system.</returns>
+        public static bool TryFindParentGroup(this ComponentSystem system, out ComponentSystemGroup group)
         {
             var worldSystems = system.World.Systems;
             foreach (ComponentSystemBase worldSystem in worldSystems)


### PR DESCRIPTION
`ComponentSystemBaseExtension.TryFindParentGroup`
- Add `///` docs
- Expose method to all systems not just groups. This was the intended purpose but was accidentally constrained to just groups.

### What is the current behaviour?

`ComponentSystemBaseExtension.TryFindParentGroup`
- There are no docs
- Only groups can find their parent group

### What is the new behaviour?

- There are docs
- Any `ComponentSystemBase` can try to find its parent group.

### What issues does this resolve?
- None

### What PRs does this depend on?
<!-- List PRs in other repos that need to be merged before this one -->
 - None

### Does this introduce a breaking change?
 - [ ] Yes <!-- If so, what are the migration considerations? -->
 - [x] No
