### PR TITLE
FixedList... Extension Methods

### DIFF
--- a/Scripts/Runtime/Data/Collections/Util/FixedListExtension.cs
+++ b/Scripts/Runtime/Data/Collections/Util/FixedListExtension.cs
@@ -54,5 +54,53 @@ namespace Anvil.Unity.DOTS.Data
         {
             return UnsafeUtilityExtensions.AsRef(list).IndexOf(value);
         }
+
+        /// <inheritdoc cref="FixedList32BytesExtensions.Contains{T,U}"/>
+        /// <remarks>
+        /// A version of <see cref="FixedList32BytesExtensions.Contains{T,U}"/> that is compatible with readonly references.
+        /// </remarks>
+        public static bool ContainsReadOnly<T, U>(this in FixedList32Bytes<T> list, U value) where T : unmanaged, IEquatable<U>
+        {
+            return UnsafeUtilityExtensions.AsRef(list).Contains(value);
+        }
+
+        /// <inheritdoc cref="FixedList64BytesExtensions.Contains{T,U}"/>
+        /// <remarks>
+        /// A version of <see cref="FixedList64BytesExtensions.Contains{T,U}"/> that is compatible with readonly references.
+        /// </remarks>
+        public static bool ContainsReadOnly<T, U>(this in FixedList64Bytes<T> list, U value) where T : unmanaged, IEquatable<U>
+        {
+            return UnsafeUtilityExtensions.AsRef(list).Contains(value);
+        }
+
+        /// <inheritdoc cref="FixedList128BytesExtensions.Contains{T,U}"/>
+        /// <remarks>
+        /// A version of <see cref="FixedList128BytesExtensions.Contains{T,U}"/> that is compatible with readonly
+        /// references.
+        /// </remarks>
+        public static bool ContainsReadOnly<T, U>(this in FixedList128Bytes<T> list, U value) where T : unmanaged, IEquatable<U>
+        {
+            return UnsafeUtilityExtensions.AsRef(list).Contains(value);
+        }
+
+        /// <inheritdoc cref="FixedList512BytesExtensions.Contains{T,U}"/>
+        /// <remarks>
+        /// A version of <see cref="FixedList512BytesExtensions.Contains{T,U}"/> that is compatible with readonly
+        /// references.
+        /// </remarks>
+        public static bool ContainsReadOnly<T, U>(this in FixedList512Bytes<T> list, U value) where T : unmanaged, IEquatable<U>
+        {
+            return UnsafeUtilityExtensions.AsRef(list).Contains(value);
+        }
+
+        /// <inheritdoc cref="FixedList4096BytesExtensions.Contains{T,U}"/>
+        /// <remarks>
+        /// A version of <see cref="FixedList4096BytesExtensions.Contains{T,U}"/> that is compatible with readonly
+        /// references.
+        /// </remarks>
+        public static bool ContainsReadOnly<T, U>(this in FixedList4096Bytes<T> list, U value) where T : unmanaged, IEquatable<U>
+        {
+            return UnsafeUtilityExtensions.AsRef(list).Contains(value);
+        }
     }
 }

--- a/Scripts/Runtime/Data/Collections/Util/FixedListExtension.cs
+++ b/Scripts/Runtime/Data/Collections/Util/FixedListExtension.cs
@@ -102,5 +102,104 @@ namespace Anvil.Unity.DOTS.Data
         {
             return UnsafeUtilityExtensions.AsRef(list).Contains(value);
         }
+
+        /// <inheritdoc cref="FixedList32BytesExtensions.RemoveSwapBack{T,U}"/>
+        /// <remarks>
+        /// A version of <see cref="FixedList32BytesExtensions.RemoveSwapBack{T,U}"/> that is compatible with Enums and
+        /// readonly references.
+        /// </remarks>
+        public static bool RemoveSwapBack<TEnum, TUnderlying>(this in FixedList32Bytes<TEnum> list, TUnderlying value)
+            where TEnum : unmanaged, Enum
+            where TUnderlying : unmanaged, IEquatable<TUnderlying>
+        {
+            int index = list.IndexOf(value);
+            if (index == -1)
+            {
+                return false;
+            }
+
+            list.RemoveAtSwapBack(index);
+
+            return true;
+        }
+
+        /// <inheritdoc cref="FixedList64BytesExtensions.RemoveSwapBack{T,U}"/>
+        /// <remarks>
+        /// A version of <see cref="FixedList64BytesExtensions.RemoveSwapBack{T,U}"/> that is compatible with Enums and
+        /// readonly references.
+        /// </remarks>
+        public static bool RemoveSwapBack<TEnum, TUnderlying>(this in FixedList64Bytes<TEnum> list, TUnderlying value)
+            where TEnum : unmanaged, Enum
+            where TUnderlying : unmanaged, IEquatable<TUnderlying>
+        {
+            int index = list.IndexOf(value);
+            if (index == -1)
+            {
+                return false;
+            }
+
+            list.RemoveAtSwapBack(index);
+
+            return true;
+        }
+
+        /// <inheritdoc cref="FixedList128BytesExtensions.RemoveSwapBack{T,U}"/>
+        /// <remarks>
+        /// A version of <see cref="FixedList128BytesExtensions.RemoveSwapBack{T,U}"/> that is compatible with Enums and
+        /// readonly references.
+        /// </remarks>
+        public static bool RemoveSwapBack<TEnum, TUnderlying>(this in FixedList128Bytes<TEnum> list, TUnderlying value)
+            where TEnum : unmanaged, Enum
+            where TUnderlying : unmanaged, IEquatable<TUnderlying>
+        {
+            int index = list.IndexOf(value);
+            if (index == -1)
+            {
+                return false;
+            }
+
+            list.RemoveAtSwapBack(index);
+
+            return true;
+        }
+
+        /// <inheritdoc cref="FixedList512BytesExtensions.RemoveSwapBack{T,U}"/>
+        /// <remarks>
+        /// A version of <see cref="FixedList512BytesExtensions.RemoveSwapBack{T,U}"/> that is compatible with Enums and readonly references.
+        /// </remarks>
+        public static bool RemoveSwapBack<TEnum, TUnderlying>(this in FixedList512Bytes<TEnum> list, TUnderlying value)
+            where TEnum : unmanaged, Enum
+            where TUnderlying : unmanaged, IEquatable<TUnderlying>
+        {
+            int index = list.IndexOf(value);
+            if (index == -1)
+            {
+                return false;
+            }
+
+            list.RemoveAtSwapBack(index);
+
+            return true;
+        }
+
+        /// <inheritdoc cref="FixedList4096BytesExtensions.RemoveSwapBack{T,U}"/>
+        /// <remarks>
+        /// A version of <see cref="FixedList4096BytesExtensions.RemoveSwapBack{T,U}"/> that is compatible with Enums
+        /// and readonly references.
+        /// </remarks>
+        public static bool RemoveSwapBack<TEnum, TUnderlying>(this in FixedList4096Bytes<TEnum> list, TUnderlying value)
+            where TEnum : unmanaged, Enum
+            where TUnderlying : unmanaged, IEquatable<TUnderlying>
+        {
+            int index = list.IndexOf(value);
+            if (index == -1)
+            {
+                return false;
+            }
+
+            list.RemoveAtSwapBack(index);
+
+            return true;
+        }
     }
 }

--- a/Scripts/Runtime/Data/Collections/Util/FixedListExtension.cs
+++ b/Scripts/Runtime/Data/Collections/Util/FixedListExtension.cs
@@ -1,0 +1,58 @@
+using Anvil.Unity.Collections;
+using System;
+using Unity.Collections;
+using Unity.Collections.LowLevel.Unsafe;
+
+namespace Anvil.Unity.DOTS.Data
+{
+    /// <summary>
+    /// A collection of extension methods for <see cref="FixedList32Bytes{T}"/> (and friends).
+    /// </summary>
+    public static class FixedListExtension
+    {
+        /// <inheritdoc cref="FixedList32BytesExtensions.IndexOf{T,U}"/>
+        /// <remarks>
+        /// A version of <see cref="FixedList32BytesExtensions.IndexOf{T,U}"/> that is compatible with readonly references.
+        /// </remarks>
+        public static int IndexOfReadOnly<T, U>(this in FixedList32Bytes<T> list, U value) where T : unmanaged, IEquatable<U>
+        {
+            return UnsafeUtilityExtensions.AsRef(list).IndexOf(value);
+        }
+
+        /// <inheritdoc cref="FixedList64BytesExtensions.IndexOf{T,U}"/>
+        /// <remarks>
+        /// A version of <see cref="FixedList64BytesExtensions.IndexOf{T,U}"/> that is compatible with readonly references.
+        /// </remarks>
+        public static int IndexOfReadOnly<T, U>(this in FixedList64Bytes<T> list, U value) where T : unmanaged, IEquatable<U>
+        {
+            return UnsafeUtilityExtensions.AsRef(list).IndexOf(value);
+        }
+
+        /// <inheritdoc cref="FixedList128BytesExtensions.IndexOf{T,U}"/>
+        /// <remarks>
+        /// A version of <see cref="FixedList128BytesExtensions.IndexOf{T,U}"/> that is compatible with readonly references.
+        /// </remarks>
+        public static int IndexOfReadOnly<T, U>(this in FixedList128Bytes<T> list, U value) where T : unmanaged, IEquatable<U>
+        {
+            return UnsafeUtilityExtensions.AsRef(list).IndexOf(value);
+        }
+
+        /// <inheritdoc cref="FixedList512BytesExtensions.IndexOf{T,U}"/>
+        /// <remarks>
+        /// A version of <see cref="FixedList512BytesExtensions.IndexOf{T,U}"/> that is compatible with readonly references.
+        /// </remarks>
+        public static int IndexOfReadOnly<T, U>(this in FixedList512Bytes<T> list, U value) where T : unmanaged, IEquatable<U>
+        {
+            return UnsafeUtilityExtensions.AsRef(list).IndexOf(value);
+        }
+
+        /// <inheritdoc cref="FixedList4096BytesExtensions.IndexOf{T,U}"/>
+        /// <remarks>
+        /// A version of <see cref="FixedList4096BytesExtensions.IndexOf{T,U}"/> that is compatible with readonly references.
+        /// </remarks>
+        public static int IndexOfReadOnly<T, U>(this in FixedList4096Bytes<T> list, U value) where T : unmanaged, IEquatable<U>
+        {
+            return UnsafeUtilityExtensions.AsRef(list).IndexOf(value);
+        }
+    }
+}

--- a/Scripts/Runtime/Data/Collections/Util/FixedListExtension.cs.meta
+++ b/Scripts/Runtime/Data/Collections/Util/FixedListExtension.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 9f39a3b5b71840bcbd68cd95b1ad9e54
+timeCreated: 1680897587


### PR DESCRIPTION
Add extension methods for FixedList implementations
 - `ContainsReadOnly`
 - `IndexOfReadOnly`
 - `RemoveSwapBack<T> where T : enum`

### What is the current behaviour?

FixedList only contains `IndexOf` and `Contains` implementations that take `ref` arguments. This is not usable when trying to call these methods in a read only context (`readonly` struct or `[ReadOnly]` attribute).

There is no way to call `RemoveSwapBack` when the fixed list contains elements of type `enum`

### What is the new behaviour?

Developers can use `IndexOfReadOnly` and `ContainsReadOnly` on read-only references to their collections.

`RemoveSwapBack` can now be used if the elements of the list are of type `enum` so long as they cast their enum value down to its underlying type. Under the hood, this uses the existing Anvil `FixedListInternal` extension methods that allow IndexOf and Contains to be used on enum elements. (#175)

### What issues does this resolve?
 - None

### What PRs does this depend on?
 - None

### Does this introduce a breaking change?
 - [ ] Yes <!-- If so, what are the migration considerations? -->
 - [x] No
