### PR TITLE
EntityPersistentData Reader/Writer - Add Count and IsEmpty

### DIFF
--- a/Scripts/Runtime/Entities/TaskDriver/TaskSet/TaskData/JobDataInteraction/EntityPersistentDataReader.cs
+++ b/Scripts/Runtime/Entities/TaskDriver/TaskSet/TaskData/JobDataInteraction/EntityPersistentDataReader.cs
@@ -10,16 +10,11 @@ namespace Anvil.Unity.DOTS.Entities.TaskDriver
     /// </summary>
     /// <typeparam name="TData">They type of <see cref="IEntityPersistentDataInstance"/> to read</typeparam>
     [BurstCompatible]
-    public readonly struct EntityPersistentDataReader<TData> 
+    public readonly struct EntityPersistentDataReader<TData>
         where TData : struct, IEntityPersistentDataInstance
     {
         [ReadOnly] private readonly UnsafeParallelHashMap<Entity, TData> m_Lookup;
 
-        internal EntityPersistentDataReader(ref UnsafeParallelHashMap<Entity, TData> lookup)
-        {
-            m_Lookup = lookup;
-        }
-        
         /// <summary>
         /// Gets the <typeparamref name="TData"/> for the specified <see cref="Entity"/>.
         /// </summary>
@@ -43,6 +38,11 @@ namespace Anvil.Unity.DOTS.Entities.TaskDriver
         public int Count
         {
             get => m_Lookup.Count();
+        }
+
+        internal EntityPersistentDataReader(ref UnsafeParallelHashMap<Entity, TData> lookup)
+        {
+            m_Lookup = lookup;
         }
     }
 }

--- a/Scripts/Runtime/Entities/TaskDriver/TaskSet/TaskData/JobDataInteraction/EntityPersistentDataReader.cs
+++ b/Scripts/Runtime/Entities/TaskDriver/TaskSet/TaskData/JobDataInteraction/EntityPersistentDataReader.cs
@@ -28,5 +28,21 @@ namespace Anvil.Unity.DOTS.Entities.TaskDriver
         {
             get => m_Lookup[entity];
         }
+
+        /// <summary>
+        /// Returns whether the persistent data has no entries.
+        /// </summary>
+        public bool IsEmpty
+        {
+            get => m_Lookup.IsEmpty;
+        }
+
+        /// <summary>
+        /// Returns the number of entries currently stored in persistent data.
+        /// </summary>
+        public int Count
+        {
+            get => m_Lookup.Count();
+        }
     }
 }

--- a/Scripts/Runtime/Entities/TaskDriver/TaskSet/TaskData/JobDataInteraction/EntityPersistentDataWriter.cs
+++ b/Scripts/Runtime/Entities/TaskDriver/TaskSet/TaskData/JobDataInteraction/EntityPersistentDataWriter.cs
@@ -26,6 +26,21 @@ namespace Anvil.Unity.DOTS.Entities.TaskDriver
             set => m_Lookup[entity] = value;
         }
 
+        /// <summary>
+        /// Returns whether the persistent data has no entries.
+        /// </summary>
+        public bool IsEmpty
+        {
+            get => m_Lookup.IsEmpty;
+        }
+
+        /// <summary>
+        /// Returns the number of entries currently stored in persistent data.
+        /// </summary>
+        public int Count
+        {
+            get => m_Lookup.Count();
+        }
 
         internal EntityPersistentDataWriter(ref UnsafeParallelHashMap<Entity, TData> lookup)
         {


### PR DESCRIPTION
Add `IsEmpty` and `Count` to the `EntityPersistentDataReader` and `EntityPersistentDataWriter`

### What is the current behaviour?

Though unusual, there is now way to check the number of elements in an Entity Persisten Data instance.

### What is the new behaviour?

`IsEmpty` and `Count` getters are now passed through from the underlying collection.

### What issues does this resolve?
 - None

### What PRs does this depend on?
<!-- List PRs in other repos that need to be merged before this one -->
 - None

### Does this introduce a breaking change?
 - [ ] Yes <!-- If so, what are the migration considerations? -->
 - [x] No
