### PR TITLE
Adding extensions to get elements as refs from Arrays

### DIFF
--- a/Scripts/Runtime/Data/Collections/Util/NativeArrayExtension.cs
+++ b/Scripts/Runtime/Data/Collections/Util/NativeArrayExtension.cs
@@ -11,6 +11,29 @@ namespace Anvil.Unity.DOTS.Data
     public static class NativeArrayExtension
     {
         /// <summary>
+        /// Returns a reference to the element at a given index.
+        /// </summary>
+        /// <param name="nativeArray">The <see cref="NativeArray{T}"/></param>
+        /// <param name="index">The index to access. Must be in the range of [0..Length).</param>
+        /// <returns>A reference to the element at the index.</returns>
+        public static unsafe ref T ElementAt<T>(this NativeArray<T> nativeArray, int index) where T : unmanaged
+        {
+            Debug.Assert(index >= 0 && index < nativeArray.Length);
+            return ref UnsafeUtility.ArrayElementAsRef<T>(nativeArray.GetUnsafePtr(), index);
+        }
+        
+        /// <summary>
+        /// Returns a read only reference to the element at a given index.
+        /// </summary>
+        /// <param name="nativeArray">The <see cref="NativeArray{T}"/></param>
+        /// <param name="index">The index to access. Must be in the range of [0..Length).</param>
+        /// <returns>A reference to the element at the index.</returns>
+        public static ref readonly T ElementAtReadOnly<T>(this NativeArray<T> nativeArray, int index) where T : unmanaged
+        {
+            return ref nativeArray.ElementAt(index);
+        }
+        
+        /// <summary>
         /// Sets all elements in a collection to their default value.
         /// </summary>
         /// <typeparam name="T">The element type of the collection.</typeparam>

--- a/Scripts/Runtime/Data/Collections/Util/UnsafeArrayExtension.cs
+++ b/Scripts/Runtime/Data/Collections/Util/UnsafeArrayExtension.cs
@@ -1,0 +1,34 @@
+using Unity.Collections.LowLevel.Unsafe;
+using UnityEngine;
+
+namespace Anvil.Unity.DOTS.Data
+{
+    /// <summary>
+    /// Extension methods for use with a <see cref="UnsafeArray{T}"/> instance.
+    /// </summary>
+    public static class UnsafeArrayExtension
+    {
+        /// <summary>
+        /// Returns a reference to the element at a given index.
+        /// </summary>
+        /// <param name="unsafeArray">The <see cref="UnsafeArray{T}"/></param>
+        /// <param name="index">The index to access. Must be in the range of [0..Length).</param>
+        /// <returns>A reference to the element at the index.</returns>
+        public static unsafe ref T ElementAt<T>(this UnsafeArray<T> unsafeArray, int index) where T : unmanaged
+        {
+            Debug.Assert(index >= 0 && index < unsafeArray.Length);
+            return ref UnsafeUtility.ArrayElementAsRef<T>(unsafeArray.GetUnsafePtr(), index);
+        }
+        
+        /// <summary>
+        /// Returns a read only reference to the element at a given index.
+        /// </summary>
+        /// <param name="unsafeArray">The <see cref="UnsafeArray{T}"/></param>
+        /// <param name="index">The index to access. Must be in the range of [0..Length).</param>
+        /// <returns>A reference to the element at the index.</returns>
+        public static ref readonly T ElementAtReadOnly<T>(this UnsafeArray<T> unsafeArray, int index) where T : unmanaged
+        {
+            return ref unsafeArray.ElementAt(index);
+        }
+    }
+}

--- a/Scripts/Runtime/Data/Collections/Util/UnsafeArrayExtension.cs.meta
+++ b/Scripts/Runtime/Data/Collections/Util/UnsafeArrayExtension.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 706d4f937d394af3a0342fa051e66b6d
+timeCreated: 1681932080


### PR DESCRIPTION
Adding similar methods to `UnsafeArray` and `NativeArray` as were already contained on `UnsafeList` and `DynamicBufferExtension`

### What is the current behaviour?

- We didn't have these methods.

### What is the new behaviour?

- Now we do.

### What issues does this resolve?
 - None

### What PRs does this depend on?
 - None

### Does this introduce a breaking change?
 - [ ] Yes
 - [x] No
