### PR TITLE
EntitySpawner - Fix burst errors

### DIFF
--- a/Scripts/Runtime/Entities/Lifecycle/EntitySpawnSystem.cs
+++ b/Scripts/Runtime/Entities/Lifecycle/EntitySpawnSystem.cs
@@ -112,11 +112,17 @@ namespace Anvil.Unity.DOTS.Entities
             // ReSharper disable once InvertIf
             if (!m_EntitySpawners.TryGetValue(definitionType, out IEntitySpawner entitySpawner))
             {
-                entitySpawner = new EntitySpawner<TEntitySpawnDefinition>(
-                    EntityManager,
-                    m_EntityArchetypes,
-                    m_EntityPrototypes,
-                    EntitySpawnSystemReflectionHelper.SHOULD_DISABLE_BURST_LOOKUP[definitionType]);
+                // TODO: #86 - When upgrading to Entities 1.0 we can use an unmanaged shared component which will let us
+                // TODO:       use burst for all spawners.
+                entitySpawner = EntitySpawnSystemReflectionHelper.SHOULD_DISABLE_BURST_LOOKUP[definitionType]
+                    ? new EntitySpawner<TEntitySpawnDefinition>(
+                        EntityManager,
+                        m_EntityArchetypes,
+                        m_EntityPrototypes)
+                    : new BurstEntitySpawner<TEntitySpawnDefinition>(
+                        EntityManager,
+                        m_EntityArchetypes,
+                        m_EntityPrototypes);
                 entitySpawner.OnPendingWorkAdded += EntitySpawner_OnWriterAcquired;
                 m_EntitySpawners.Add(definitionType, entitySpawner);
             }

--- a/Scripts/Runtime/Entities/Lifecycle/Spawner/BurstEntitySpawner.cs
+++ b/Scripts/Runtime/Entities/Lifecycle/Spawner/BurstEntitySpawner.cs
@@ -1,0 +1,104 @@
+using Anvil.Unity.DOTS.Data;
+using Anvil.Unity.DOTS.Jobs;
+using System;
+using Unity.Burst;
+using Unity.Collections;
+using Unity.Entities;
+using Unity.Jobs;
+
+namespace Anvil.Unity.DOTS.Entities
+{
+    // TODO: #86 - When upgrading to Entities 1.0 we can use an unmanaged shared component which will let us use burst
+    // TODO:       for all spawners. Remove this type and replace NoBurstSpawnJob with SpawnJob in EntitySpawner.
+    public class BurstEntitySpawner<TEntitySpawnDefinition> : EntitySpawner<TEntitySpawnDefinition>
+        where TEntitySpawnDefinition : unmanaged, IEntitySpawnDefinition
+    {
+        internal BurstEntitySpawner(
+            EntityManager entityManager,
+            NativeParallelHashMap<long, EntityArchetype> entityArchetypes,
+            IReadAccessControlledValue<NativeParallelHashMap<long, Entity>> prototypes)
+            : base(
+                entityManager,
+                entityArchetypes,
+                prototypes) { }
+
+        private protected override JobHandle ScheduleSpawnJob(
+            JobHandle dependsOn,
+            UnsafeTypedStream<SpawnDefinitionWrapper<TEntitySpawnDefinition>> spawnDefinitions,
+            EntitySpawnHelper entitySpawnHelper,
+            ref EntityCommandBuffer ecb)
+        {
+            SpawnJob job = new SpawnJob(spawnDefinitions, ref ecb, entitySpawnHelper);
+            return job.Schedule(dependsOn);
+        }
+
+        [BurstCompile]
+        private struct SpawnJob : IJob
+        {
+            [ReadOnly] private UnsafeTypedStream<SpawnDefinitionWrapper<TEntitySpawnDefinition>> m_SpawnDefinitions;
+            [ReadOnly] private readonly EntitySpawnHelper m_EntitySpawnHelper;
+
+            private readonly long m_Hash;
+
+            private EntityCommandBuffer m_ECB;
+
+            public SpawnJob(
+                UnsafeTypedStream<SpawnDefinitionWrapper<TEntitySpawnDefinition>> spawnDefinitions,
+                ref EntityCommandBuffer ecb,
+                in EntitySpawnHelper entitySpawnHelper)
+            {
+                m_SpawnDefinitions = spawnDefinitions;
+                m_ECB = ecb;
+                m_EntitySpawnHelper = entitySpawnHelper;
+
+                m_Hash = BurstRuntime.GetHashCode64<TEntitySpawnDefinition>();
+            }
+
+            public void Execute()
+            {
+                NativeParallelHashSet<Entity> prototypesToDestroy = new NativeParallelHashSet<Entity>(32, Allocator.Temp);
+                foreach (SpawnDefinitionWrapper<TEntitySpawnDefinition> spawnDefinition in m_SpawnDefinitions)
+                {
+                    switch (spawnDefinition.SpawnBehaviour)
+                    {
+                        case PrototypeSpawnBehaviour.None:
+                            CreateEntity(spawnDefinition.EntitySpawnDefinition);
+                            break;
+
+                        case PrototypeSpawnBehaviour.Keep:
+                            InstantiateEntity(spawnDefinition.EntitySpawnDefinition, m_EntitySpawnHelper.GetPrototypeEntityForDefinition(m_Hash));
+                            break;
+
+                        case PrototypeSpawnBehaviour.Destroy:
+                            Entity prototype = m_EntitySpawnHelper.GetPrototypeEntityForDefinition(m_Hash);
+                            prototypesToDestroy.Add(prototype);
+                            InstantiateEntity(spawnDefinition.EntitySpawnDefinition, prototype);
+                            break;
+
+                        default:
+                            throw new ArgumentOutOfRangeException();
+                    }
+                }
+
+                m_SpawnDefinitions.Clear();
+
+                foreach (Entity entity in prototypesToDestroy)
+                {
+                    m_ECB.DestroyEntity(entity);
+                }
+            }
+
+            private void CreateEntity(TEntitySpawnDefinition spawnDefinition)
+            {
+                Entity entity = m_ECB.CreateEntity(m_EntitySpawnHelper.GetEntityArchetypeForDefinition(m_Hash));
+                spawnDefinition.PopulateOnEntity(entity, ref m_ECB, m_EntitySpawnHelper);
+            }
+
+            private void InstantiateEntity(TEntitySpawnDefinition spawnDefinition, Entity prototype)
+            {
+                Entity entity = m_ECB.Instantiate(prototype);
+                spawnDefinition.PopulateOnEntity(entity, ref m_ECB, m_EntitySpawnHelper);
+            }
+        }
+    }
+}

--- a/Scripts/Runtime/Entities/Lifecycle/Spawner/BurstEntitySpawner.cs.meta
+++ b/Scripts/Runtime/Entities/Lifecycle/Spawner/BurstEntitySpawner.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 0199571a357f49eba991ebd5634d6c1e
+timeCreated: 1681937654


### PR DESCRIPTION
Now that projects have references to concrete EntitySpawner types (Ex: `EntitySpawner<MyDefinition>`) the burst compiler is trying to compile the spawn jobs with the incompatible definition types.

This isn't really a problem because we're selecting the correct non burst job at runtime but the error's are annoying.

The burstable entity spawner is now split into a separate type (`BurstEntitySpawner<T>`) that extends `EntitySpawner<T>`. This is a temporary workaround until #86 is resolved.

### What is the current behaviour?

The Burst compiler throws errors when compiling type variants of `EntitySpawner<T>` when the definition sets `ISharedComponentData` on the ECB.

### What is the new behaviour?

The burst compatible components of `EntitySpawner<T>` have been moved into the subclass `BurstEntitySpawner<T>`.

`EntitySpawnSystem` will instantiate the appropriate entity spawner based on the needs of the definition.

### What issues does this resolve?
 - None

### What PRs does this depend on?
<!-- List PRs in other repos that need to be merged before this one -->
 - #220

### Does this introduce a breaking change?
 - [ ] Yes <!-- If so, what are the migration considerations? -->
 - [x] No
