### PR TITLE
ComponentTypeDependencyExtension - Add

### DIFF
--- a/Scripts/AssemblyInjections/Unity.Entities/ComponentTypeDependencyExtension.cs
+++ b/Scripts/AssemblyInjections/Unity.Entities/ComponentTypeDependencyExtension.cs
@@ -1,0 +1,171 @@
+using Unity.Collections;
+using Unity.Collections.LowLevel.Unsafe;
+using Unity.Entities;
+using Unity.Jobs;
+using UnityEngine;
+
+/// <summary>
+/// A collection of extension methods to help calculate the scheduling dependencies on <see cref="ComponentType"/>s.
+/// </summary>
+[BurstCompatible]
+public static class ComponentTypeDependencyExtension
+{
+    private static UnsafeList<int> s_WriteTypeList_ScratchPad = new UnsafeList<int>(0, Allocator.Persistent);
+    private static UnsafeList<int> s_ReadTypeList_ScratchPad = new UnsafeList<int>(0, Allocator.Persistent);
+
+    /// <summary>
+    /// Get the dependency of an individual component type.
+    /// Useful for scheduling jobs that depend on components out of band with a system's
+    /// <see cref="ComponentSystemBase.OnUpdate"/>.
+    /// </summary>
+    /// <param name="manager"> The <see cref="World"/>'s <see cref="EntityManager"/>.</param>
+    /// <param name="component">The component type to get the dependency of.</param>
+    /// <returns>The dependency for the component type</returns>
+    public static unsafe JobHandle GetDependency(this EntityManager manager, ComponentType componentType)
+    {
+        return GetDependency(manager.GetUncheckedEntityDataAccess()->DependencyManager, componentType);
+    }
+
+    /// <summary>
+    /// Get the combined dependency of a collection of component types.
+    /// Useful for scheduling jobs that depend on components out of band with a system's
+    /// <see cref="ComponentSystemBase.OnUpdate"/>.
+    /// </summary>
+    /// <param name="manager"> The <see cref="World"/>'s <see cref="EntityManager"/>.</param>
+    /// <param name="component">The component types to calculate the dependency of.</param>
+    /// <returns>The combined dependency for the component types</returns>
+    [NotBurstCompatible]
+    public static unsafe JobHandle GetDependency(this EntityManager manager, params ComponentType[] componentTypes)
+    {
+        return GetDependency(manager.GetUncheckedEntityDataAccess()->DependencyManager, componentTypes);
+    }
+
+    /// <summary>
+    /// Get the combined dependency of a collection of component types.
+    /// Useful for scheduling jobs that depend on components out of band with a system's
+    /// <see cref="ComponentSystemBase.OnUpdate"/>.
+    /// </summary>
+    /// <param name="manager"> The <see cref="World"/>'s <see cref="EntityManager"/>.</param>
+    /// <param name="component">The component types to calculate the dependency of.</param>
+    /// <returns>The combined dependency for the component types</returns>
+    public static unsafe JobHandle GetDependency(this EntityManager manager, NativeArray<ComponentType> componentTypes)
+    {
+        return GetDependency(manager.GetUncheckedEntityDataAccess()->DependencyManager, componentTypes);
+    }
+
+    /// <summary>
+    /// Get the dependency of an individual component type.
+    /// Useful for scheduling jobs out of band with a system's <see cref="ComponentSystemBase.OnUpdate"/>.
+    /// </summary>
+    /// <param name="system">
+    /// The system running the out of band job. If not in a system use the <see cref="EntityManager"/> extension instead.
+    /// </param>
+    /// <param name="component">The component type to get the dependency of.</param>
+    /// <returns>The dependency for the component type</returns>
+    public static unsafe JobHandle GetDependency(this ComponentSystemBase system, ComponentType componentType)
+    {
+        return GetDependency(system.CheckedState()->m_DependencyManager, componentType);
+    }
+
+    /// <summary>
+    /// Get the combined dependency of a collection of component types.
+    /// Useful for scheduling jobs out of band with a system's <see cref="ComponentSystemBase.OnUpdate"/>.
+    /// </summary>
+    /// <param name="system">
+    /// The system running the out of band job. If not in a system use the <see cref="EntityManager"/> extension instead.
+    /// </param>
+    /// <param name="component">The component types to calculate the dependency of.</param>
+    /// <returns>The combined dependency for the component types</returns>
+    [NotBurstCompatible]
+    public static unsafe JobHandle GetDependency(this ComponentSystemBase system, params ComponentType[] componentTypes)
+    {
+        return GetDependency(system.CheckedState()->m_DependencyManager, componentTypes);
+    }
+
+    /// <summary>
+    /// Get the combined dependency of a collection of component types.
+    /// Useful for scheduling jobs out of band with a system's <see cref="ComponentSystemBase.OnUpdate"/>.
+    /// </summary>
+    /// <param name="system">
+    /// The system running the out of band job. If not in a system use the <see cref="EntityManager"/> extension instead.
+    /// </param>
+    /// <param name="component">The component types to calculate the dependency of.</param>
+    /// <returns>The combined dependency for the component types</returns>
+    public static unsafe JobHandle GetDependency(this ComponentSystemBase system, NativeArray<ComponentType> componentTypes)
+    {
+        return GetDependency(system.CheckedState()->m_DependencyManager, componentTypes);
+    }
+
+    /// <summary>
+    /// Get the dependency of an individual component type.
+    /// Useful for scheduling jobs out of band with a system's <see cref="ComponentSystemBase.OnUpdate"/>.
+    /// </summary>
+    /// <param name="system">
+    /// The system running the out of band job. If not in a system use the <see cref="EntityManager"/> extension instead.
+    /// </param>
+    /// <param name="componentType">The component type to get the dependency of.</param>
+    /// <returns>The dependency for the component type</returns>
+    private static unsafe JobHandle GetDependency(ComponentDependencyManager* dependencyManager, ComponentType componentType)
+    {
+        Debug.Assert(componentType.AccessModeType is ComponentType.AccessMode.ReadOnly or ComponentType.AccessMode.ReadWrite);
+
+        // Micro-optimization
+        // Since we're ony dealing with one component we can skip building a list.
+        //  1. Get the pointer to the one type index.
+        //  2. Use the pointer for both the reader and writer parameters
+        //  3. Calculate the reader/writer count based on the component type's access mode.
+        int* typeIndexPtr = (int*)UnsafeUtility.AddressOf(ref componentType.TypeIndex);
+        int writerCount = componentType.AccessModeType == ComponentType.AccessMode.ReadWrite ? 1 : 0;
+        int readerCount = 1 - writerCount;
+
+        return dependencyManager
+            ->GetDependency(typeIndexPtr, readerCount, typeIndexPtr, writerCount);
+    }
+
+    /// <summary>
+    /// Get the combined dependency of a collection of component types.
+    /// Useful for scheduling jobs out of band with a system's <see cref="ComponentSystemBase.OnUpdate"/>.
+    /// </summary>
+    /// <param name="system">
+    /// The system running the out of band job. If not in a system use the <see cref="EntityManager"/> extension instead.
+    /// </param>
+    /// <param name="component">The component types to calculate the dependency of.</param>
+    /// <returns>The combined dependency for the component types</returns>
+    [NotBurstCompatible]
+    private static unsafe JobHandle GetDependency(ComponentDependencyManager* dependencyManager, ComponentType[] componentTypes)
+    {
+        s_WriteTypeList_ScratchPad.Clear();
+        s_ReadTypeList_ScratchPad.Clear();
+
+        foreach (ComponentType componentType in componentTypes)
+        {
+            CalculateReaderWriterDependency.Add(componentType, ref s_ReadTypeList_ScratchPad, ref s_WriteTypeList_ScratchPad);
+        }
+
+        return dependencyManager
+            ->GetDependency(s_ReadTypeList_ScratchPad.Ptr, s_ReadTypeList_ScratchPad.Length, s_WriteTypeList_ScratchPad.Ptr, s_WriteTypeList_ScratchPad.Length);
+    }
+
+    /// <summary>
+    /// Get the combined dependency of a collection of component types.
+    /// Useful for scheduling jobs out of band with a system's <see cref="ComponentSystemBase.OnUpdate"/>.
+    /// </summary>
+    /// <param name="system">
+    /// The system running the out of band job. If not in a system use the <see cref="EntityManager"/> extension instead.
+    /// </param>
+    /// <param name="component">The component types to calculate the dependency of.</param>
+    /// <returns>The combined dependency for the component types</returns>
+    private static unsafe JobHandle GetDependency(ComponentDependencyManager* dependencyManager, NativeArray<ComponentType> componentTypes)
+    {
+        s_WriteTypeList_ScratchPad.Clear();
+        s_ReadTypeList_ScratchPad.Clear();
+
+        foreach (ComponentType componentType in componentTypes)
+        {
+            CalculateReaderWriterDependency.Add(componentType, ref s_ReadTypeList_ScratchPad, ref s_WriteTypeList_ScratchPad);
+        }
+
+        return dependencyManager
+            ->GetDependency(s_ReadTypeList_ScratchPad.Ptr, s_ReadTypeList_ScratchPad.Length, s_WriteTypeList_ScratchPad.Ptr, s_WriteTypeList_ScratchPad.Length);
+    }
+}

--- a/Scripts/AssemblyInjections/Unity.Entities/ComponentTypeDependencyExtension.cs
+++ b/Scripts/AssemblyInjections/Unity.Entities/ComponentTypeDependencyExtension.cs
@@ -34,7 +34,7 @@ public static class ComponentTypeDependencyExtension
     /// <returns>The dependency for the component types</returns>
     public static unsafe JobHandle GetDependency(this EntityManager manager, ComponentType componentType)
     {
-        return GetDependency(manager.GetUncheckedEntityDataAccess()->DependencyManager, componentType);
+        return GetDependency(manager.GetCheckedEntityDataAccess()->DependencyManager, componentType);
     }
 
     /// <summary>
@@ -48,7 +48,7 @@ public static class ComponentTypeDependencyExtension
     [NotBurstCompatible]
     public static unsafe JobHandle GetDependency(this EntityManager manager, params ComponentType[] componentTypes)
     {
-        return GetDependency(manager.GetUncheckedEntityDataAccess()->DependencyManager, componentTypes);
+        return GetDependency(manager.GetCheckedEntityDataAccess()->DependencyManager, componentTypes);
     }
 
     /// <summary>
@@ -64,7 +64,7 @@ public static class ComponentTypeDependencyExtension
     public static unsafe JobHandle GetDependency<T>(this EntityManager manager, T componentTypes)
         where T : class, IEnumerable<ComponentType>
     {
-        return GetDependency(manager.GetUncheckedEntityDataAccess()->DependencyManager, componentTypes);
+        return GetDependency(manager.GetCheckedEntityDataAccess()->DependencyManager, componentTypes);
     }
 
     /// <summary>
@@ -77,7 +77,7 @@ public static class ComponentTypeDependencyExtension
     /// <returns>The combined dependency for the component types</returns>
     public static unsafe JobHandle GetDependency(this EntityManager manager, ref NativeArray<ComponentType> componentTypes)
     {
-        return GetDependency(manager.GetUncheckedEntityDataAccess()->DependencyManager, ref componentTypes);
+        return GetDependency(manager.GetCheckedEntityDataAccess()->DependencyManager, ref componentTypes);
     }
 
     /// <summary>
@@ -89,7 +89,7 @@ public static class ComponentTypeDependencyExtension
     /// <returns>The dependency for the component type</returns>
     public static unsafe JobHandle GetDependency(this ComponentType componentType, EntityManager manager)
     {
-        return GetDependency(manager.GetUncheckedEntityDataAccess()->DependencyManager, componentType);
+        return GetDependency(manager.GetCheckedEntityDataAccess()->DependencyManager, componentType);
     }
 
     /// <summary>
@@ -104,7 +104,7 @@ public static class ComponentTypeDependencyExtension
     public static unsafe JobHandle GetDependency<T>(this T componentTypes, EntityManager manager)
         where T : class, IEnumerable<ComponentType>
     {
-        return GetDependency(manager.GetUncheckedEntityDataAccess()->DependencyManager, componentTypes);
+        return GetDependency(manager.GetCheckedEntityDataAccess()->DependencyManager, componentTypes);
     }
 
     /// <summary>
@@ -117,7 +117,7 @@ public static class ComponentTypeDependencyExtension
     [NotBurstCompatible]
     public static unsafe JobHandle GetDependency(this ref NativeArray<ComponentType> componentTypes, EntityManager manager)
     {
-        return GetDependency(manager.GetUncheckedEntityDataAccess()->DependencyManager, ref componentTypes);
+        return GetDependency(manager.GetCheckedEntityDataAccess()->DependencyManager, ref componentTypes);
     }
 
     private static unsafe JobHandle GetDependency(ComponentDependencyManager* dependencyManager, ComponentType componentType)

--- a/Scripts/AssemblyInjections/Unity.Entities/ComponentTypeDependencyExtension.cs
+++ b/Scripts/AssemblyInjections/Unity.Entities/ComponentTypeDependencyExtension.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using Unity.Collections;
 using Unity.Collections.LowLevel.Unsafe;
 using Unity.Entities;
@@ -29,8 +30,8 @@ public static class ComponentTypeDependencyExtension
     /// <see cref="ComponentSystemBase.OnUpdate"/>.
     /// </summary>
     /// <param name="manager"> The <see cref="World"/>'s <see cref="EntityManager"/>.</param>
-    /// <param name="component">The component type to get the dependency of.</param>
-    /// <returns>The dependency for the component type</returns>
+    /// <param name="componentTypes">The component type to get the dependency of.</param>
+    /// <returns>The dependency for the component types</returns>
     public static unsafe JobHandle GetDependency(this EntityManager manager, ComponentType componentType)
     {
         return GetDependency(manager.GetUncheckedEntityDataAccess()->DependencyManager, componentType);
@@ -42,7 +43,7 @@ public static class ComponentTypeDependencyExtension
     /// <see cref="ComponentSystemBase.OnUpdate"/>.
     /// </summary>
     /// <param name="manager"> The <see cref="World"/>'s <see cref="EntityManager"/>.</param>
-    /// <param name="component">The component types to calculate the dependency of.</param>
+    /// <param name="componentTypes">The component types to calculate the dependency of.</param>
     /// <returns>The combined dependency for the component types</returns>
     [NotBurstCompatible]
     public static unsafe JobHandle GetDependency(this EntityManager manager, params ComponentType[] componentTypes)
@@ -55,66 +56,70 @@ public static class ComponentTypeDependencyExtension
     /// Useful for scheduling jobs that depend on components out of band with a system's
     /// <see cref="ComponentSystemBase.OnUpdate"/>.
     /// </summary>
+    /// <typeparam name="T">The collection type.</typeparam>
     /// <param name="manager"> The <see cref="World"/>'s <see cref="EntityManager"/>.</param>
-    /// <param name="component">The component types to calculate the dependency of.</param>
+    /// <param name="componentTypes">The component types to calculate the dependency of.</param>
     /// <returns>The combined dependency for the component types</returns>
-    public static unsafe JobHandle GetDependency(this EntityManager manager, NativeArray<ComponentType> componentTypes)
+    [NotBurstCompatible]
+    public static unsafe JobHandle GetDependency<T>(this EntityManager manager, T componentTypes)
+        where T : class, IEnumerable<ComponentType>
     {
         return GetDependency(manager.GetUncheckedEntityDataAccess()->DependencyManager, componentTypes);
     }
 
     /// <summary>
+    /// Get the combined dependency of a collection of component types.
+    /// Useful for scheduling jobs that depend on components out of band with a system's
+    /// <see cref="ComponentSystemBase.OnUpdate"/>.
+    /// </summary>
+    /// <param name="manager"> The <see cref="World"/>'s <see cref="EntityManager"/>.</param>
+    /// <param name="componentTypes">The component types to calculate the dependency of.</param>
+    /// <returns>The combined dependency for the component types</returns>
+    public static unsafe JobHandle GetDependency(this EntityManager manager, ref NativeArray<ComponentType> componentTypes)
+    {
+        return GetDependency(manager.GetUncheckedEntityDataAccess()->DependencyManager, ref componentTypes);
+    }
+
+    /// <summary>
     /// Get the dependency of an individual component type.
     /// Useful for scheduling jobs out of band with a system's <see cref="ComponentSystemBase.OnUpdate"/>.
     /// </summary>
-    /// <param name="system">
-    /// The system running the out of band job. If not in a system use the <see cref="EntityManager"/> extension instead.
-    /// </param>
-    /// <param name="component">The component type to get the dependency of.</param>
+    /// <param name="componentType">The component type to get the dependency of.</param>
+    /// <param name="manager"> The <see cref="World"/>'s <see cref="EntityManager"/>.</param>
     /// <returns>The dependency for the component type</returns>
-    public static unsafe JobHandle GetDependency(this ComponentSystemBase system, ComponentType componentType)
+    public static unsafe JobHandle GetDependency(this ComponentType componentType, EntityManager manager)
     {
-        return GetDependency(system.CheckedState()->m_DependencyManager, componentType);
+        return GetDependency(manager.GetUncheckedEntityDataAccess()->DependencyManager, componentType);
     }
 
     /// <summary>
     /// Get the combined dependency of a collection of component types.
     /// Useful for scheduling jobs out of band with a system's <see cref="ComponentSystemBase.OnUpdate"/>.
     /// </summary>
-    /// <param name="system">
-    /// The system running the out of band job. If not in a system use the <see cref="EntityManager"/> extension instead.
-    /// </param>
-    /// <param name="component">The component types to calculate the dependency of.</param>
+    /// <typeparam name="T">The collection type.</typeparam>
+    /// <param name="componentTypes">The component types to calculate the dependency of.</param>
+    /// <param name="manager"> The <see cref="World"/>'s <see cref="EntityManager"/>.</param>
     /// <returns>The combined dependency for the component types</returns>
     [NotBurstCompatible]
-    public static unsafe JobHandle GetDependency(this ComponentSystemBase system, params ComponentType[] componentTypes)
+    public static unsafe JobHandle GetDependency<T>(this T componentTypes, EntityManager manager)
+        where T : class, IEnumerable<ComponentType>
     {
-        return GetDependency(system.CheckedState()->m_DependencyManager, componentTypes);
+        return GetDependency(manager.GetUncheckedEntityDataAccess()->DependencyManager, componentTypes);
     }
 
     /// <summary>
     /// Get the combined dependency of a collection of component types.
     /// Useful for scheduling jobs out of band with a system's <see cref="ComponentSystemBase.OnUpdate"/>.
     /// </summary>
-    /// <param name="system">
-    /// The system running the out of band job. If not in a system use the <see cref="EntityManager"/> extension instead.
-    /// </param>
-    /// <param name="component">The component types to calculate the dependency of.</param>
+    /// <param name="componentTypes">The component types to calculate the dependency of.</param>
+    /// <param name="manager"> The <see cref="World"/>'s <see cref="EntityManager"/>.</param>
     /// <returns>The combined dependency for the component types</returns>
-    public static unsafe JobHandle GetDependency(this ComponentSystemBase system, NativeArray<ComponentType> componentTypes)
+    [NotBurstCompatible]
+    public static unsafe JobHandle GetDependency(this ref NativeArray<ComponentType> componentTypes, EntityManager manager)
     {
-        return GetDependency(system.CheckedState()->m_DependencyManager, componentTypes);
+        return GetDependency(manager.GetUncheckedEntityDataAccess()->DependencyManager, ref componentTypes);
     }
 
-    /// <summary>
-    /// Get the dependency of an individual component type.
-    /// Useful for scheduling jobs out of band with a system's <see cref="ComponentSystemBase.OnUpdate"/>.
-    /// </summary>
-    /// <param name="system">
-    /// The system running the out of band job. If not in a system use the <see cref="EntityManager"/> extension instead.
-    /// </param>
-    /// <param name="componentType">The component type to get the dependency of.</param>
-    /// <returns>The dependency for the component type</returns>
     private static unsafe JobHandle GetDependency(ComponentDependencyManager* dependencyManager, ComponentType componentType)
     {
         Debug.Assert(componentType.AccessModeType is ComponentType.AccessMode.ReadOnly or ComponentType.AccessMode.ReadWrite);
@@ -132,17 +137,9 @@ public static class ComponentTypeDependencyExtension
             ->GetDependency(typeIndexPtr, readerCount, typeIndexPtr, writerCount);
     }
 
-    /// <summary>
-    /// Get the combined dependency of a collection of component types.
-    /// Useful for scheduling jobs out of band with a system's <see cref="ComponentSystemBase.OnUpdate"/>.
-    /// </summary>
-    /// <param name="system">
-    /// The system running the out of band job. If not in a system use the <see cref="EntityManager"/> extension instead.
-    /// </param>
-    /// <param name="component">The component types to calculate the dependency of.</param>
-    /// <returns>The combined dependency for the component types</returns>
     [NotBurstCompatible]
-    private static unsafe JobHandle GetDependency(ComponentDependencyManager* dependencyManager, ComponentType[] componentTypes)
+    private static unsafe JobHandle GetDependency<T>(ComponentDependencyManager* dependencyManager, T componentTypes)
+        where T : class, IEnumerable<ComponentType>
     {
         s_WriteTypeList_ScratchPad.Clear();
         s_ReadTypeList_ScratchPad.Clear();
@@ -156,16 +153,7 @@ public static class ComponentTypeDependencyExtension
             ->GetDependency(s_ReadTypeList_ScratchPad.Ptr, s_ReadTypeList_ScratchPad.Length, s_WriteTypeList_ScratchPad.Ptr, s_WriteTypeList_ScratchPad.Length);
     }
 
-    /// <summary>
-    /// Get the combined dependency of a collection of component types.
-    /// Useful for scheduling jobs out of band with a system's <see cref="ComponentSystemBase.OnUpdate"/>.
-    /// </summary>
-    /// <param name="system">
-    /// The system running the out of band job. If not in a system use the <see cref="EntityManager"/> extension instead.
-    /// </param>
-    /// <param name="component">The component types to calculate the dependency of.</param>
-    /// <returns>The combined dependency for the component types</returns>
-    private static unsafe JobHandle GetDependency(ComponentDependencyManager* dependencyManager, NativeArray<ComponentType> componentTypes)
+    private static unsafe JobHandle GetDependency(ComponentDependencyManager* dependencyManager, ref NativeArray<ComponentType> componentTypes)
     {
         s_WriteTypeList_ScratchPad.Clear();
         s_ReadTypeList_ScratchPad.Clear();

--- a/Scripts/AssemblyInjections/Unity.Entities/ComponentTypeDependencyExtension.cs
+++ b/Scripts/AssemblyInjections/Unity.Entities/ComponentTypeDependencyExtension.cs
@@ -17,10 +17,16 @@ public static class ComponentTypeDependencyExtension
     [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.SubsystemRegistration)]
     private static void Init()
     {
-        s_WriteTypeList_ScratchPad.Dispose();
+        if (s_WriteTypeList_ScratchPad.IsCreated)
+        {
+            s_WriteTypeList_ScratchPad.Dispose();
+        }
         s_WriteTypeList_ScratchPad = new UnsafeList<int>(0, Allocator.Persistent);
 
-        s_ReadTypeList_ScratchPad.Dispose();
+        if (s_ReadTypeList_ScratchPad.IsCreated)
+        {
+            s_ReadTypeList_ScratchPad.Dispose();
+        }
         s_ReadTypeList_ScratchPad = new UnsafeList<int>(0, Allocator.Persistent);
     }
 

--- a/Scripts/AssemblyInjections/Unity.Entities/ComponentTypeDependencyExtension.cs
+++ b/Scripts/AssemblyInjections/Unity.Entities/ComponentTypeDependencyExtension.cs
@@ -10,8 +10,18 @@ using UnityEngine;
 [BurstCompatible]
 public static class ComponentTypeDependencyExtension
 {
-    private static UnsafeList<int> s_WriteTypeList_ScratchPad = new UnsafeList<int>(0, Allocator.Persistent);
-    private static UnsafeList<int> s_ReadTypeList_ScratchPad = new UnsafeList<int>(0, Allocator.Persistent);
+    private static UnsafeList<int> s_WriteTypeList_ScratchPad;
+    private static UnsafeList<int> s_ReadTypeList_ScratchPad;
+
+    [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.SubsystemRegistration)]
+    private static void Init()
+    {
+        s_WriteTypeList_ScratchPad.Dispose();
+        s_WriteTypeList_ScratchPad = new UnsafeList<int>(0, Allocator.Persistent);
+
+        s_ReadTypeList_ScratchPad.Dispose();
+        s_ReadTypeList_ScratchPad = new UnsafeList<int>(0, Allocator.Persistent);
+    }
 
     /// <summary>
     /// Get the dependency of an individual component type.

--- a/Scripts/AssemblyInjections/Unity.Entities/ComponentTypeDependencyExtension.cs.meta
+++ b/Scripts/AssemblyInjections/Unity.Entities/ComponentTypeDependencyExtension.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b8e5eccf07d9147c88cdc775a96777e5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Provides ability to get the job dependency on an arbitrary component or set of components.

@jkeon This may provide the opportunity to decouple task drivers from systems (if we want that)

**Question:**
Does making these extension methods of `ComponentSystemBase` and `EntityManager` make sense?
Alternatively (or additionally) we can have the extension methods work off of the `ComponentType<T>` instances themselves.
Examples:
 - `ComponentType<MyComponent>.ReadOnly().GetDependency(EntityManager)` (or system)
 -  `myComponentCollection.GetDependency(EntityManager)` (or system)

`EntityManager` and `ComponentSystemBase` are the providers for the pointer to the underlying `ComponentDependencyManager` instance. That's why the current extension methods are setup as they are.

### What is the current behaviour?

Currently, the only way to get the scheduling dependency of a collection of components is through an `EntityQuery`.

### What is the new behaviour?

With a reference to `EntityManager` or `ComponentSystemBase` instance developers can calculate the scheduling dependency on an arbitrary collection of components.

### What issues does this resolve?
 - None

### What PRs does this depend on?
 - None

### Does this introduce a breaking change?
 - [ ] Yes <!-- If so, what are the migration considerations? -->
 - [x] No
