### PR TITLE
EntityPersistentDataReader - Add Contains and TryGet

### DIFF
--- a/Scripts/Runtime/Entities/TaskDriver/TaskSet/TaskData/JobDataInteraction/EntityPersistentDataReader.cs
+++ b/Scripts/Runtime/Entities/TaskDriver/TaskSet/TaskData/JobDataInteraction/EntityPersistentDataReader.cs
@@ -42,6 +42,12 @@ namespace Anvil.Unity.DOTS.Entities.TaskDriver
         /// <inheritdoc cref="UnsafeParallelHashMap{TKey,TValue}.Count"/>
         public int Count() => m_Lookup.Count();
 
+        /// <inheritdoc cref="UnsafeParallelHashMap{TKey,TValue}.TryGetValue"/>
+        public bool TryGet(Entity entity, out TData data) => m_Lookup.TryGetValue(entity, out data);
+
+        /// <inheritdoc cref="UnsafeParallelHashMap{TKey,TValue}.ContainsKey"/>
+        public bool Contains(Entity entity) => m_Lookup.ContainsKey(entity);
+
         /// <inheritdoc cref="UnsafeParallelHashMap{TKey,TValue}.GetKeyArray"/>>
         public NativeArray<Entity> GetKeyArray(AllocatorManager.AllocatorHandle allocator)
         {


### PR DESCRIPTION
Add `Contains` and `TryGet` methods to `EntityPersistentDataReader`.
(EntityPersistentDataWriter already has them.)

### What is the current behaviour?

`Contains` and `TryGet` methods are missing from `EntityPersistentDataReader`.

### What is the new behaviour?

`Contains` and `TryGet` methods are present in `EntityPersistentDataReader`.

### What issues does this resolve?
 - None

### What PRs does this depend on?
 - None

### Does this introduce a breaking change?
 - [ ] Yes <!-- If so, what are the migration considerations? -->
 - [x] No
