### PR TITLE
EntityPersistentData - Rework to be API compatible with ACV

### DIFF
--- a/Scripts/Runtime/Entities/PersistentData/Data/AbstractPersistentData.cs
+++ b/Scripts/Runtime/Entities/PersistentData/Data/AbstractPersistentData.cs
@@ -47,5 +47,11 @@ namespace Anvil.Unity.DOTS.Entities
         {
             m_AccessController.Release();
         }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public AccessController.AccessHandle AcquireWithHandle(AccessType accessType)
+        {
+            return m_AccessController.AcquireWithHandle(accessType);
+        }
     }
 }

--- a/Scripts/Runtime/Entities/PersistentData/Data/EntityPersistentData.cs
+++ b/Scripts/Runtime/Entities/PersistentData/Data/EntityPersistentData.cs
@@ -92,8 +92,8 @@ namespace Anvil.Unity.DOTS.Entities
             //Launch the migration job to get that burst speed
             dependsOn = JobHandle.CombineDependencies(
                 dependsOn,
-                AcquireWriterAsync(out EntityPersistentDataWriter<T> currentData),
-                destinationEntityPersistentData.AcquireWriterAsync(out EntityPersistentDataWriter<T> destinationData));
+                AcquireSharedWriteAsync(out EntityPersistentDataWriter<T> currentData),
+                destinationEntityPersistentData.AcquireSharedWriteAsync(out EntityPersistentDataWriter<T> destinationData));
 
             MigrateJob migrateJob = new MigrateJob(
                 currentData,
@@ -101,8 +101,8 @@ namespace Anvil.Unity.DOTS.Entities
                 ref remapArray);
             dependsOn = migrateJob.Schedule(dependsOn);
 
-            destinationEntityPersistentData.ReleaseWriterAsync(dependsOn);
-            ReleaseWriterAsync(dependsOn);
+            destinationEntityPersistentData.ReleaseAsync(dependsOn);
+            ReleaseAsync(dependsOn);
 
             return dependsOn;
         }

--- a/Scripts/Runtime/Entities/PersistentData/Data/EntityPersistentData.cs
+++ b/Scripts/Runtime/Entities/PersistentData/Data/EntityPersistentData.cs
@@ -81,6 +81,26 @@ namespace Anvil.Unity.DOTS.Entities
                 CreateEntityPersistentDataWriter());
         }
 
+        public JobHandle AcquireExclusiveWriteAsync(out EntityPersistentDataWriter<T> writer)
+        {
+            writer = CreateEntityPersistentDataWriter();
+            return AcquireAsync(AccessType.ExclusiveWrite);
+        }
+
+        public EntityPersistentDataWriter<T> AcquireExclusiveWrite()
+        {
+            Acquire(AccessType.ExclusiveWrite);
+            return CreateEntityPersistentDataWriter();
+        }
+
+        public AccessControlledValue<EntityPersistentDataWriter<T>>.AccessHandle AcquireWithExclusiveWriteHandle()
+        {
+            return new AccessControlledValue<EntityPersistentDataWriter<T>>.AccessHandle(
+                AcquireWithHandle(AccessType.ExclusiveWrite),
+                CreateEntityPersistentDataWriter());
+        }
+
+
         //*************************************************************************************************************
         // MIGRATION
         //*************************************************************************************************************

--- a/Scripts/Runtime/Entities/PersistentData/Data/EntityPersistentData.cs
+++ b/Scripts/Runtime/Entities/PersistentData/Data/EntityPersistentData.cs
@@ -112,8 +112,8 @@ namespace Anvil.Unity.DOTS.Entities
             //Launch the migration job to get that burst speed
             dependsOn = JobHandle.CombineDependencies(
                 dependsOn,
-                AcquireSharedWriteAsync(out EntityPersistentDataWriter<T> currentData),
-                destinationEntityPersistentData.AcquireSharedWriteAsync(out EntityPersistentDataWriter<T> destinationData));
+                AcquireExclusiveWriteAsync(out EntityPersistentDataWriter<T> currentData),
+                destinationEntityPersistentData.AcquireExclusiveWriteAsync(out EntityPersistentDataWriter<T> destinationData));
 
             MigrateJob migrateJob = new MigrateJob(
                 currentData,

--- a/Scripts/Runtime/Entities/PersistentData/Data/EntityPersistentData.cs
+++ b/Scripts/Runtime/Entities/PersistentData/Data/EntityPersistentData.cs
@@ -42,52 +42,45 @@ namespace Anvil.Unity.DOTS.Entities
             return new EntityPersistentDataWriter<T>(ref Data);
         }
 
-        public JobHandle AcquireReaderAsync(out EntityPersistentDataReader<T> reader)
+        public JobHandle AcquireReadAsync(out EntityPersistentDataReader<T> reader)
         {
-            JobHandle dependsOn = AcquireAsync(AccessType.SharedRead);
             reader = CreateEntityPersistentDataReader();
-            return dependsOn;
+            return AcquireAsync(AccessType.SharedRead);
+            ;
         }
 
-        public void ReleaseReaderAsync(JobHandle dependsOn)
-        {
-            ReleaseAsync(dependsOn);
-        }
-
-        public EntityPersistentDataReader<T> AcquireReader()
+        public EntityPersistentDataReader<T> AcquireRead()
         {
             Acquire(AccessType.SharedRead);
             return CreateEntityPersistentDataReader();
         }
 
-        public void ReleaseReader()
+        public AccessControlledValue<EntityPersistentDataReader<T>>.AccessHandle AcquireWithReadHandle()
         {
-            Release();
+            return new AccessControlledValue<EntityPersistentDataReader<T>>.AccessHandle(
+                AcquireWithHandle(AccessType.SharedRead),
+                CreateEntityPersistentDataReader());
         }
 
-        public JobHandle AcquireWriterAsync(out EntityPersistentDataWriter<T> writer)
+        public JobHandle AcquireSharedWriteAsync(out EntityPersistentDataWriter<T> writer)
         {
-            JobHandle dependsOn = AcquireAsync(AccessType.SharedWrite);
             writer = CreateEntityPersistentDataWriter();
-            return dependsOn;
+            return AcquireAsync(AccessType.SharedWrite);
         }
 
-        public void ReleaseWriterAsync(JobHandle dependsOn)
-        {
-            ReleaseAsync(dependsOn);
-        }
-
-        public EntityPersistentDataWriter<T> AcquireWriter()
+        public EntityPersistentDataWriter<T> AcquireSharedWrite()
         {
             Acquire(AccessType.SharedWrite);
             return CreateEntityPersistentDataWriter();
         }
 
-        public void ReleaseWriter()
+        public AccessControlledValue<EntityPersistentDataWriter<T>>.AccessHandle AcquireWithSharedWriteHandle()
         {
-            Release();
+            return new AccessControlledValue<EntityPersistentDataWriter<T>>.AccessHandle(
+                AcquireWithHandle(AccessType.SharedWrite),
+                CreateEntityPersistentDataWriter());
         }
-        
+
         //*************************************************************************************************************
         // MIGRATION
         //*************************************************************************************************************
@@ -97,7 +90,8 @@ namespace Anvil.Unity.DOTS.Entities
             EntityPersistentData<T> destinationEntityPersistentData = (EntityPersistentData<T>)destinationPersistentData;
 
             //Launch the migration job to get that burst speed
-            dependsOn = JobHandle.CombineDependencies(dependsOn,
+            dependsOn = JobHandle.CombineDependencies(
+                dependsOn,
                 AcquireWriterAsync(out EntityPersistentDataWriter<T> currentData),
                 destinationEntityPersistentData.AcquireWriterAsync(out EntityPersistentDataWriter<T> destinationData));
 
@@ -106,7 +100,7 @@ namespace Anvil.Unity.DOTS.Entities
                 destinationData,
                 ref remapArray);
             dependsOn = migrateJob.Schedule(dependsOn);
-            
+
             destinationEntityPersistentData.ReleaseWriterAsync(dependsOn);
             ReleaseWriterAsync(dependsOn);
 
@@ -121,8 +115,8 @@ namespace Anvil.Unity.DOTS.Entities
             [ReadOnly] private NativeArray<EntityRemapUtility.EntityRemapInfo> m_RemapArray;
 
             public MigrateJob(
-                EntityPersistentDataWriter<T> currentData, 
-                EntityPersistentDataWriter<T> destinationData, 
+                EntityPersistentDataWriter<T> currentData,
+                EntityPersistentDataWriter<T> destinationData,
                 ref NativeArray<EntityRemapUtility.EntityRemapInfo> remapArray)
             {
                 m_CurrentData = currentData;
@@ -133,7 +127,7 @@ namespace Anvil.Unity.DOTS.Entities
             public void Execute()
             {
                 //TODO: Optimization: Could pass through the array of entities that were moving to avoid the copy. See: https://github.com/decline-cookies/anvil-unity-dots/pull/232#discussion_r1181697951
-                
+
                 //Can't remove while iterating so we collapse to an array first of our current keys/values
                 NativeKeyValueArrays<Entity, T> currentEntries = m_CurrentData.GetKeyValueArrays(Allocator.Temp);
 
@@ -148,11 +142,11 @@ namespace Anvil.Unity.DOTS.Entities
 
                     //Otherwise, remove us from this world's lookup
                     m_CurrentData.Remove(currentEntity);
-                    
+
                     //Get our data and patch it
                     T currentValue = currentEntries.Values[i];
                     currentValue.PatchEntityReferences(ref m_RemapArray);
-                    
+
                     //Then write the newly remapped data to the new world's lookup
                     m_DestinationData[remappedEntity] = currentValue;
                 }

--- a/Scripts/Runtime/Entities/PersistentData/Data/Interface/IEntityPersistentData.cs
+++ b/Scripts/Runtime/Entities/PersistentData/Data/Interface/IEntityPersistentData.cs
@@ -13,6 +13,7 @@ namespace Anvil.Unity.DOTS.Entities
     /// <typeparam name="T">The type of <see cref="IEntityPersistentDataInstance"/></typeparam>
     public interface IEntityPersistentData<T> : IAbstractPersistentData,
                                                 IReadOnlyEntityPersistentData<T>,
-                                                ISharedWriteAccessControlledValue<EntityPersistentDataWriter<T>>
+                                                ISharedWriteAccessControlledValue<EntityPersistentDataWriter<T>>,
+                                                IExclusiveWriteAccessControlledValue<EntityPersistentDataWriter<T>>
         where T : struct, IEntityPersistentDataInstance { }
 }

--- a/Scripts/Runtime/Entities/PersistentData/Data/Interface/IEntityPersistentData.cs
+++ b/Scripts/Runtime/Entities/PersistentData/Data/Interface/IEntityPersistentData.cs
@@ -1,4 +1,5 @@
 using Anvil.Unity.DOTS.Entities.TaskDriver;
+using Anvil.Unity.DOTS.Jobs;
 using Unity.Entities;
 using Unity.Jobs;
 
@@ -10,36 +11,8 @@ namespace Anvil.Unity.DOTS.Entities
     /// The data is associated with an <see cref="Entity"/>.
     /// </summary>
     /// <typeparam name="T">The type of <see cref="IEntityPersistentDataInstance"/></typeparam>
-    public interface IEntityPersistentData<T> : IAbstractPersistentData, IReadOnlyEntityPersistentData<T>
-        where T : struct, IEntityPersistentDataInstance
-    {
-        /// <summary>
-        /// Gets a <see cref="EntityPersistentDataWriter{TInstance}"/> for use in a job outside the Task Driver context.
-        /// Requires a call to <see cref="ReleaseWriterAsync"/> after scheduling the job.
-        /// </summary>
-        /// <param name="writer">The <see cref="EntityPersistentDataWriter{TInstance}"/></param>
-        /// <returns>The <see cref="JobHandle"/> to wait on</returns>
-        public JobHandle AcquireWriterAsync(out EntityPersistentDataWriter<T> writer);
-
-        /// <summary>
-        /// Allows other jobs to use the underlying data for the <see cref="EntityPersistentDataWriter{TInstance}"/>
-        /// and ensures data integrity across those other usages.
-        /// </summary>
-        /// <param name="dependsOn">The <see cref="JobHandle"/> that used this data.</param>
-        public void ReleaseWriterAsync(JobHandle dependsOn);
-
-        /// <summary>
-        /// Gets a <see cref="EntityPersistentDataWriter{TInstance}"/> for use on the main thread outside the Task Driver
-        /// context.
-        /// Requires a call to <see cref="ReleaseWriter"/> when done.
-        /// </summary>
-        /// <returns>The <see cref="EntityPersistentDataWriter{TInstance}"/></returns>
-        public EntityPersistentDataWriter<T> AcquireWriter();
-
-        /// <summary>
-        /// Allows other jobs or code to use to underlying data for the <see cref="EntityPersistentDataWriter{TInstance}"/>
-        /// and ensures data integrity across those other usages.
-        /// </summary>
-        public void ReleaseWriter();
-    }
+    public interface IEntityPersistentData<T> : IAbstractPersistentData,
+                                                IReadOnlyEntityPersistentData<T>,
+                                                ISharedWriteAccessControlledValue<EntityPersistentDataWriter<T>>
+        where T : struct, IEntityPersistentDataInstance { }
 }

--- a/Scripts/Runtime/Entities/PersistentData/Data/Interface/IReadOnlyEntityPersistentData.cs
+++ b/Scripts/Runtime/Entities/PersistentData/Data/Interface/IReadOnlyEntityPersistentData.cs
@@ -1,6 +1,6 @@
 using Anvil.Unity.DOTS.Entities.TaskDriver;
+using Anvil.Unity.DOTS.Jobs;
 using Unity.Entities;
-using Unity.Jobs;
 
 namespace Anvil.Unity.DOTS.Entities
 {
@@ -10,36 +10,7 @@ namespace Anvil.Unity.DOTS.Entities
     /// The data is associated with an <see cref="Entity"/>.
     /// </summary>
     /// <typeparam name="T">The type of <see cref="IEntityPersistentDataInstance"/></typeparam>
-    public interface IReadOnlyEntityPersistentData<T> : IAbstractPersistentData
-        where T : struct, IEntityPersistentDataInstance
-    {
-        /// <summary>
-        /// Gets a <see cref="EntityPersistentDataReader{TInstance}"/> for use in a job outside the Task Driver context.
-        /// Requires a call to <see cref="ReleaseReaderAsync"/> after scheduling the job.
-        /// </summary>
-        /// <param name="reader">The <see cref="EntityPersistentDataReader{TInstance}"/></param>
-        /// <returns>A <see cref="JobHandle"/> to wait on</returns>
-        public JobHandle AcquireReaderAsync(out EntityPersistentDataReader<T> reader);
-
-        /// <summary>
-        /// Allows other jobs to use the underlying data for the <see cref="EntityPersistentDataReader{TInstance}"/>
-        /// and ensures data integrity across those other usages.
-        /// </summary>
-        /// <param name="dependsOn">The <see cref="JobHandle"/> that used this data.</param>
-        public void ReleaseReaderAsync(JobHandle dependsOn);
-
-        /// <summary>
-        /// Gets a <see cref="EntityPersistentDataReader{TInstance}"/> for use on the main thread outside the Task Driver
-        /// context.
-        /// Requires a call to <see cref="ReleaseReader"/> when done.
-        /// </summary>
-        /// <returns>The <see cref="EntityPersistentDataReader{TInstance}"/></returns>
-        public EntityPersistentDataReader<T> AcquireReader();
-
-        /// <summary>
-        /// Allows other jobs or code to use to underlying data for the <see cref="EntityPersistentDataReader{TInstance}"/>
-        /// and ensures data integrity across those other usages.
-        /// </summary>
-        public void ReleaseReader();
-    }
+    public interface IReadOnlyEntityPersistentData<T> : IAbstractPersistentData,
+                                                        IReadAccessControlledValue<EntityPersistentDataReader<T>>
+        where T : struct, IEntityPersistentDataInstance { }
 }


### PR DESCRIPTION
Reworked the API for `EntityPersistentData` to be compatible with the appropriate AccessControlledValue interfaces. This allows more flexible use with other ACV based features.

### What is the current behaviour?

The `EntityPersistentData` accomplishes many of the same things that the ACV interfaces do but are just slightly different. This makes them incompatible with types written to generically deal with ACV types.

### What is the new behaviour?

`EntityPersistentData` implements `ISharedWriteAccessControlledValue<EntityPersistentDataWriter<T>>` and `IReadAccessControlledValue<EntityPersistentDataReader<T>>` allowing it to continue delivering specialized readers/writers depending on requested access but also be compatible as a specialized ACV.

In the future we can evaluate whether it makes sense to add Exclusive Write support and support the entire ACV API.

### What issues does this resolve?
 - None

### What PRs does this depend on?
 - None

### Does this introduce a breaking change?
 - [x] Yes <!-- If so, what are the migration considerations? -->
 - [ ] No

Find and replace:
 - `AcquireReader...` -> `AcquireRead...`
 - `AcquireWriter...` -> `AcquireSharedWrite...`
 - `ReleaseWriter...` -> `Release...`
 - `ReleaseReader...` -> `Release...`