### PR TITLE
IJobConfig Requirement Delegation

### DIFF
--- a/Scripts/Runtime/Entities/TaskDriver/TaskSet/Job/JobConfig/AbstractJobConfig.cs
+++ b/Scripts/Runtime/Entities/TaskDriver/TaskSet/Job/JobConfig/AbstractJobConfig.cs
@@ -264,6 +264,12 @@ namespace Anvil.Unity.DOTS.Entities.TaskDriver
             return this;
         }
 
+        public IJobConfig AddRequirementsFrom<T>(T taskDriver, Func<T, IJobConfig, IJobConfig> configureRequirements)
+            where T : AbstractTaskDriver
+        {
+            return configureRequirements(taskDriver, this);
+        }
+
         //*************************************************************************************************************
         // HARDEN
         //*************************************************************************************************************

--- a/Scripts/Runtime/Entities/TaskDriver/TaskSet/Job/JobConfig/AbstractJobConfig.cs
+++ b/Scripts/Runtime/Entities/TaskDriver/TaskSet/Job/JobConfig/AbstractJobConfig.cs
@@ -264,7 +264,7 @@ namespace Anvil.Unity.DOTS.Entities.TaskDriver
             return this;
         }
 
-        public IJobConfig AddRequirementsFrom<T>(T taskDriver, Func<T, IJobConfig, IJobConfig> configureRequirements)
+        public IJobConfig AddRequirementsFrom<T>(T taskDriver, IJobConfig.ConfigureJobRequirementsDelegate<T> configureRequirements)
             where T : AbstractTaskDriver
         {
             return configureRequirements(taskDriver, this);

--- a/Scripts/Runtime/Entities/TaskDriver/TaskSet/Job/JobConfig/Interface/IJobConfig.cs
+++ b/Scripts/Runtime/Entities/TaskDriver/TaskSet/Job/JobConfig/Interface/IJobConfig.cs
@@ -175,6 +175,15 @@ namespace Anvil.Unity.DOTS.Entities.TaskDriver
         public IJobConfig RequireDBFEForExclusiveWrite<T>()
             where T : struct, IBufferElementData;
 
+        /// <summary>
+        /// Specifies a delegate to call to add additional requirements.
+        /// This allows requirements to be defined by a static method on the job rather than at the configuration call
+        /// site.
+        /// </summary>
+        /// <param name="taskDriver">The task driver instance that the job is being configured on. (usually this)</param>
+        /// <param name="configureRequirements">The delegate to call to configure requirements.</param>
+        /// <typeparam name="T">The type of the task driver instance.</typeparam>
+        /// <returns>A reference to itself to continue chaining configuration methods</returns>
         IJobConfig AddRequirementsFrom<T>(T taskDriver, Func<T, IJobConfig, IJobConfig> configureRequirements)
             where T : AbstractTaskDriver;
     }

--- a/Scripts/Runtime/Entities/TaskDriver/TaskSet/Job/JobConfig/Interface/IJobConfig.cs
+++ b/Scripts/Runtime/Entities/TaskDriver/TaskSet/Job/JobConfig/Interface/IJobConfig.cs
@@ -1,5 +1,4 @@
 using Anvil.Unity.DOTS.Jobs;
-using System;
 using Unity.Collections;
 using Unity.Entities;
 
@@ -10,6 +9,23 @@ namespace Anvil.Unity.DOTS.Entities.TaskDriver
     /// </summary>
     public interface IJobConfig
     {
+        /// <summary>
+        /// A delegate that configures the requirements for a job on the provided <see cref="IJobConfig"/>.
+        /// The same <see cref="IJobConfig"/> instance should be returned by the method to allow for chaining of
+        /// additional requirements.
+        /// </summary>
+        /// <param name="taskDriver">
+        /// The task driver instance that is configuring the job. This may be used to gain access to streams or other
+        /// task driver specific references.
+        /// </param>
+        /// <param name="jobConfig">The job config instance to set requirements on.</param>
+        /// <typeparam name="T">The concrete type of the <see cref="AbstractTaskDriver"/></typeparam>
+        /// <returns>
+        /// A reference to the <see cref="IJobConfig"/> instance passed in to continue chaining configuration methods.
+        /// </returns>
+        public delegate IJobConfig ConfigureJobRequirementsDelegate<in T>(T taskDriver, IJobConfig jobConfig)
+            where T : AbstractTaskDriver;
+
         /// <summary>
         /// Whether the Job is enabled or not.
         /// A job that is not enabled will not be scheduled or run but will still exist as part of the
@@ -184,7 +200,7 @@ namespace Anvil.Unity.DOTS.Entities.TaskDriver
         /// <param name="configureRequirements">The delegate to call to configure requirements.</param>
         /// <typeparam name="T">The type of the task driver instance.</typeparam>
         /// <returns>A reference to itself to continue chaining configuration methods</returns>
-        IJobConfig AddRequirementsFrom<T>(T taskDriver, Func<T, IJobConfig, IJobConfig> configureRequirements)
+        IJobConfig AddRequirementsFrom<T>(T taskDriver, ConfigureJobRequirementsDelegate<T> configureRequirements)
             where T : AbstractTaskDriver;
     }
 }

--- a/Scripts/Runtime/Entities/TaskDriver/TaskSet/Job/JobConfig/Interface/IJobConfig.cs
+++ b/Scripts/Runtime/Entities/TaskDriver/TaskSet/Job/JobConfig/Interface/IJobConfig.cs
@@ -1,4 +1,5 @@
 using Anvil.Unity.DOTS.Jobs;
+using System;
 using Unity.Collections;
 using Unity.Entities;
 
@@ -173,5 +174,8 @@ namespace Anvil.Unity.DOTS.Entities.TaskDriver
         /// <returns>A reference to itself to continue chaining configuration methods</returns>
         public IJobConfig RequireDBFEForExclusiveWrite<T>()
             where T : struct, IBufferElementData;
+
+        IJobConfig AddRequirementsFrom<T>(T taskDriver, Func<T, IJobConfig, IJobConfig> configureRequirements)
+            where T : AbstractTaskDriver;
     }
 }

--- a/Scripts/Runtime/Entities/TaskDriver/TaskSet/Job/JobConfig/NoOpJobConfig.cs
+++ b/Scripts/Runtime/Entities/TaskDriver/TaskSet/Job/JobConfig/NoOpJobConfig.cs
@@ -1,4 +1,5 @@
 using Anvil.Unity.DOTS.Jobs;
+using System;
 using Unity.Entities;
 
 namespace Anvil.Unity.DOTS.Entities.TaskDriver
@@ -114,6 +115,12 @@ namespace Anvil.Unity.DOTS.Entities.TaskDriver
             where TData : unmanaged, IEntityPersistentDataInstance
         {
             return this;
+        }
+
+        public IJobConfig AddRequirementsFrom<T>(T taskDriver, Func<T, IJobConfig, IJobConfig> configureRequirements)
+            where T : AbstractTaskDriver
+        {
+            return configureRequirements(taskDriver, this);
         }
     }
 }

--- a/Scripts/Runtime/Entities/TaskDriver/TaskSet/Job/JobConfig/NoOpJobConfig.cs
+++ b/Scripts/Runtime/Entities/TaskDriver/TaskSet/Job/JobConfig/NoOpJobConfig.cs
@@ -117,7 +117,7 @@ namespace Anvil.Unity.DOTS.Entities.TaskDriver
             return this;
         }
 
-        public IJobConfig AddRequirementsFrom<T>(T taskDriver, Func<T, IJobConfig, IJobConfig> configureRequirements)
+        public IJobConfig AddRequirementsFrom<T>(T taskDriver, IJobConfig.ConfigureJobRequirementsDelegate<T> configureRequirements)
             where T : AbstractTaskDriver
         {
             return configureRequirements(taskDriver, this);


### PR DESCRIPTION
Add `AddRequirementsFrom()` to `IJobConfig` to allow requirement configuration to be offloaded to another method.

Generally this will reference a static method on the trigger job so that requirements can be listed more closely to their usage rather than at the configuration call site.

### What is the current behaviour?

Offloading requirement configuration cannot be done as part of the chained pattern used for all other requirement configuration.

### What is the new behaviour?

Using `AddRequirementsFrom()` developers can now offload all or a portion of requirement configuration to another method.

### What issues does this resolve?
 - None

### What PRs does this depend on?
 - None

### Does this introduce a breaking change?
 - [ ] Yes <!-- If so, what are the migration considerations? -->
 - [x] No (unless you have your own `IJobConfig` implementation)
