### PR TITLE
IResolvableJobConfigRequirements - AddRequirementsFrom

### DIFF
--- a/Scripts/Runtime/Entities/TaskDriver/TaskSet/Job/JobConfig/AbstractResolvableJobConfig.cs
+++ b/Scripts/Runtime/Entities/TaskDriver/TaskSet/Job/JobConfig/AbstractResolvableJobConfig.cs
@@ -44,6 +44,12 @@ namespace Anvil.Unity.DOTS.Entities.TaskDriver
             return this;
         }
 
+        public IResolvableJobConfigRequirements AddRequirementsFrom<T>(T taskDriver, IResolvableJobConfigRequirements.ConfigureJobRequirementsDelegate<T> configureRequirements)
+            where T : AbstractTaskDriver
+        {
+            return configureRequirements(taskDriver, this);
+        }
+
         //*************************************************************************************************************
         // HARDEN
         //*************************************************************************************************************

--- a/Scripts/Runtime/Entities/TaskDriver/TaskSet/Job/JobConfig/Interface/IResolvableJobConfigRequirements.cs
+++ b/Scripts/Runtime/Entities/TaskDriver/TaskSet/Job/JobConfig/Interface/IResolvableJobConfigRequirements.cs
@@ -6,6 +6,9 @@ namespace Anvil.Unity.DOTS.Entities.TaskDriver
     /// </summary>
     public interface IResolvableJobConfigRequirements : IJobConfig
     {
+        public delegate IResolvableJobConfigRequirements ConfigureJobRequirementsDelegate<in T>(T taskDriver, IResolvableJobConfigRequirements jobConfig)
+            where T : AbstractTaskDriver;
+
         /// <summary>
         /// Requires a specific type of data that the job can resolve itself into.
         /// </summary>
@@ -13,5 +16,8 @@ namespace Anvil.Unity.DOTS.Entities.TaskDriver
         /// <returns>A reference to itself to continue chaining configuration methods</returns>
         public IResolvableJobConfigRequirements RequireResolveTarget<TResolveTargetType>()
             where TResolveTargetType : unmanaged, IEntityProxyInstance;
+
+        IResolvableJobConfigRequirements AddRequirementsFrom<T>(T taskDriver, ConfigureJobRequirementsDelegate<T> configureRequirements)
+            where T : AbstractTaskDriver;
     }
 }

--- a/Scripts/Runtime/Entities/TaskDriver/TaskSet/Job/JobConfig/NoOpJobConfig.cs
+++ b/Scripts/Runtime/Entities/TaskDriver/TaskSet/Job/JobConfig/NoOpJobConfig.cs
@@ -122,5 +122,11 @@ namespace Anvil.Unity.DOTS.Entities.TaskDriver
         {
             return configureRequirements(taskDriver, this);
         }
+
+        public IResolvableJobConfigRequirements AddRequirementsFrom<T>(T taskDriver, IResolvableJobConfigRequirements.ConfigureJobRequirementsDelegate<T> configureRequirements)
+            where T : AbstractTaskDriver
+        {
+            return configureRequirements(taskDriver, this);
+        }
     }
 }


### PR DESCRIPTION
Add an `AddRequirementsFrom` overload to `IResolvableJobConfigRequirements` to match the capabilities of IJobConfig

### What is the current behaviour?

There is no way to use the `AddRequirementsFrom` to help set the requirements on an `IResolvableJobConfigRequirements` instance.

### What is the new behaviour?

`AddRequirementsFrom` may be used on `IResolvableJobConfigRequirements` now. With the appropriate delegate parameters.

### What issues does this resolve?
 - None

### What PRs does this depend on?
 - None

### Does this introduce a breaking change?
 - [ ] Yes <!-- If so, what are the migration considerations? -->
 - [x] No
