### PR TITLE
Add Enumerable ToFixedString Extension Methods

### DIFF
--- a/Scripts/Runtime/Core.meta
+++ b/Scripts/Runtime/Core.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 86c6baa0ca604d83a10e8b0f865bffb5
+timeCreated: 1680925223

--- a/Scripts/Runtime/Core/IToFixedString.cs
+++ b/Scripts/Runtime/Core/IToFixedString.cs
@@ -1,0 +1,18 @@
+using Unity.Collections;
+
+namespace Anvil.Unity.DOTS.Core
+{
+    /// <summary>
+    /// Interface for a burst compatible equivalent to <see cref="object.ToString"/>. When implemented, an object will create
+    /// a fixed string (Ex: <see cref="FixedString512Bytes"/>) that represents the current object.
+    /// </summary>
+    /// <typeparam name="T">The fixed string type to return.</typeparam>
+    public interface IToFixedString<out T> where T : struct, INativeList<byte>, IUTF8Bytes
+    {
+        /// <summary>
+        /// Returns a burst compatible string of the current object.
+        /// </summary>
+        /// <returns>A fixed string that represents the current object.</returns>
+        T ToFixedString();
+    }
+}

--- a/Scripts/Runtime/Core/IToFixedString.cs.meta
+++ b/Scripts/Runtime/Core/IToFixedString.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 660127ebb61148a8a7ef2f6f71ab7230
+timeCreated: 1680924923

--- a/Scripts/Runtime/Data/Collections/Util/EnumerableToFixedStringExtension.cs
+++ b/Scripts/Runtime/Data/Collections/Util/EnumerableToFixedStringExtension.cs
@@ -298,12 +298,23 @@ namespace Anvil.Unity.DOTS.Data
             where TOutputString : struct, INativeList<byte>, IUTF8Bytes
         {
             TOutputString output = default;
+            output.Append('[');
+            bool isFirst = true;
             while (enumerator.MoveNext())
             {
+                if (!isFirst)
+                {
+                    output.Append(',');
+                }
+                else
+                {
+                    isFirst = false;
+                }
+
                 TElementString elementString = enumerator.Current.ToFixedString();
                 output.Append(elementString.GetUnsafePtr(), elementString.Length);
-                output.Append(',');
             }
+            output.Append(']');
 
             return output;
         }

--- a/Scripts/Runtime/Data/Collections/Util/EnumerableToFixedStringExtension.cs
+++ b/Scripts/Runtime/Data/Collections/Util/EnumerableToFixedStringExtension.cs
@@ -1,7 +1,10 @@
 using Anvil.Unity.DOTS.Core;
+using System;
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 using Unity.Burst;
 using Unity.Collections;
+using Unity.Collections.LowLevel.Unsafe;
 
 namespace Anvil.Unity.DOTS.Data
 {
@@ -12,11 +15,10 @@ namespace Anvil.Unity.DOTS.Data
     public static class EnumerableToFixedStringExtension
     {
         /// <summary>
-        /// Generates a burst compatible, comma separated, string of an <see cref="IEnumerable{T}"/>'s elements.
+        /// Generates a burst compatible, comma separated, string of a <see cref="UnsafeParallelHashSet{T}"/>'s elements.
         /// Each element must implement <see cref="IToFixedString{T}"/>
         /// </summary>
-        /// <param name="collection">The collection of elements.</param>
-        /// <typeparam name="TCollection">The <see cref="IEnumerable{T}"/>'s concrete type.</typeparam>
+        /// <param name="collection">The collection of elements</param>
         /// <typeparam name="TElement">The element's type. Must implement <see cref="IToFixedString{T}"/>.</typeparam>
         /// <typeparam name="TElementString">The element's string type.</typeparam>
         /// <typeparam name="TOutputString">
@@ -24,16 +26,281 @@ namespace Anvil.Unity.DOTS.Data
         /// per element for the comma.
         /// </typeparam>
         /// <returns>The generated string instance.</returns>
-        public static unsafe TOutputString ToFixedString<TCollection, TElement, TElementString, TOutputString>(ref this TCollection collection)
-            where TCollection : struct, IEnumerable<TElement>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static TOutputString ToFixedString<TElement, TElementString, TOutputString>(ref this UnsafeParallelHashSet<TElement> collection)
+            where TElement : unmanaged, IToFixedString<TElementString>, IEquatable<TElement>
+            where TElementString : struct, INativeList<byte>, IUTF8Bytes
+            where TOutputString : struct, INativeList<byte>, IUTF8Bytes
+        {
+            UnsafeParallelHashSet<TElement>.Enumerator enumerator = collection.GetEnumerator();
+            return enumerator.ToFixedString<UnsafeParallelHashSet<TElement>.Enumerator, TElement, TElementString, TOutputString>();
+        }
+
+        /// <summary>
+        /// Generates a burst compatible, comma separated, string of a <see cref="NativeParallelHashSet{T}"/>'s elements.
+        /// Each element must implement <see cref="IToFixedString{T}"/>
+        /// </summary>
+        /// <param name="collection">The collection of elements</param>
+        /// <typeparam name="TElement">The element's type. Must implement <see cref="IToFixedString{T}"/>.</typeparam>
+        /// <typeparam name="TElementString">The element's string type.</typeparam>
+        /// <typeparam name="TOutputString">
+        /// The output's string type. This must be large enough to contain the strings of all elements plus one byte
+        /// per element for the comma.
+        /// </typeparam>
+        /// <returns>The generated string instance.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static TOutputString ToFixedString<TElement, TElementString, TOutputString>(ref this NativeParallelHashSet<TElement> collection)
+            where TElement : unmanaged, IToFixedString<TElementString>, IEquatable<TElement>
+            where TElementString : struct, INativeList<byte>, IUTF8Bytes
+            where TOutputString : struct, INativeList<byte>, IUTF8Bytes
+        {
+            NativeParallelHashSet<TElement>.Enumerator enumerator = collection.GetEnumerator();
+            return enumerator.ToFixedString<NativeParallelHashSet<TElement>.Enumerator, TElement, TElementString, TOutputString>();
+        }
+
+        /// <summary>
+        /// Generates a burst compatible, comma separated, string of a <see cref="UnsafeList{T}"/>'s elements.
+        /// Each element must implement <see cref="IToFixedString{T}"/>
+        /// </summary>
+        /// <param name="collection">The collection of elements</param>
+        /// <typeparam name="TElement">The element's type. Must implement <see cref="IToFixedString{T}"/>.</typeparam>
+        /// <typeparam name="TElementString">The element's string type.</typeparam>
+        /// <typeparam name="TOutputString">
+        /// The output's string type. This must be large enough to contain the strings of all elements plus one byte
+        /// per element for the comma.
+        /// </typeparam>
+        /// <returns>The generated string instance.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static TOutputString ToFixedString<TElement, TElementString, TOutputString>(ref this UnsafeList<TElement> collection)
+            where TElement : unmanaged, IToFixedString<TElementString>
+            where TElementString : struct, INativeList<byte>, IUTF8Bytes
+            where TOutputString : struct, INativeList<byte>, IUTF8Bytes
+        {
+            UnsafeList<TElement>.Enumerator enumerator = collection.GetEnumerator();
+            return enumerator.ToFixedString<UnsafeList<TElement>.Enumerator, TElement, TElementString, TOutputString>();
+        }
+
+        /// <summary>
+        /// Generates a burst compatible, comma separated, string of a <see cref="NativeList{T}"/>'s elements.
+        /// Each element must implement <see cref="IToFixedString{T}"/>
+        /// </summary>
+        /// <param name="collection">The collection of elements</param>
+        /// <typeparam name="TElement">The element's type. Must implement <see cref="IToFixedString{T}"/>.</typeparam>
+        /// <typeparam name="TElementString">The element's string type.</typeparam>
+        /// <typeparam name="TOutputString">
+        /// The output's string type. This must be large enough to contain the strings of all elements plus one byte
+        /// per element for the comma.
+        /// </typeparam>
+        /// <returns>The generated string instance.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static TOutputString ToFixedString<TElement, TElementString, TOutputString>(ref this NativeList<TElement> collection)
+            where TElement : unmanaged, IToFixedString<TElementString>
+            where TElementString : struct, INativeList<byte>, IUTF8Bytes
+            where TOutputString : struct, INativeList<byte>, IUTF8Bytes
+        {
+            NativeArray<TElement>.Enumerator enumerator = collection.GetEnumerator();
+            return enumerator.ToFixedString<NativeArray<TElement>.Enumerator, TElement, TElementString, TOutputString>();
+        }
+
+        /// <summary>
+        /// Generates a burst compatible, comma separated, string of a <see cref="UnsafeArray{T}"/>'s elements.
+        /// Each element must implement <see cref="IToFixedString{T}"/>
+        /// </summary>
+        /// <param name="collection">The collection of elements</param>
+        /// <typeparam name="TElement">The element's type. Must implement <see cref="IToFixedString{T}"/>.</typeparam>
+        /// <typeparam name="TElementString">The element's string type.</typeparam>
+        /// <typeparam name="TOutputString">
+        /// The output's string type. This must be large enough to contain the strings of all elements plus one byte
+        /// per element for the comma.
+        /// </typeparam>
+        /// <returns>The generated string instance.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static TOutputString ToFixedString<TElement, TElementString, TOutputString>(ref this UnsafeArray<TElement> collection)
+            where TElement : unmanaged, IToFixedString<TElementString>
+            where TElementString : struct, INativeList<byte>, IUTF8Bytes
+            where TOutputString : struct, INativeList<byte>, IUTF8Bytes
+        {
+            UnsafeArray<TElement>.Enumerator enumerator = collection.GetEnumerator();
+            return enumerator.ToFixedString<UnsafeArray<TElement>.Enumerator, TElement, TElementString, TOutputString>();
+        }
+
+        /// <summary>
+        /// Generates a burst compatible, comma separated, string of a <see cref="NativeArray{T}"/>'s elements.
+        /// Each element must implement <see cref="IToFixedString{T}"/>
+        /// </summary>
+        /// <param name="collection">The collection of elements</param>
+        /// <typeparam name="TElement">The element's type. Must implement <see cref="IToFixedString{T}"/>.</typeparam>
+        /// <typeparam name="TElementString">The element's string type.</typeparam>
+        /// <typeparam name="TOutputString">
+        /// The output's string type. This must be large enough to contain the strings of all elements plus one byte
+        /// per element for the comma.
+        /// </typeparam>
+        /// <returns>The generated string instance.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static TOutputString ToFixedString<TElement, TElementString, TOutputString>(ref this NativeArray<TElement> collection)
+            where TElement : unmanaged, IToFixedString<TElementString>
+            where TElementString : struct, INativeList<byte>, IUTF8Bytes
+            where TOutputString : struct, INativeList<byte>, IUTF8Bytes
+        {
+            NativeArray<TElement>.Enumerator enumerator = collection.GetEnumerator();
+            return enumerator.ToFixedString<NativeArray<TElement>.Enumerator, TElement, TElementString, TOutputString>();
+        }
+
+        /// <summary>
+        /// Generates a burst compatible, comma separated, string of a <see cref="NativeArray{T}.ReadOnly"/>'s elements.
+        /// Each element must implement <see cref="IToFixedString{T}"/>
+        /// </summary>
+        /// <param name="collection">The collection of elements</param>
+        /// <typeparam name="TElement">The element's type. Must implement <see cref="IToFixedString{T}"/>.</typeparam>
+        /// <typeparam name="TElementString">The element's string type.</typeparam>
+        /// <typeparam name="TOutputString">
+        /// The output's string type. This must be large enough to contain the strings of all elements plus one byte
+        /// per element for the comma.
+        /// </typeparam>
+        /// <returns>The generated string instance.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static TOutputString ToFixedString<TElement, TElementString, TOutputString>(ref this NativeArray<TElement>.ReadOnly collection)
+            where TElement : unmanaged, IToFixedString<TElementString>
+            where TElementString : struct, INativeList<byte>, IUTF8Bytes
+            where TOutputString : struct, INativeList<byte>, IUTF8Bytes
+        {
+            NativeArray<TElement>.ReadOnly.Enumerator enumerator = collection.GetEnumerator();
+            return enumerator.ToFixedString<NativeArray<TElement>.ReadOnly.Enumerator, TElement, TElementString, TOutputString>();
+        }
+
+        /// <summary>
+        /// Generates a burst compatible, comma separated, string of a <see cref="FixedList32Bytes{T}"/>'s elements.
+        /// Each element must implement <see cref="IToFixedString{T}"/>
+        /// </summary>
+        /// <param name="collection">The collection of elements</param>
+        /// <typeparam name="TElement">The element's type. Must implement <see cref="IToFixedString{T}"/>.</typeparam>
+        /// <typeparam name="TElementString">The element's string type.</typeparam>
+        /// <typeparam name="TOutputString">
+        /// The output's string type. This must be large enough to contain the strings of all elements plus one byte
+        /// per element for the comma.
+        /// </typeparam>
+        /// <returns>The generated string instance.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static TOutputString ToFixedString<TElement, TElementString, TOutputString>(ref this FixedList32Bytes<TElement> collection)
+            where TElement : unmanaged, IToFixedString<TElementString>
+            where TElementString : struct, INativeList<byte>, IUTF8Bytes
+            where TOutputString : struct, INativeList<byte>, IUTF8Bytes
+        {
+            FixedList32Bytes<TElement>.Enumerator enumerator = collection.GetEnumerator();
+            return enumerator.ToFixedString<FixedList32Bytes<TElement>.Enumerator, TElement, TElementString, TOutputString>();
+        }
+
+        /// <summary>
+        /// Generates a burst compatible, comma separated, string of a <see cref="FixedList64Bytes{T}"/>'s elements.
+        /// Each element must implement <see cref="IToFixedString{T}"/>
+        /// </summary>
+        /// <param name="collection">The collection of elements</param>
+        /// <typeparam name="TElement">The element's type. Must implement <see cref="IToFixedString{T}"/>.</typeparam>
+        /// <typeparam name="TElementString">The element's string type.</typeparam>
+        /// <typeparam name="TOutputString">
+        /// The output's string type. This must be large enough to contain the strings of all elements plus one byte
+        /// per element for the comma.
+        /// </typeparam>
+        /// <returns>The generated string instance.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static TOutputString ToFixedString<TElement, TElementString, TOutputString>(ref this FixedList64Bytes<TElement> collection)
+            where TElement : unmanaged, IToFixedString<TElementString>
+            where TElementString : struct, INativeList<byte>, IUTF8Bytes
+            where TOutputString : struct, INativeList<byte>, IUTF8Bytes
+        {
+            FixedList64Bytes<TElement>.Enumerator enumerator = collection.GetEnumerator();
+            return enumerator.ToFixedString<FixedList64Bytes<TElement>.Enumerator, TElement, TElementString, TOutputString>();
+        }
+
+        /// <summary>
+        /// Generates a burst compatible, comma separated, string of a <see cref="FixedList128Bytes{T}"/>'s elements.
+        /// Each element must implement <see cref="IToFixedString{T}"/>
+        /// </summary>
+        /// <param name="collection">The collection of elements</param>
+        /// <typeparam name="TElement">The element's type. Must implement <see cref="IToFixedString{T}"/>.</typeparam>
+        /// <typeparam name="TElementString">The element's string type.</typeparam>
+        /// <typeparam name="TOutputString">
+        /// The output's string type. This must be large enough to contain the strings of all elements plus one byte
+        /// per element for the comma.
+        /// </typeparam>
+        /// <returns>The generated string instance.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static TOutputString ToFixedString<TElement, TElementString, TOutputString>(ref this FixedList128Bytes<TElement> collection)
+            where TElement : unmanaged, IToFixedString<TElementString>
+            where TElementString : struct, INativeList<byte>, IUTF8Bytes
+            where TOutputString : struct, INativeList<byte>, IUTF8Bytes
+        {
+            FixedList128Bytes<TElement>.Enumerator enumerator = collection.GetEnumerator();
+            return enumerator.ToFixedString<FixedList128Bytes<TElement>.Enumerator, TElement, TElementString, TOutputString>();
+        }
+
+        /// <summary>
+        /// Generates a burst compatible, comma separated, string of a <see cref="FixedList512Bytes{T}"/>'s elements.
+        /// Each element must implement <see cref="IToFixedString{T}"/>
+        /// </summary>
+        /// <param name="collection">The collection of elements</param>
+        /// <typeparam name="TElement">The element's type. Must implement <see cref="IToFixedString{T}"/>.</typeparam>
+        /// <typeparam name="TElementString">The element's string type.</typeparam>
+        /// <typeparam name="TOutputString">
+        /// The output's string type. This must be large enough to contain the strings of all elements plus one byte
+        /// per element for the comma.
+        /// </typeparam>
+        /// <returns>The generated string instance.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static TOutputString ToFixedString<TElement, TElementString, TOutputString>(ref this FixedList512Bytes<TElement> collection)
+            where TElement : unmanaged, IToFixedString<TElementString>
+            where TElementString : struct, INativeList<byte>, IUTF8Bytes
+            where TOutputString : struct, INativeList<byte>, IUTF8Bytes
+        {
+            FixedList512Bytes<TElement>.Enumerator enumerator = collection.GetEnumerator();
+            return enumerator.ToFixedString<FixedList512Bytes<TElement>.Enumerator, TElement, TElementString, TOutputString>();
+        }
+
+        /// <summary>
+        /// Generates a burst compatible, comma separated, string of a <see cref="FixedList4096Bytes{T}"/>'s elements.
+        /// Each element must implement <see cref="IToFixedString{T}"/>
+        /// </summary>
+        /// <param name="collection">The collection of elements</param>
+        /// <typeparam name="TElement">The element's type. Must implement <see cref="IToFixedString{T}"/>.</typeparam>
+        /// <typeparam name="TElementString">The element's string type.</typeparam>
+        /// <typeparam name="TOutputString">
+        /// The output's string type. This must be large enough to contain the strings of all elements plus one byte
+        /// per element for the comma.
+        /// </typeparam>
+        /// <returns>The generated string instance.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static TOutputString ToFixedString<TElement, TElementString, TOutputString>(ref this FixedList4096Bytes<TElement> collection)
+            where TElement : unmanaged, IToFixedString<TElementString>
+            where TElementString : struct, INativeList<byte>, IUTF8Bytes
+            where TOutputString : struct, INativeList<byte>, IUTF8Bytes
+        {
+            FixedList4096Bytes<TElement>.Enumerator enumerator = collection.GetEnumerator();
+            return enumerator.ToFixedString<FixedList4096Bytes<TElement>.Enumerator, TElement, TElementString, TOutputString>();
+        }
+
+        /// <summary>
+        /// Generates a burst compatible, comma separated, string of an <see cref="IEnumerator{T}"/>'s elements.
+        /// Each element must implement <see cref="IToFixedString{T}"/>
+        /// </summary>
+        /// <param name="collection">The enumerator of the elements.</param>
+        /// <typeparam name="TEnumerator">The <see cref="IEnumerator{T}"/>'s concrete type.</typeparam>
+        /// <typeparam name="TElement">The element's type. Must implement <see cref="IToFixedString{T}"/>.</typeparam>
+        /// <typeparam name="TElementString">The element's string type.</typeparam>
+        /// <typeparam name="TOutputString">
+        /// The output's string type. This must be large enough to contain the strings of all elements plus one byte
+        /// per element for the comma.
+        /// </typeparam>
+        /// <returns>The generated string instance.</returns>
+        public static unsafe TOutputString ToFixedString<TEnumerator, TElement, TElementString, TOutputString>(ref this TEnumerator enumerator)
+            where TEnumerator : struct, IEnumerator<TElement>
             where TElement : struct, IToFixedString<TElementString>
             where TElementString : struct, INativeList<byte>, IUTF8Bytes
             where TOutputString : struct, INativeList<byte>, IUTF8Bytes
         {
             TOutputString output = default;
-            foreach (TElement element in collection)
+            while (enumerator.MoveNext())
             {
-                TElementString elementString = element.ToFixedString();
+                TElementString elementString = enumerator.Current.ToFixedString();
                 output.Append(elementString.GetUnsafePtr(), elementString.Length);
                 output.Append(',');
             }

--- a/Scripts/Runtime/Data/Collections/Util/EnumerableToFixedStringExtension.cs
+++ b/Scripts/Runtime/Data/Collections/Util/EnumerableToFixedStringExtension.cs
@@ -1,0 +1,44 @@
+using Anvil.Unity.DOTS.Core;
+using System.Collections.Generic;
+using Unity.Burst;
+using Unity.Collections;
+
+namespace Anvil.Unity.DOTS.Data
+{
+    /// <summary>
+    /// A collection of extension methods for working with burst compatible implementations of <see cref="IEnumerable{T}"/>.
+    /// </summary>
+    [BurstCompile]
+    public static class EnumerableToFixedStringExtension
+    {
+        /// <summary>
+        /// Generates a burst compatible, comma separated, string of an <see cref="IEnumerable{T}"/>'s elements.
+        /// Each element must implement <see cref="IToFixedString{T}"/>
+        /// </summary>
+        /// <param name="collection">The collection of elements.</param>
+        /// <typeparam name="TCollection">The <see cref="IEnumerable{T}"/>'s concrete type.</typeparam>
+        /// <typeparam name="TElement">The element's type. Must implement <see cref="IToFixedString{T}"/>.</typeparam>
+        /// <typeparam name="TElementString">The element's string type.</typeparam>
+        /// <typeparam name="TOutputString">
+        /// The output's string type. This must be large enough to contain the strings of all elements plus one byte
+        /// per element for the comma.
+        /// </typeparam>
+        /// <returns>The generated string instance.</returns>
+        public static unsafe TOutputString ToFixedString<TCollection, TElement, TElementString, TOutputString>(ref this TCollection collection)
+            where TCollection : struct, IEnumerable<TElement>
+            where TElement : struct, IToFixedString<TElementString>
+            where TElementString : struct, INativeList<byte>, IUTF8Bytes
+            where TOutputString : struct, INativeList<byte>, IUTF8Bytes
+        {
+            TOutputString output = default;
+            foreach (TElement element in collection)
+            {
+                TElementString elementString = element.ToFixedString();
+                output.Append(elementString.GetUnsafePtr(), elementString.Length);
+                output.Append(',');
+            }
+
+            return output;
+        }
+    }
+}

--- a/Scripts/Runtime/Data/Collections/Util/EnumerableToFixedStringExtension.cs.meta
+++ b/Scripts/Runtime/Data/Collections/Util/EnumerableToFixedStringExtension.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 858685e9804d3419aaa914562c504ecb
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/Runtime/Entities/Data/EntityEnumerableToFixedStringExtension.cs
+++ b/Scripts/Runtime/Entities/Data/EntityEnumerableToFixedStringExtension.cs
@@ -1,6 +1,7 @@
 using Anvil.Unity.DOTS.Core;
 using Anvil.Unity.DOTS.Data;
 using System;
+using System.Runtime.CompilerServices;
 using Unity.Burst;
 using Unity.Collections;
 using Unity.Collections.LowLevel.Unsafe;
@@ -27,11 +28,12 @@ namespace Anvil.Unity.DOTS.Entities
         /// <returns>
         /// <inheritdoc cref="EnumerableToFixedStringExtension.ToFixedString{TCollection, TElement, TElementString, TOutputString}"/>
         /// </returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static TOutputString ToFixedString<TOutputString>(ref this UnsafeParallelHashSet<Entity> collection)
             where TOutputString : struct, INativeList<byte>, IUTF8Bytes
         {
             return UnsafeUtility.As<UnsafeParallelHashSet<Entity>, UnsafeParallelHashSet<EntityWrapper>>(ref collection)
-                .ToFixedString<UnsafeParallelHashSet<EntityWrapper>, EntityWrapper, FixedString64Bytes, TOutputString>();
+                .ToFixedString<EntityWrapper, FixedString64Bytes, TOutputString>();
         }
 
         /// <summary>
@@ -45,11 +47,12 @@ namespace Anvil.Unity.DOTS.Entities
         /// <returns>
         /// <inheritdoc cref="EnumerableToFixedStringExtension.ToFixedString{TCollection, TElement, TElementString, TOutputString}"/>
         /// </returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static TOutputString ToFixedString<TOutputString>(ref this NativeParallelHashSet<Entity> collection)
             where TOutputString : struct, INativeList<byte>, IUTF8Bytes
         {
             return UnsafeUtility.As<NativeParallelHashSet<Entity>, NativeParallelHashSet<EntityWrapper>>(ref collection)
-                .ToFixedString<NativeParallelHashSet<EntityWrapper>, EntityWrapper, FixedString64Bytes, TOutputString>();
+                .ToFixedString<EntityWrapper, FixedString64Bytes, TOutputString>();
         }
 
         /// <summary>
@@ -67,7 +70,7 @@ namespace Anvil.Unity.DOTS.Entities
             where TOutputString : struct, INativeList<byte>, IUTF8Bytes
         {
             return UnsafeUtility.As<UnsafeList<Entity>, UnsafeList<EntityWrapper>>(ref collection)
-                .ToFixedString<UnsafeList<EntityWrapper>, EntityWrapper, FixedString64Bytes, TOutputString>();
+                .ToFixedString<EntityWrapper, FixedString64Bytes, TOutputString>();
         }
 
         /// <summary>
@@ -81,11 +84,12 @@ namespace Anvil.Unity.DOTS.Entities
         /// <returns>
         /// <inheritdoc cref="EnumerableToFixedStringExtension.ToFixedString{TCollection, TElement, TElementString, TOutputString}"/>
         /// </returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static TOutputString ToFixedString<TOutputString>(ref this NativeList<Entity> collection)
             where TOutputString : struct, INativeList<byte>, IUTF8Bytes
         {
             return UnsafeUtility.As<NativeList<Entity>, NativeList<EntityWrapper>>(ref collection)
-                .ToFixedString<NativeList<EntityWrapper>, EntityWrapper, FixedString64Bytes, TOutputString>();
+                .ToFixedString<EntityWrapper, FixedString64Bytes, TOutputString>();
         }
 
         /// <summary>
@@ -99,11 +103,12 @@ namespace Anvil.Unity.DOTS.Entities
         /// <returns>
         /// <inheritdoc cref="EnumerableToFixedStringExtension.ToFixedString{TCollection, TElement, TElementString, TOutputString}"/>
         /// </returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static TOutputString ToFixedString<TOutputString>(ref this UnsafeArray<Entity> collection)
             where TOutputString : struct, INativeList<byte>, IUTF8Bytes
         {
             return UnsafeUtility.As<UnsafeArray<Entity>, UnsafeArray<EntityWrapper>>(ref collection)
-                .ToFixedString<UnsafeArray<EntityWrapper>, EntityWrapper, FixedString64Bytes, TOutputString>();
+                .ToFixedString<EntityWrapper, FixedString64Bytes, TOutputString>();
         }
 
         /// <summary>
@@ -117,11 +122,12 @@ namespace Anvil.Unity.DOTS.Entities
         /// <returns>
         /// <inheritdoc cref="EnumerableToFixedStringExtension.ToFixedString{TCollection, TElement, TElementString, TOutputString}"/>
         /// </returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static TOutputString ToFixedString<TOutputString>(ref this NativeArray<Entity> collection)
             where TOutputString : struct, INativeList<byte>, IUTF8Bytes
         {
             return UnsafeUtility.As<NativeArray<Entity>, NativeArray<EntityWrapper>>(ref collection)
-                .ToFixedString<NativeArray<EntityWrapper>, EntityWrapper, FixedString64Bytes, TOutputString>();
+                .ToFixedString<EntityWrapper, FixedString64Bytes, TOutputString>();
         }
 
         /// <summary>
@@ -135,11 +141,12 @@ namespace Anvil.Unity.DOTS.Entities
         /// <returns>
         /// <inheritdoc cref="EnumerableToFixedStringExtension.ToFixedString{TCollection, TElement, TElementString, TOutputString}"/>
         /// </returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static TOutputString ToFixedString<TOutputString>(ref this NativeArray<Entity>.ReadOnly collection)
             where TOutputString : struct, INativeList<byte>, IUTF8Bytes
         {
             return UnsafeUtility.As<NativeArray<Entity>.ReadOnly, NativeArray<EntityWrapper>.ReadOnly>(ref collection)
-                .ToFixedString<NativeArray<EntityWrapper>.ReadOnly, EntityWrapper, FixedString64Bytes, TOutputString>();
+                .ToFixedString<EntityWrapper, FixedString64Bytes, TOutputString>();
         }
 
         /// <summary>
@@ -151,10 +158,11 @@ namespace Anvil.Unity.DOTS.Entities
         /// <inheritdoc cref="EnumerableToFixedStringExtension.ToFixedString{TCollection, TElement, TElementString, TOutputString}"/>
         /// </returns>
         /// <remarks>The outputted string size assumes each element's string is 64-bytes</remarks>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static FixedString512Bytes ToFixedString(ref this FixedList32Bytes<Entity> collection)
         {
             return UnsafeUtility.As<FixedList32Bytes<Entity>, FixedList32Bytes<EntityWrapper>>(ref collection)
-                .ToFixedString<FixedList32Bytes<EntityWrapper>, EntityWrapper, FixedString64Bytes, FixedString512Bytes>();
+                .ToFixedString<EntityWrapper, FixedString64Bytes, FixedString512Bytes>();
         }
 
         /// <summary>
@@ -166,10 +174,11 @@ namespace Anvil.Unity.DOTS.Entities
         /// <inheritdoc cref="EnumerableToFixedStringExtension.ToFixedString{TCollection, TElement, TElementString, TOutputString}"/>
         /// </returns>
         /// <remarks>The outputted string size assumes each element's string is 64-bytes</remarks>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static FixedString512Bytes ToFixedString(ref this FixedList64Bytes<Entity> collection)
         {
             return UnsafeUtility.As<FixedList64Bytes<Entity>, FixedList64Bytes<EntityWrapper>>(ref collection)
-                .ToFixedString<FixedList64Bytes<EntityWrapper>, EntityWrapper, FixedString64Bytes, FixedString512Bytes>();
+                .ToFixedString<EntityWrapper, FixedString64Bytes, FixedString512Bytes>();
         }
 
         /// <summary>
@@ -181,10 +190,11 @@ namespace Anvil.Unity.DOTS.Entities
         /// <inheritdoc cref="EnumerableToFixedStringExtension.ToFixedString{TCollection, TElement, TElementString, TOutputString}"/>
         /// </returns>
         /// <remarks>The outputted string size assumes each element's string is 64-bytes</remarks>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static FixedString4096Bytes ToFixedString(ref this FixedList128Bytes<Entity> collection)
         {
             return UnsafeUtility.As<FixedList128Bytes<Entity>, FixedList128Bytes<EntityWrapper>>(ref collection)
-                .ToFixedString<FixedList128Bytes<EntityWrapper>, EntityWrapper, FixedString64Bytes, FixedString4096Bytes>();
+                .ToFixedString<EntityWrapper, FixedString64Bytes, FixedString4096Bytes>();
         }
 
         /// <summary>
@@ -196,10 +206,11 @@ namespace Anvil.Unity.DOTS.Entities
         /// <inheritdoc cref="EnumerableToFixedStringExtension.ToFixedString{TCollection, TElement, TElementString, TOutputString}"/>
         /// </returns>
         /// <remarks>The outputted string size assumes each element's string is 64-bytes</remarks>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static FixedString4096Bytes ToFixedString(ref this FixedList512Bytes<Entity> collection)
         {
             return UnsafeUtility.As<FixedList512Bytes<Entity>, FixedList512Bytes<EntityWrapper>>(ref collection)
-                .ToFixedString<FixedList512Bytes<EntityWrapper>, EntityWrapper, FixedString64Bytes, FixedString4096Bytes>();
+                .ToFixedString<EntityWrapper, FixedString64Bytes, FixedString4096Bytes>();
         }
 
         /// <summary>
@@ -211,10 +222,11 @@ namespace Anvil.Unity.DOTS.Entities
         /// <inheritdoc cref="EnumerableToFixedStringExtension.ToFixedString{TCollection, TElement, TElementString, TOutputString}"/>
         /// </returns>
         /// <remarks>The outputted string size assumes each element's string is 64-bytes</remarks>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static FixedString4096Bytes ToFixedString(ref this FixedList4096Bytes<Entity> collection)
         {
             return UnsafeUtility.As<FixedList4096Bytes<Entity>, FixedList4096Bytes<EntityWrapper>>(ref collection)
-                .ToFixedString<FixedList4096Bytes<EntityWrapper>, EntityWrapper, FixedString64Bytes, FixedString4096Bytes>();
+                .ToFixedString<EntityWrapper, FixedString64Bytes, FixedString4096Bytes>();
         }
 
         /// <summary>

--- a/Scripts/Runtime/Entities/Data/EntityEnumerableToFixedStringExtension.cs
+++ b/Scripts/Runtime/Entities/Data/EntityEnumerableToFixedStringExtension.cs
@@ -1,0 +1,232 @@
+using Anvil.Unity.DOTS.Core;
+using Anvil.Unity.DOTS.Data;
+using System;
+using Unity.Burst;
+using Unity.Collections;
+using Unity.Collections.LowLevel.Unsafe;
+using Unity.Entities;
+
+namespace Anvil.Unity.DOTS.Entities
+{
+    /// <summary>
+    /// A collection of extension methods for generating burst compatible strings from burst compatible collections of
+    /// <see cref="Entity"/> elements.
+    /// This is an <see cref="Entity"/> specific version of what is offered in <see cref="EnumerableToFixedStringExtension"/>/
+    /// </summary>
+    [BurstCompile]
+    public static class EntityEnumerableToFixedStringExtension
+    {
+        /// <summary>
+        /// Returns a burst compatible string of the collection using
+        /// <see cref="EnumerableToFixedStringExtension.ToFixedString{TCollection, TElement, TElementString, TOutputString}"/>.
+        /// </summary>
+        /// <param name="collection">The collection to generate the string from.</param>
+        /// <typeparam name="TOutputString">
+        /// <see cref="EnumerableToFixedStringExtension.ToFixedString{TCollection, TElement, TElementString, TOutputString}"/>.
+        /// </typeparam>
+        /// <returns>
+        /// <inheritdoc cref="EnumerableToFixedStringExtension.ToFixedString{TCollection, TElement, TElementString, TOutputString}"/>
+        /// </returns>
+        public static TOutputString ToFixedString<TOutputString>(ref this UnsafeParallelHashSet<Entity> collection)
+            where TOutputString : struct, INativeList<byte>, IUTF8Bytes
+        {
+            return UnsafeUtility.As<UnsafeParallelHashSet<Entity>, UnsafeParallelHashSet<EntityWrapper>>(ref collection)
+                .ToFixedString<UnsafeParallelHashSet<EntityWrapper>, EntityWrapper, FixedString64Bytes, TOutputString>();
+        }
+
+        /// <summary>
+        /// Returns a burst compatible string of the collection using
+        /// <see cref="EnumerableToFixedStringExtension.ToFixedString{TCollection, TElement, TElementString, TOutputString}"/>.
+        /// </summary>
+        /// <param name="collection">The collection to generate the string from.</param>
+        /// <typeparam name="TOutputString">
+        /// <see cref="EnumerableToFixedStringExtension.ToFixedString{TCollection, TElement, TElementString, TOutputString}"/>.
+        /// </typeparam>
+        /// <returns>
+        /// <inheritdoc cref="EnumerableToFixedStringExtension.ToFixedString{TCollection, TElement, TElementString, TOutputString}"/>
+        /// </returns>
+        public static TOutputString ToFixedString<TOutputString>(ref this NativeParallelHashSet<Entity> collection)
+            where TOutputString : struct, INativeList<byte>, IUTF8Bytes
+        {
+            return UnsafeUtility.As<NativeParallelHashSet<Entity>, NativeParallelHashSet<EntityWrapper>>(ref collection)
+                .ToFixedString<NativeParallelHashSet<EntityWrapper>, EntityWrapper, FixedString64Bytes, TOutputString>();
+        }
+
+        /// <summary>
+        /// Returns a burst compatible string of the collection using
+        /// <see cref="EnumerableToFixedStringExtension.ToFixedString{TCollection, TElement, TElementString, TOutputString}"/>.
+        /// </summary>
+        /// <param name="collection">The collection to generate the string from.</param>
+        /// <typeparam name="TOutputString">
+        /// <see cref="EnumerableToFixedStringExtension.ToFixedString{TCollection, TElement, TElementString, TOutputString}"/>.
+        /// </typeparam>
+        /// <returns>
+        /// <inheritdoc cref="EnumerableToFixedStringExtension.ToFixedString{TCollection, TElement, TElementString, TOutputString}"/>
+        /// </returns>
+        public static TOutputString ToFixedString<TOutputString>(ref this UnsafeList<Entity> collection)
+            where TOutputString : struct, INativeList<byte>, IUTF8Bytes
+        {
+            return UnsafeUtility.As<UnsafeList<Entity>, UnsafeList<EntityWrapper>>(ref collection)
+                .ToFixedString<UnsafeList<EntityWrapper>, EntityWrapper, FixedString64Bytes, TOutputString>();
+        }
+
+        /// <summary>
+        /// Returns a burst compatible string of the collection using
+        /// <see cref="EnumerableToFixedStringExtension.ToFixedString{TCollection, TElement, TElementString, TOutputString}"/>.
+        /// </summary>
+        /// <param name="collection">The collection to generate the string from.</param>
+        /// <typeparam name="TOutputString">
+        /// <see cref="EnumerableToFixedStringExtension.ToFixedString{TCollection, TElement, TElementString, TOutputString}"/>.
+        /// </typeparam>
+        /// <returns>
+        /// <inheritdoc cref="EnumerableToFixedStringExtension.ToFixedString{TCollection, TElement, TElementString, TOutputString}"/>
+        /// </returns>
+        public static TOutputString ToFixedString<TOutputString>(ref this NativeList<Entity> collection)
+            where TOutputString : struct, INativeList<byte>, IUTF8Bytes
+        {
+            return UnsafeUtility.As<NativeList<Entity>, NativeList<EntityWrapper>>(ref collection)
+                .ToFixedString<NativeList<EntityWrapper>, EntityWrapper, FixedString64Bytes, TOutputString>();
+        }
+
+        /// <summary>
+        /// Returns a burst compatible string of the collection using
+        /// <see cref="EnumerableToFixedStringExtension.ToFixedString{TCollection, TElement, TElementString, TOutputString}"/>.
+        /// </summary>
+        /// <param name="collection">The collection to generate the string from.</param>
+        /// <typeparam name="TOutputString">
+        /// <see cref="EnumerableToFixedStringExtension.ToFixedString{TCollection, TElement, TElementString, TOutputString}"/>.
+        /// </typeparam>
+        /// <returns>
+        /// <inheritdoc cref="EnumerableToFixedStringExtension.ToFixedString{TCollection, TElement, TElementString, TOutputString}"/>
+        /// </returns>
+        public static TOutputString ToFixedString<TOutputString>(ref this UnsafeArray<Entity> collection)
+            where TOutputString : struct, INativeList<byte>, IUTF8Bytes
+        {
+            return UnsafeUtility.As<UnsafeArray<Entity>, UnsafeArray<EntityWrapper>>(ref collection)
+                .ToFixedString<UnsafeArray<EntityWrapper>, EntityWrapper, FixedString64Bytes, TOutputString>();
+        }
+
+        /// <summary>
+        /// Returns a burst compatible string of the collection using
+        /// <see cref="EnumerableToFixedStringExtension.ToFixedString{TCollection, TElement, TElementString, TOutputString}"/>.
+        /// </summary>
+        /// <param name="collection">The collection to generate the string from.</param>
+        /// <typeparam name="TOutputString">
+        /// <see cref="EnumerableToFixedStringExtension.ToFixedString{TCollection, TElement, TElementString, TOutputString}"/>.
+        /// </typeparam>
+        /// <returns>
+        /// <inheritdoc cref="EnumerableToFixedStringExtension.ToFixedString{TCollection, TElement, TElementString, TOutputString}"/>
+        /// </returns>
+        public static TOutputString ToFixedString<TOutputString>(ref this NativeArray<Entity> collection)
+            where TOutputString : struct, INativeList<byte>, IUTF8Bytes
+        {
+            return UnsafeUtility.As<NativeArray<Entity>, NativeArray<EntityWrapper>>(ref collection)
+                .ToFixedString<NativeArray<EntityWrapper>, EntityWrapper, FixedString64Bytes, TOutputString>();
+        }
+
+        /// <summary>
+        /// Returns a burst compatible string of the collection using
+        /// <see cref="EnumerableToFixedStringExtension.ToFixedString{TCollection, TElement, TElementString, TOutputString}"/>.
+        /// </summary>
+        /// <param name="collection">The collection to generate the string from.</param>
+        /// <typeparam name="TOutputString">
+        /// <see cref="EnumerableToFixedStringExtension.ToFixedString{TCollection, TElement, TElementString, TOutputString}"/>.
+        /// </typeparam>
+        /// <returns>
+        /// <inheritdoc cref="EnumerableToFixedStringExtension.ToFixedString{TCollection, TElement, TElementString, TOutputString}"/>
+        /// </returns>
+        public static TOutputString ToFixedString<TOutputString>(ref this NativeArray<Entity>.ReadOnly collection)
+            where TOutputString : struct, INativeList<byte>, IUTF8Bytes
+        {
+            return UnsafeUtility.As<NativeArray<Entity>.ReadOnly, NativeArray<EntityWrapper>.ReadOnly>(ref collection)
+                .ToFixedString<NativeArray<EntityWrapper>.ReadOnly, EntityWrapper, FixedString64Bytes, TOutputString>();
+        }
+
+        /// <summary>
+        /// Returns a burst compatible string of the collection using
+        /// <see cref="EnumerableToFixedStringExtension.ToFixedString{TCollection, TElement, TElementString, TOutputString}"/>.
+        /// </summary>
+        /// <param name="collection">The collection to generate the string from.</param>
+        /// <returns>
+        /// <inheritdoc cref="EnumerableToFixedStringExtension.ToFixedString{TCollection, TElement, TElementString, TOutputString}"/>
+        /// </returns>
+        /// <remarks>The outputted string size assumes each element's string is 64-bytes</remarks>
+        public static FixedString512Bytes ToFixedString(ref this FixedList32Bytes<Entity> collection)
+        {
+            return UnsafeUtility.As<FixedList32Bytes<Entity>, FixedList32Bytes<EntityWrapper>>(ref collection)
+                .ToFixedString<FixedList32Bytes<EntityWrapper>, EntityWrapper, FixedString64Bytes, FixedString512Bytes>();
+        }
+
+        /// <summary>
+        /// Returns a burst compatible string of the collection using
+        /// <see cref="EnumerableToFixedStringExtension.ToFixedString{TCollection, TElement, TElementString, TOutputString}"/>.
+        /// </summary>
+        /// <param name="collection">The collection to generate the string from.</param>
+        /// <returns>
+        /// <inheritdoc cref="EnumerableToFixedStringExtension.ToFixedString{TCollection, TElement, TElementString, TOutputString}"/>
+        /// </returns>
+        /// <remarks>The outputted string size assumes each element's string is 64-bytes</remarks>
+        public static FixedString512Bytes ToFixedString(ref this FixedList64Bytes<Entity> collection)
+        {
+            return UnsafeUtility.As<FixedList64Bytes<Entity>, FixedList64Bytes<EntityWrapper>>(ref collection)
+                .ToFixedString<FixedList64Bytes<EntityWrapper>, EntityWrapper, FixedString64Bytes, FixedString512Bytes>();
+        }
+
+        /// <summary>
+        /// Returns a burst compatible string of the collection using
+        /// <see cref="EnumerableToFixedStringExtension.ToFixedString{TCollection, TElement, TElementString, TOutputString}"/>.
+        /// </summary>
+        /// <param name="collection">The collection to generate the string from.</param>
+        /// <returns>
+        /// <inheritdoc cref="EnumerableToFixedStringExtension.ToFixedString{TCollection, TElement, TElementString, TOutputString}"/>
+        /// </returns>
+        /// <remarks>The outputted string size assumes each element's string is 64-bytes</remarks>
+        public static FixedString4096Bytes ToFixedString(ref this FixedList128Bytes<Entity> collection)
+        {
+            return UnsafeUtility.As<FixedList128Bytes<Entity>, FixedList128Bytes<EntityWrapper>>(ref collection)
+                .ToFixedString<FixedList128Bytes<EntityWrapper>, EntityWrapper, FixedString64Bytes, FixedString4096Bytes>();
+        }
+
+        /// <summary>
+        /// Returns a burst compatible string of the collection using
+        /// <see cref="EnumerableToFixedStringExtension.ToFixedString{TCollection, TElement, TElementString, TOutputString}"/>.
+        /// </summary>
+        /// <param name="collection">The collection to generate the string from.</param>
+        /// <returns>
+        /// <inheritdoc cref="EnumerableToFixedStringExtension.ToFixedString{TCollection, TElement, TElementString, TOutputString}"/>
+        /// </returns>
+        /// <remarks>The outputted string size assumes each element's string is 64-bytes</remarks>
+        public static FixedString4096Bytes ToFixedString(ref this FixedList512Bytes<Entity> collection)
+        {
+            return UnsafeUtility.As<FixedList512Bytes<Entity>, FixedList512Bytes<EntityWrapper>>(ref collection)
+                .ToFixedString<FixedList512Bytes<EntityWrapper>, EntityWrapper, FixedString64Bytes, FixedString4096Bytes>();
+        }
+
+        /// <summary>
+        /// Returns a burst compatible string of the collection using
+        /// <see cref="EnumerableToFixedStringExtension.ToFixedString{TCollection, TElement, TElementString, TOutputString}"/>.
+        /// </summary>
+        /// <param name="collection">The collection to generate the string from.</param>
+        /// <returns>
+        /// <inheritdoc cref="EnumerableToFixedStringExtension.ToFixedString{TCollection, TElement, TElementString, TOutputString}"/>
+        /// </returns>
+        /// <remarks>The outputted string size assumes each element's string is 64-bytes</remarks>
+        public static FixedString4096Bytes ToFixedString(ref this FixedList4096Bytes<Entity> collection)
+        {
+            return UnsafeUtility.As<FixedList4096Bytes<Entity>, FixedList4096Bytes<EntityWrapper>>(ref collection)
+                .ToFixedString<FixedList4096Bytes<EntityWrapper>, EntityWrapper, FixedString64Bytes, FixedString4096Bytes>();
+        }
+
+        /// <summary>
+        /// Wraps an entity and implements <see cref="IToFixedString{T}"/>.
+        /// </summary>
+        private struct EntityWrapper : IToFixedString<FixedString64Bytes>, IEquatable<EntityWrapper>
+        {
+            private Entity Entity;
+
+            public FixedString64Bytes ToFixedString() => Entity.ToFixedString();
+
+            public bool Equals(EntityWrapper other) => other.Entity == Entity;
+        }
+    }
+}

--- a/Scripts/Runtime/Entities/Data/EntityEnumerableToFixedStringExtension.cs.meta
+++ b/Scripts/Runtime/Entities/Data/EntityEnumerableToFixedStringExtension.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 1bd8b3bc36ca4943b0129ad4aae1f0e5
+timeCreated: 1680707094


### PR DESCRIPTION
Provide a reasonably convenient way to convert collections of Entities and `IToFixedString` implementations to a Fixed String representation. 

Introduce `IToFixedString` to provide an interface for any type to be able to generate a burst compatible string output of itself. The burst counterpart to `object.ToString()`.

The resulting string is `[element1String,elemetn2string,...]`

### What is the current behaviour?

Developers
 - Have to manually generate fixed strings to represent collections of objects in a burst context.
 - Have no way of defining a ToFixedString method in a consistent way.

### What is the new behaviour?

ToFixedString() may be called on any of the built in or Anvil burst compatible collections (or enumerators) that contain elements which implement `IToFixedString`. The generic parameters required to call this method aren't ideal but I haven't been able to devise a better solution.

Collections of entities are a special case of extension methods since they have a ToFixedString method but do not implement IToFixedString. Leveraging aliasing we're able to wrap the entities in an `IToFixedString` implementation without any additional allocations.
The entity collection calls just happen to be much nicer to call with no generic parameters required.

### What issues does this resolve?
 - None

### What PRs does this depend on?
 - None

### Does this introduce a breaking change?
 - [ ] Yes <!-- If so, what are the migration considerations? -->
 - [x] No
