### PR TITLE
Add Readonly EntityPersistentData Interface

### DIFF
--- a/Scripts/Runtime/Entities/PersistentData/Data/Interface/IEntityPersistentData.cs
+++ b/Scripts/Runtime/Entities/PersistentData/Data/Interface/IEntityPersistentData.cs
@@ -6,79 +6,13 @@ namespace Anvil.Unity.DOTS.Entities
 {
     /// <summary>
     /// An <see cref="IAbstractPersistentData"/> typed to a specific <see cref="IEntityPersistentDataInstance"/>
-    /// The data is associated with an <see cref="Entity"/>
-    /// </summary>
-    /// <typeparam name="T">The type of <see cref="IEntityPersistentDataInstance"/></typeparam>
-    public interface IReadOnlyEntityPersistentData<T> : IAbstractPersistentData
-        where T : struct, IEntityPersistentDataInstance
-    {
-        /// <summary>
-        /// Gets a <see cref="EntityPersistentDataReader{TInstance}"/> for use in a job outside the Task Driver context.
-        /// Requires a call to <see cref="ReleaseReaderAsync"/> after scheduling the job.
-        /// </summary>
-        /// <param name="reader">The <see cref="EntityPersistentDataReader{TInstance}"/></param>
-        /// <returns>A <see cref="JobHandle"/> to wait on</returns>
-        public JobHandle AcquireReaderAsync(out EntityPersistentDataReader<T> reader);
-
-        /// <summary>
-        /// Allows other jobs to use the underlying data for the <see cref="EntityPersistentDataReader{TInstance}"/>
-        /// and ensures data integrity across those other usages.
-        /// </summary>
-        /// <param name="dependsOn">The <see cref="JobHandle"/> that used this data.</param>
-        public void ReleaseReaderAsync(JobHandle dependsOn);
-
-        /// <summary>
-        /// Gets a <see cref="EntityPersistentDataReader{TInstance}"/> for use on the main thread outside the Task Driver
-        /// context.
-        /// Requires a call to <see cref="ReleaseReader"/> when done.
-        /// </summary>
-        /// <returns>The <see cref="EntityPersistentDataReader{TInstance}"/></returns>
-        public EntityPersistentDataReader<T> AcquireReader();
-
-        /// <summary>
-        /// Allows other jobs or code to use to underlying data for the <see cref="EntityPersistentDataReader{TInstance}"/>
-        /// and ensures data integrity across those other usages.
-        /// </summary>
-        public void ReleaseReader();
-    }
-
-    /// <summary>
-    /// An <see cref="IAbstractPersistentData"/> typed to a specific <see cref="IEntityPersistentDataInstance"/>
-    /// The data is associated with an <see cref="Entity"/>
+    /// that exposes read-write access.
+    /// The data is associated with an <see cref="Entity"/>.
     /// </summary>
     /// <typeparam name="T">The type of <see cref="IEntityPersistentDataInstance"/></typeparam>
     public interface IEntityPersistentData<T> : IAbstractPersistentData, IReadOnlyEntityPersistentData<T>
         where T : struct, IEntityPersistentDataInstance
     {
-        /// <summary>
-        /// Gets a <see cref="EntityPersistentDataReader{TInstance}"/> for use in a job outside the Task Driver context.
-        /// Requires a call to <see cref="ReleaseReaderAsync"/> after scheduling the job.
-        /// </summary>
-        /// <param name="reader">The <see cref="EntityPersistentDataReader{TInstance}"/></param>
-        /// <returns>A <see cref="JobHandle"/> to wait on</returns>
-        public JobHandle AcquireReaderAsync(out EntityPersistentDataReader<T> reader);
-
-        /// <summary>
-        /// Allows other jobs to use the underlying data for the <see cref="EntityPersistentDataReader{TInstance}"/>
-        /// and ensures data integrity across those other usages.
-        /// </summary>
-        /// <param name="dependsOn">The <see cref="JobHandle"/> that used this data.</param>
-        public void ReleaseReaderAsync(JobHandle dependsOn);
-
-        /// <summary>
-        /// Gets a <see cref="EntityPersistentDataReader{TInstance}"/> for use on the main thread outside the Task Driver
-        /// context.
-        /// Requires a call to <see cref="ReleaseReader"/> when done.
-        /// </summary>
-        /// <returns>The <see cref="EntityPersistentDataReader{TInstance}"/></returns>
-        public EntityPersistentDataReader<T> AcquireReader();
-
-        /// <summary>
-        /// Allows other jobs or code to use to underlying data for the <see cref="EntityPersistentDataReader{TInstance}"/>
-        /// and ensures data integrity across those other usages.
-        /// </summary>
-        public void ReleaseReader();
-
         /// <summary>
         /// Gets a <see cref="EntityPersistentDataWriter{TInstance}"/> for use in a job outside the Task Driver context.
         /// Requires a call to <see cref="ReleaseWriterAsync"/> after scheduling the job.

--- a/Scripts/Runtime/Entities/PersistentData/Data/Interface/IEntityPersistentData.cs
+++ b/Scripts/Runtime/Entities/PersistentData/Data/Interface/IEntityPersistentData.cs
@@ -9,7 +9,7 @@ namespace Anvil.Unity.DOTS.Entities
     /// The data is associated with an <see cref="Entity"/>
     /// </summary>
     /// <typeparam name="T">The type of <see cref="IEntityPersistentDataInstance"/></typeparam>
-    public interface IEntityPersistentData<T> : IAbstractPersistentData
+    public interface IReadOnlyEntityPersistentData<T> : IAbstractPersistentData
         where T : struct, IEntityPersistentDataInstance
     {
         /// <summary>
@@ -19,7 +19,7 @@ namespace Anvil.Unity.DOTS.Entities
         /// <param name="reader">The <see cref="EntityPersistentDataReader{TInstance}"/></param>
         /// <returns>A <see cref="JobHandle"/> to wait on</returns>
         public JobHandle AcquireReaderAsync(out EntityPersistentDataReader<T> reader);
-        
+
         /// <summary>
         /// Allows other jobs to use the underlying data for the <see cref="EntityPersistentDataReader{TInstance}"/>
         /// and ensures data integrity across those other usages.
@@ -34,7 +34,45 @@ namespace Anvil.Unity.DOTS.Entities
         /// </summary>
         /// <returns>The <see cref="EntityPersistentDataReader{TInstance}"/></returns>
         public EntityPersistentDataReader<T> AcquireReader();
-        
+
+        /// <summary>
+        /// Allows other jobs or code to use to underlying data for the <see cref="EntityPersistentDataReader{TInstance}"/>
+        /// and ensures data integrity across those other usages.
+        /// </summary>
+        public void ReleaseReader();
+    }
+
+    /// <summary>
+    /// An <see cref="IAbstractPersistentData"/> typed to a specific <see cref="IEntityPersistentDataInstance"/>
+    /// The data is associated with an <see cref="Entity"/>
+    /// </summary>
+    /// <typeparam name="T">The type of <see cref="IEntityPersistentDataInstance"/></typeparam>
+    public interface IEntityPersistentData<T> : IAbstractPersistentData, IReadOnlyEntityPersistentData<T>
+        where T : struct, IEntityPersistentDataInstance
+    {
+        /// <summary>
+        /// Gets a <see cref="EntityPersistentDataReader{TInstance}"/> for use in a job outside the Task Driver context.
+        /// Requires a call to <see cref="ReleaseReaderAsync"/> after scheduling the job.
+        /// </summary>
+        /// <param name="reader">The <see cref="EntityPersistentDataReader{TInstance}"/></param>
+        /// <returns>A <see cref="JobHandle"/> to wait on</returns>
+        public JobHandle AcquireReaderAsync(out EntityPersistentDataReader<T> reader);
+
+        /// <summary>
+        /// Allows other jobs to use the underlying data for the <see cref="EntityPersistentDataReader{TInstance}"/>
+        /// and ensures data integrity across those other usages.
+        /// </summary>
+        /// <param name="dependsOn">The <see cref="JobHandle"/> that used this data.</param>
+        public void ReleaseReaderAsync(JobHandle dependsOn);
+
+        /// <summary>
+        /// Gets a <see cref="EntityPersistentDataReader{TInstance}"/> for use on the main thread outside the Task Driver
+        /// context.
+        /// Requires a call to <see cref="ReleaseReader"/> when done.
+        /// </summary>
+        /// <returns>The <see cref="EntityPersistentDataReader{TInstance}"/></returns>
+        public EntityPersistentDataReader<T> AcquireReader();
+
         /// <summary>
         /// Allows other jobs or code to use to underlying data for the <see cref="EntityPersistentDataReader{TInstance}"/>
         /// and ensures data integrity across those other usages.
@@ -48,7 +86,7 @@ namespace Anvil.Unity.DOTS.Entities
         /// <param name="writer">The <see cref="EntityPersistentDataWriter{TInstance}"/></param>
         /// <returns>The <see cref="JobHandle"/> to wait on</returns>
         public JobHandle AcquireWriterAsync(out EntityPersistentDataWriter<T> writer);
-        
+
         /// <summary>
         /// Allows other jobs to use the underlying data for the <see cref="EntityPersistentDataWriter{TInstance}"/>
         /// and ensures data integrity across those other usages.
@@ -63,7 +101,7 @@ namespace Anvil.Unity.DOTS.Entities
         /// </summary>
         /// <returns>The <see cref="EntityPersistentDataWriter{TInstance}"/></returns>
         public EntityPersistentDataWriter<T> AcquireWriter();
-        
+
         /// <summary>
         /// Allows other jobs or code to use to underlying data for the <see cref="EntityPersistentDataWriter{TInstance}"/>
         /// and ensures data integrity across those other usages.

--- a/Scripts/Runtime/Entities/PersistentData/Data/Interface/IReadOnlyEntityPersistentData.cs
+++ b/Scripts/Runtime/Entities/PersistentData/Data/Interface/IReadOnlyEntityPersistentData.cs
@@ -1,0 +1,45 @@
+using Anvil.Unity.DOTS.Entities.TaskDriver;
+using Unity.Entities;
+using Unity.Jobs;
+
+namespace Anvil.Unity.DOTS.Entities
+{
+    /// <summary>
+    /// An <see cref="IAbstractPersistentData"/> typed to a specific <see cref="IEntityPersistentDataInstance"/>
+    /// that exposes read-only access.
+    /// The data is associated with an <see cref="Entity"/>.
+    /// </summary>
+    /// <typeparam name="T">The type of <see cref="IEntityPersistentDataInstance"/></typeparam>
+    public interface IReadOnlyEntityPersistentData<T> : IAbstractPersistentData
+        where T : struct, IEntityPersistentDataInstance
+    {
+        /// <summary>
+        /// Gets a <see cref="EntityPersistentDataReader{TInstance}"/> for use in a job outside the Task Driver context.
+        /// Requires a call to <see cref="ReleaseReaderAsync"/> after scheduling the job.
+        /// </summary>
+        /// <param name="reader">The <see cref="EntityPersistentDataReader{TInstance}"/></param>
+        /// <returns>A <see cref="JobHandle"/> to wait on</returns>
+        public JobHandle AcquireReaderAsync(out EntityPersistentDataReader<T> reader);
+
+        /// <summary>
+        /// Allows other jobs to use the underlying data for the <see cref="EntityPersistentDataReader{TInstance}"/>
+        /// and ensures data integrity across those other usages.
+        /// </summary>
+        /// <param name="dependsOn">The <see cref="JobHandle"/> that used this data.</param>
+        public void ReleaseReaderAsync(JobHandle dependsOn);
+
+        /// <summary>
+        /// Gets a <see cref="EntityPersistentDataReader{TInstance}"/> for use on the main thread outside the Task Driver
+        /// context.
+        /// Requires a call to <see cref="ReleaseReader"/> when done.
+        /// </summary>
+        /// <returns>The <see cref="EntityPersistentDataReader{TInstance}"/></returns>
+        public EntityPersistentDataReader<T> AcquireReader();
+
+        /// <summary>
+        /// Allows other jobs or code to use to underlying data for the <see cref="EntityPersistentDataReader{TInstance}"/>
+        /// and ensures data integrity across those other usages.
+        /// </summary>
+        public void ReleaseReader();
+    }
+}

--- a/Scripts/Runtime/Entities/PersistentData/Data/Interface/IReadOnlyEntityPersistentData.cs.meta
+++ b/Scripts/Runtime/Entities/PersistentData/Data/Interface/IReadOnlyEntityPersistentData.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 3f070b847f1444098058efe0666e2f80
+timeCreated: 1681347335

--- a/Scripts/Runtime/Entities/TaskDriver/TaskSet/Job/JobConfig/AbstractJobConfig.cs
+++ b/Scripts/Runtime/Entities/TaskDriver/TaskSet/Job/JobConfig/AbstractJobConfig.cs
@@ -255,7 +255,7 @@ namespace Anvil.Unity.DOTS.Entities.TaskDriver
             return this;
         }
 
-        public IJobConfig RequireEntityPersistentDataForRead<TData>(IEntityPersistentData<TData> entityPersistentData)
+        public IJobConfig RequireEntityPersistentDataForRead<TData>(IReadOnlyEntityPersistentData<TData> entityPersistentData)
             where TData : unmanaged, IEntityPersistentDataInstance
         {
             EntityPersistentData<TData> data = (EntityPersistentData<TData>)entityPersistentData;

--- a/Scripts/Runtime/Entities/TaskDriver/TaskSet/Job/JobConfig/Interface/IJobConfig.cs
+++ b/Scripts/Runtime/Entities/TaskDriver/TaskSet/Job/JobConfig/Interface/IJobConfig.cs
@@ -84,7 +84,7 @@ namespace Anvil.Unity.DOTS.Entities.TaskDriver
         public IJobConfig RequireEntityPersistentDataForWrite<TData>(IEntityPersistentData<TData> entityPersistentData)
             where TData : unmanaged, IEntityPersistentDataInstance;
 
-        public IJobConfig RequireEntityPersistentDataForRead<TData>(IEntityPersistentData<TData> entityPersistentData)
+        public IJobConfig RequireEntityPersistentDataForRead<TData>(IReadOnlyEntityPersistentData<TData> entityPersistentData)
             where TData : unmanaged, IEntityPersistentDataInstance;
 
         /// <summary>

--- a/Scripts/Runtime/Entities/TaskDriver/TaskSet/Job/JobConfig/NoOpJobConfig.cs
+++ b/Scripts/Runtime/Entities/TaskDriver/TaskSet/Job/JobConfig/NoOpJobConfig.cs
@@ -110,7 +110,7 @@ namespace Anvil.Unity.DOTS.Entities.TaskDriver
             return this;
         }
 
-        public IJobConfig RequireEntityPersistentDataForRead<TData>(IEntityPersistentData<TData> entityPersistentData)
+        public IJobConfig RequireEntityPersistentDataForRead<TData>(IReadOnlyEntityPersistentData<TData> entityPersistentData)
             where TData : unmanaged, IEntityPersistentDataInstance
         {
             return this;


### PR DESCRIPTION
Add an `IReadOnlyEntityPersistentData` interface.

### What is the current behaviour?

Developers must always expose a read/write EPD to outside consumers.

### What is the new behaviour?

Developers are able to constrain the EPD they expose to outside consumers to read-only.

### What issues does this resolve?
 - None

### What PRs does this depend on?
 - None

### Does this introduce a breaking change?
 - [ ] Yes <!-- If so, what are the migration considerations? -->
 - [x] No
