### PR TITLE
CDFE and DBFE writers - Disable safety and document issue

### DIFF
--- a/Scripts/Runtime/Entities/Data/CDFEWriter.cs
+++ b/Scripts/Runtime/Entities/Data/CDFEWriter.cs
@@ -20,6 +20,8 @@ namespace Anvil.Unity.DOTS.Entities
     [BurstCompatible]
     public struct CDFEWriter<T> where T : struct, IComponentData
     {
+        // TODO: #197 - Improve Safety. Currently unable to detect parallel writing from multiple jobs.
+        // Required to allow JobPart patterns
         [NativeDisableContainerSafetyRestriction] [NativeDisableParallelForRestriction]
         private ComponentDataFromEntity<T> m_CDFE;
 


### PR DESCRIPTION
Disable container safety restriction on CDFE and DBFE writers.

### What is the current behaviour?

Using the JobPart pattern there are cases when a single job instance will have both readers and writers of CDFE or DBFE instances. Unity's safety system flags this as an issue since it thinks they are two separate jobs with concurrent read and write access.

### What is the new behaviour?

Unity's safety system is disabled for the CDFE and DBFE writers. This is a temporary work around until #197 can be addressed.

In the meantime you're on your own to ensure you're not reading and writing to component data at the same time.

### What issues does this resolve?
 - None

### What PRs does this depend on?
<!-- List PRs in other repos that need to be merged before this one -->
 - #201 

### Does this introduce a breaking change?
 - [ ] Yes <!-- If so, what are the migration considerations? -->
 - [x] No
