### PR TITLE
Add IEntitySpawnDefinitionExtension.CreateAndPopulate()

### DIFF
--- a/Scripts/Runtime/Entities/Lifecycle/IEntitySpawnDefinitionExtension.cs
+++ b/Scripts/Runtime/Entities/Lifecycle/IEntitySpawnDefinitionExtension.cs
@@ -1,0 +1,30 @@
+using Unity.Entities;
+
+namespace Anvil.Unity.DOTS.Entities
+{
+    /// <summary>
+    /// A collection of extension methods for <see cref="IEntitySpawnDefinition"/> instances.
+    /// </summary>
+    public static class IEntitySpawnDefinitionExtension
+    {
+        /// <summary>
+        /// Create and populate an entity based on a <see cref="IEntitySpawnDefinition"/>.
+        /// Generally <see cref="EntitySpawnSystem" />'s spawn methods should be preferred. They are more performant.
+        /// This method is useful when the archetype or spawn system isn't available and you immediately need the entity
+        /// configured on an <see cref="EntityCommandBuffer"/>. ("Ex: Proxy Entities)
+        /// TODO: #192 - Replace when there is a way to have definitions spawn proxy entities as part of their populate.
+        /// </summary>
+        /// <param name="definition">The definition to create and populate an instance from.</param>
+        /// <param name="ecb">The <see cref="EntityCommandBuffer"/> to write to.</param>
+        /// <typeparam name="T">The type of the definition that implements <see cref="IEntitySpawnDefinition"/>.</typeparam>
+        /// <returns>The created entity reference.</returns>
+        public static Entity CreateAndPopulate<T>(ref this T definition, ref EntityCommandBuffer ecb) where T : struct, IEntitySpawnDefinition
+        {
+            Entity entity = ecb.CreateEntity();
+            ecb.AddComponent(entity, new ComponentTypes(definition.RequiredComponents));
+            definition.PopulateOnEntity(entity, ref ecb);
+
+            return entity;
+        }
+    }
+}

--- a/Scripts/Runtime/Entities/Lifecycle/IEntitySpawnDefinitionExtension.cs.meta
+++ b/Scripts/Runtime/Entities/Lifecycle/IEntitySpawnDefinitionExtension.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: c306255ce0344e51951df1372fe21007
+timeCreated: 1680205675


### PR DESCRIPTION
Add a mechanism to create and populate an `IEntitySpawnDefinitionExtension` on an `EntityCommandBuffer` when the `Archetype` from `EntitySpawnSystem` is not available.

This is a temporary workaround until #192 is resolved.

### What is the current behaviour?

If an `IEntitySpawnDefinitionExtension` needs to spawn multiple entities as part of its creation there is no simple way to leverage other `IEntitySpawnDefinitionExtension` instances to help with the creation.

### What is the new behaviour?

`IEntitySpawnDefinitionExtension` can now have `CreateAndPopulate<T>()` called on them to create and populate an entity from the definition and return the entity created so the parent definition may store a reference to the entity.

### What issues does this resolve?
 - None

### What PRs does this depend on?
<!-- List PRs in other repos that need to be merged before this one -->
 - None

### Does this introduce a breaking change?
 - [ ] Yes <!-- If so, what are the migration considerations? -->
 - [x] No
