### PR TITLE
Add Methods to DBFE Reader and Writer

### DIFF
--- a/Scripts/Runtime/Entities/Data/DBFEForExclusiveWrite.cs
+++ b/Scripts/Runtime/Entities/Data/DBFEForExclusiveWrite.cs
@@ -29,5 +29,11 @@ namespace Anvil.Unity.DOTS.Entities
         {
             get => m_DBFE[entity];
         }
+
+        /// <inheritdoc cref="BufferFromEntity{T}.HasComponent"/>
+        public bool HasComponent(Entity entity) => m_DBFE.HasComponent(entity);
+
+        /// <inheritdoc cref="BufferFromEntity{T}.TryGetComponent"/>
+        public bool TryGetBuffer(Entity entity, out DynamicBuffer<T> component) => m_DBFE.TryGetBuffer(entity, out component);
     }
 }

--- a/Scripts/Runtime/Entities/Data/DBFEForRead.cs
+++ b/Scripts/Runtime/Entities/Data/DBFEForRead.cs
@@ -27,5 +27,11 @@ namespace Anvil.Unity.DOTS.Entities
         {
             get => m_DBFE[entity];
         }
+
+        /// <inheritdoc cref="BufferFromEntity{T}.HasComponent"/>
+        public bool HasComponent(Entity entity) => m_DBFE.HasComponent(entity);
+
+        /// <inheritdoc cref="BufferFromEntity{T}.TryGetComponent"/>
+        public bool TryGetBuffer(Entity entity, out DynamicBuffer<T> component) => m_DBFE.TryGetBuffer(entity, out component);
     }
 }


### PR DESCRIPTION
Add `HasComponent` and `TryGetBuffer` to `DBFEForExclusiveWrite` and `DBFEForRead`

### What is the current behaviour?

There is no access to these common DBFE methods.

### What is the new behaviour?

There is now access to these DBFE methods.

### What issues does this resolve?
 - None

### What PRs does this depend on?
<!-- List PRs in other repos that need to be merged before this one -->
 - #201

### Does this introduce a breaking change?
 - [ ] Yes <!-- If so, what are the migration considerations? -->
 - [x] No
