### PR TITLE
Adapt EntitySpawner to be ACV compatible

### DIFF
--- a/Scripts/Runtime/Entities/Lifecycle/Spawner/IEntitySpawner.cs
+++ b/Scripts/Runtime/Entities/Lifecycle/Spawner/IEntitySpawner.cs
@@ -1,4 +1,5 @@
 using Anvil.CSharp.Core;
+using System;
 using Unity.Entities;
 using Unity.Jobs;
 
@@ -6,6 +7,8 @@ namespace Anvil.Unity.DOTS.Entities
 {
     internal interface IEntitySpawner : IAnvilDisposable
     {
+        internal event Action<IEntitySpawner> OnPendingWorkAdded;
+
         public JobHandle Schedule(
             JobHandle dependsOn,
             ref EntityCommandBuffer ecb);


### PR DESCRIPTION
The entity spawning feature has been adapted to conform to the `ISharedWriteAccessControlledValue` interface. This makes for easy inclusion in TaskDriver jobs that require entity spawning.

### What is the current behaviour?

In a `TaskDriver`, to gain access to an `EntitySpawnWriter` the developer must manually acquire and pass the writer into their job through a custom the scheduling delegate. This is painful.

### What is the new behaviour?

Developers can now include `EntitySpawnWriter`s in their `TaskDriver` jobs with a convenient `RequireGenericDataForWrite(EntitySpawner)` call.

As part of this work `EntitySpawner` is now a public type. Since developers may hold reference to the spawner rather than calling `GetSpawner<T>` every frame the mechanism for marking a spawner for update needed to be updated. `EntitySpawner` now emits an event indicating that it has pending work to schedule instead of having EntitySpawnSystem track that dirty state.

### What issues does this resolve?
<!-- None is a perfectly valid answer -->

### What PRs does this depend on?
 - #216 

### Does this introduce a breaking change?
 - [x] Yes <!-- If so, what are the migration considerations? -->
 - [ ] No

#### Migration
`EntitySpawnSystem.AcquireEntitySpawnWriterAsync<DefinitionType>(out var value)` -> `EntitySpawnSystem.GetSpawner<DefinitionType>.AcquireSharedWriteAsync(out var value)`

`EntitySpawnSystem.ReleaseEntitySpawnWriterAsync(JobHandle)` -> `EntitySpawnSystem.GetSpawner<DefinitionType>.ReleaseAsync(JobHandle)`