### PR TITLE
IResolvableJobConfigRequirements - Fix warning

### DIFF
--- a/Scripts/Runtime/Entities/TaskDriver/TaskSet/Job/JobConfig/Interface/IResolvableJobConfigRequirements.cs
+++ b/Scripts/Runtime/Entities/TaskDriver/TaskSet/Job/JobConfig/Interface/IResolvableJobConfigRequirements.cs
@@ -21,7 +21,7 @@ namespace Anvil.Unity.DOTS.Entities.TaskDriver
         /// A reference to the <see cref="IResolvableJobConfigRequirements"/> instance passed in to continue chaining
         /// configuration methods.
         /// </returns>
-        public delegate IResolvableJobConfigRequirements ConfigureJobRequirementsDelegate<in T>(T taskDriver, IResolvableJobConfigRequirements jobConfig)
+        public new delegate IResolvableJobConfigRequirements ConfigureJobRequirementsDelegate<in T>(T taskDriver, IResolvableJobConfigRequirements jobConfig)
             where T : AbstractTaskDriver;
 
         /// <summary>


### PR DESCRIPTION
Fix warning in `IResolvableJobConfigRequirements` that `ConfigureJobRequirementsDelegate` was hiding the same delegate name in `IJobConfig`

### What is the current behaviour?

The compiler would emit a warning that `ConfigureJobRequirementsDelegate` was being hidden.

### What is the new behaviour?

Added the `new` keyword so the warning is no longer emitted.

### What issues does this resolve?
 - None

### What PRs does this depend on?
 - None

### Does this introduce a breaking change?
 - [ ] Yes <!-- If so, what are the migration considerations? -->
 - [x] No
