### PR TITLE
World Unique Task Driver

### DIFF
--- a/Scripts/Runtime/Entities/TaskDriver/Attribute.meta
+++ b/Scripts/Runtime/Entities/TaskDriver/Attribute.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 64bacae3b3b844b8892e3de86a4fd16a
+timeCreated: 1682521711

--- a/Scripts/Runtime/Entities/TaskDriver/Attribute/WorldUniqueTaskDriverAttribute.cs
+++ b/Scripts/Runtime/Entities/TaskDriver/Attribute/WorldUniqueTaskDriverAttribute.cs
@@ -1,0 +1,17 @@
+using System;
+
+namespace Anvil.Unity.DOTS.Entities.TaskDriver
+{
+    /// <summary>
+    /// Constrains an <see cref="AbstractTaskDriver"/> to a single instance per world.
+    /// </summary>
+    /// <remarks>
+    /// This is enforced by the <see cref="AbstractTaskDriverSystem"/> when registering the
+    /// <see cref="AbstractTaskDriver"/> instance.
+    /// </remarks>
+    [AttributeUsage(AttributeTargets.Class, Inherited = true)]
+    public class WorldUniqueTaskDriverAttribute : Attribute
+    {
+        public WorldUniqueTaskDriverAttribute() { }
+    }
+}

--- a/Scripts/Runtime/Entities/TaskDriver/Attribute/WorldUniqueTaskDriverAttribute.cs.meta
+++ b/Scripts/Runtime/Entities/TaskDriver/Attribute/WorldUniqueTaskDriverAttribute.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 2187c7284b4542e0a0ff68f6c946b39f
+timeCreated: 1682521742

--- a/Scripts/Runtime/Entities/TaskDriver/System/AbstractTaskDriverSystem.cs
+++ b/Scripts/Runtime/Entities/TaskDriver/System/AbstractTaskDriverSystem.cs
@@ -32,12 +32,14 @@ namespace Anvil.Unity.DOTS.Entities.TaskDriver
         public new World World { get; }
 
         internal TaskSet TaskSet { get; }
+
         TaskSet ITaskSetOwner.TaskSet
         {
             get => TaskSet;
         }
-        
+
         internal uint ID { get; }
+
         uint ITaskSetOwner.ID
         {
             get => ID;
@@ -56,6 +58,7 @@ namespace Anvil.Unity.DOTS.Entities.TaskDriver
                 return m_HasCancellableData;
             }
         }
+
         bool ITaskSetOwner.HasCancellableData
         {
             get => HasCancellableData;
@@ -236,7 +239,7 @@ namespace Anvil.Unity.DOTS.Entities.TaskDriver
         // SAFETY
         //*************************************************************************************************************
 
-        [Conditional("ENABLE_UNITY_COLLECTIONS_CHECKS")]
+        [Conditional("ANVIL_DEBUG_SAFETY")]
         private void Debug_EnsureNotHardenUpdatePhase()
         {
             if (m_IsUpdatePhaseHardened)
@@ -245,7 +248,7 @@ namespace Anvil.Unity.DOTS.Entities.TaskDriver
             }
         }
 
-        [Conditional("ENABLE_UNITY_COLLECTIONS_CHECKS")]
+        [Conditional("ANVIL_DEBUG_SAFETY")]
         private void Debug_EnsureHardened()
         {
             if (!m_IsHardened)
@@ -254,7 +257,7 @@ namespace Anvil.Unity.DOTS.Entities.TaskDriver
             }
         }
 
-        [Conditional("ENABLE_UNITY_COLLECTIONS_CHECKS")]
+        [Conditional("ANVIL_DEBUG_SAFETY")]
         private void Debug_EnsureWorldsAreTheSame()
         {
             if (World != base.World)

--- a/Scripts/Runtime/Entities/TaskDriver/System/AbstractTaskDriverSystem.cs
+++ b/Scripts/Runtime/Entities/TaskDriver/System/AbstractTaskDriverSystem.cs
@@ -99,6 +99,7 @@ namespace Anvil.Unity.DOTS.Entities.TaskDriver
 
         internal void RegisterTaskDriver(AbstractTaskDriver taskDriver)
         {
+            Debug_AssertWorldUniqueConstraint(taskDriver);
             m_TaskDrivers.Add(taskDriver);
         }
 
@@ -259,6 +260,16 @@ namespace Anvil.Unity.DOTS.Entities.TaskDriver
             if (World != base.World)
             {
                 throw new InvalidOperationException($"The passed in World {World} is not the same as the automatically assigned one {base.World} in {nameof(OnCreate)}!");
+            }
+        }
+
+        [Conditional("ANVIL_DEBUG_SAFETY")]
+        private void Debug_AssertWorldUniqueConstraint(AbstractTaskDriver taskDriver)
+        {
+            if (m_TaskDrivers.Count > 0
+                && Attribute.IsDefined(taskDriver.GetType(), typeof(WorldUniqueTaskDriverAttribute)))
+            {
+                throw new Exception($"Attempting to add multiple instance of a world unique task driver. World: {World.Name}, TaskDriver:{taskDriver.GetType().GetReadableName()}");
             }
         }
     }


### PR DESCRIPTION
Add the attribute `[WorldUniqueTaskDriver]` which may be applied to task driver instances that only support a single instance per world.

## Tag Alongs
 - Instances of `ENABLE_UNITY_COLLECTIONS_CHECKS` were converted to `ANVIL_DEBUG_SAFETY` as a contribution against #139

### What is the current behaviour?

There are no uniqueness constraints on task drivers.

### What is the new behaviour?

If the `[WorldUniqueTaskDriver]` attribute is present, `AbstractTaskDriverSystem` will throw an exception when the second instance is registered.

### What issues does this resolve?
 - None

### What PRs does this depend on?
 - None

### Does this introduce a breaking change?
 - [x] Yes <!-- If so, what are the migration considerations? -->
 - [ ] No

If you're relying on `ENABLE_UNITY_COLLECTIONS_CHECKS` for the affected task driver safety make sure `ANVIL_DEBUG_SAFETY` is enabled.