### PR TITLE
AbstractTaskDriver - Assert subtask instance has no parent.

### DIFF
--- a/Scripts/Runtime/Entities/TaskDriver/AbstractTaskDriver.cs
+++ b/Scripts/Runtime/Entities/TaskDriver/AbstractTaskDriver.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Reflection;
 using Unity.Entities;
 using Unity.Jobs;
+using Debug = UnityEngine.Debug;
 
 namespace Anvil.Unity.DOTS.Entities.TaskDriver
 {
@@ -145,6 +146,7 @@ namespace Anvil.Unity.DOTS.Entities.TaskDriver
         protected TTaskDriver AddSubTaskDriver<TTaskDriver>(TTaskDriver subTaskDriver)
             where TTaskDriver : AbstractTaskDriver
         {
+            Debug.Assert(subTaskDriver.Parent == null);
             subTaskDriver.Parent = this;
             m_SubTaskDrivers.Add(subTaskDriver);
 


### PR DESCRIPTION
Add an assertion to `AddSubTaskDriver` to make sure the subtask instance hasn't already been added to another Task Driver.

### What is the current behaviour?

Though it will produce incorrect behaviour it is possible to add one subtask driver instance to multiple task drivers (or even the same task driver multiple times)

### What is the new behaviour?

An assertion will be thrown when a subtask driver instance is added multiple times.

### What issues does this resolve?
 - None

### What PRs does this depend on?
 - None

### Does this introduce a breaking change?
 - [ ] Yes <!-- If so, what are the migration considerations? -->
 - [x] No
