### PR TITLE
BurstableLogger - Use ext method for MessagePrefix copy

### DIFF
--- a/Scripts/Runtime/Logging/BurstableLogger.cs
+++ b/Scripts/Runtime/Logging/BurstableLogger.cs
@@ -59,7 +59,9 @@ namespace Anvil.Unity.DOTS.Logging
             m_ThreadIndex = UNSET_THREAD_INDEX;
             string managedMessagePrefix = logger.MessagePrefix + appendToMessagePrefix;
             MessagePrefix = default;
-            CopyError error = FixedStringMethods.CopyFrom(ref MessagePrefix, managedMessagePrefix);
+
+            CopyError error = MessagePrefix.CopyFrom(managedMessagePrefix);
+
 
             switch (error)
             {


### PR DESCRIPTION
Switch to extension method for burst loggers message prefix setup.

### What is the current behaviour?

 - Same

### What is the new behaviour?

 - Same

### What issues does this resolve?

 - None

### What PRs does this depend on?
 - None

### Does this introduce a breaking change?
 - [ ] Yes <!-- If so, what are the migration considerations? -->
 - [x] No
