### PR TITLE
EntityPersistentDataReader/Writer - Add helper methods

### DIFF
--- a/Scripts/Runtime/Entities/TaskDriver/TaskSet/TaskData/JobDataInteraction/EntityPersistentDataReader.cs
+++ b/Scripts/Runtime/Entities/TaskDriver/TaskSet/TaskData/JobDataInteraction/EntityPersistentDataReader.cs
@@ -1,3 +1,5 @@
+using System.Collections;
+using System.Collections.Generic;
 using Unity.Collections;
 using Unity.Collections.LowLevel.Unsafe;
 using Unity.Entities;
@@ -10,7 +12,7 @@ namespace Anvil.Unity.DOTS.Entities.TaskDriver
     /// </summary>
     /// <typeparam name="TData">They type of <see cref="IEntityPersistentDataInstance"/> to read</typeparam>
     [BurstCompatible]
-    public readonly struct EntityPersistentDataReader<TData> 
+    public readonly struct EntityPersistentDataReader<TData>
         where TData : struct, IEntityPersistentDataInstance
     {
         [ReadOnly] private readonly UnsafeParallelHashMap<Entity, TData> m_Lookup;
@@ -19,7 +21,7 @@ namespace Anvil.Unity.DOTS.Entities.TaskDriver
         {
             m_Lookup = lookup;
         }
-        
+
         /// <summary>
         /// Gets the <typeparamref name="TData"/> for the specified <see cref="Entity"/>.
         /// </summary>
@@ -27,6 +29,24 @@ namespace Anvil.Unity.DOTS.Entities.TaskDriver
         public TData this[Entity entity]
         {
             get => m_Lookup[entity];
+        }
+
+        /// <inheritdoc cref="UnsafeParallelHashMap{TKey,TValue}.GetKeyArray"/>>
+        public NativeArray<Entity> GetKeyArray(AllocatorManager.AllocatorHandle allocator)
+        {
+            return m_Lookup.GetKeyArray(allocator);
+        }
+
+        /// <inheritdoc cref="UnsafeParallelHashMap{TKey,TValue}.GetValueArray"/>>
+        public NativeArray<TData> GetValueArray(AllocatorManager.AllocatorHandle allocator)
+        {
+            return m_Lookup.GetValueArray(allocator);
+        }
+
+        /// <inheritdoc cref="UnsafeParallelHashMap{TKey,TValue}.GetEnumerator"/>>
+        public UnsafeParallelHashMap<Entity, TData>.Enumerator GetEnumerator()
+        {
+            return m_Lookup.GetEnumerator();
         }
     }
 }

--- a/Scripts/Runtime/Entities/TaskDriver/TaskSet/TaskData/JobDataInteraction/EntityPersistentDataWriter.cs
+++ b/Scripts/Runtime/Entities/TaskDriver/TaskSet/TaskData/JobDataInteraction/EntityPersistentDataWriter.cs
@@ -1,3 +1,4 @@
+using Anvil.Unity.DOTS.Data;
 using Unity.Collections;
 using Unity.Collections.LowLevel.Unsafe;
 using Unity.Entities;
@@ -32,6 +33,22 @@ namespace Anvil.Unity.DOTS.Entities.TaskDriver
             m_Lookup = lookup;
         }
 
+        /// <summary>
+        /// Removes a key-value pair and disposes the value.
+        /// </summary>
+        /// <param name="entity">The key to remove at.</param>
+        /// <returns>True if a key-value pair was removed.</returns>
+        public bool RemoveAndDispose(Entity entity)
+        {
+            if (m_Lookup.Remove(entity, out TData data))
+            {
+                data.Dispose();
+                return true;
+            }
+
+            return false;
+        }
+
         /// <inheritdoc cref="UnsafeParallelHashMap{TKey,TValue}.Remove"/>
         public bool Remove(Entity entity) => m_Lookup.Remove(entity);
 
@@ -40,5 +57,23 @@ namespace Anvil.Unity.DOTS.Entities.TaskDriver
 
         /// <inheritdoc cref="UnsafeParallelHashMap{TKey,TValue}.ContainsKey"/>
         public bool Contains(Entity entity) => m_Lookup.ContainsKey(entity);
+
+        /// <inheritdoc cref="UnsafeParallelHashMap{TKey,TValue}.GetKeyArray"/>>
+        public NativeArray<Entity> GetKeyArray(AllocatorManager.AllocatorHandle allocator)
+        {
+            return m_Lookup.GetKeyArray(allocator);
+        }
+
+        /// <inheritdoc cref="UnsafeParallelHashMap{TKey,TValue}.GetValueArray"/>>
+        public NativeArray<TData> GetValueArray(AllocatorManager.AllocatorHandle allocator)
+        {
+            return m_Lookup.GetValueArray(allocator);
+        }
+
+        /// <inheritdoc cref="UnsafeParallelHashMap{TKey,TValue}.GetEnumerator"/>>
+        public UnsafeParallelHashMap<Entity, TData>.Enumerator GetEnumerator()
+        {
+            return m_Lookup.GetEnumerator();
+        }
     }
 }


### PR DESCRIPTION
Add helper methods to `EntityPersistentDataReader` and `EntityPersistentDataWriter`
 - `GetKeyArray`
 - `GetValueArray`
 - `GetEnumerator`
 - `RemoveAndDispose` (Writer only)

### What is the current behaviour?

Consumers of EPD readers/writers are not able to iterate over all of the persistent data. This is an unusual usage bust still required in some situations.

Data in an EPD implements `IDisposable` but it's easy for the developer to forget to dispose the elements when removing them.

### What is the new behaviour?

The pass through methods to the backing collection are now exposed.
 - `GetKeyArray`
 - `GetValueArray`
 - `GetEnumerator`

Add `RemoveAndDispose` to the writer to help make it easier to correctly remove EPD elements. I'm open to making this the default behaviour of `Remove` and instead having a `RemoveWithoutDispose` as a special case method that can be called. Thoughts?

### What issues does this resolve?
 - None

### What PRs does this depend on?
 - None

### Does this introduce a breaking change?
 - [ ] Yes <!-- If so, what are the migration considerations? -->
 - [x] No
