### PR TITLE
WrappedAccessControlledValue - Add

### DIFF
--- a/Scripts/Runtime/Job/AccessControl/AccessControlledValue.cs
+++ b/Scripts/Runtime/Job/AccessControl/AccessControlledValue.cs
@@ -76,7 +76,7 @@ namespace Anvil.Unity.DOTS.Jobs
             return m_Value;
         }
 
-        /// <inheritdoc cref="IAccessControlledValue{T}"/>
+        /// <inheritdoc cref="IAccessControlledValue{T}.AcquireAsync"/>
         public JobHandle AcquireAsync(AccessType accessType, out T value)
         {
             value = m_Value;

--- a/Scripts/Runtime/Job/AccessControl/WrappedAccessControlledValue.cs
+++ b/Scripts/Runtime/Job/AccessControl/WrappedAccessControlledValue.cs
@@ -1,0 +1,148 @@
+using Anvil.CSharp.Core;
+using Unity.Jobs;
+
+namespace Anvil.Unity.DOTS.Jobs
+{
+    /// <summary>
+    /// Wraps an <see cref="AccessControlledValue{T}"/> and allows the controlled value to be transformed
+    /// before delivering a <see cref="TWrapped"/> instance to the consumer.
+    ///
+    /// This is an effective way of providing a constrained view of a broader internal access controlled value.
+    /// Ex: A reader/writer to an internal stream.
+    /// </summary>
+    /// <typeparam name="TWrapped">The type of the wrapped instance delivered to the consumer.</typeparam>
+    /// <typeparam name="TBase">The base access controlled value that is being wrapped.</typeparam>
+    public class WrappedAccessControlledValue<TWrapped, TBase> : AbstractAnvilBase,
+                                                                 IAccessControlledValue<TWrapped>,
+                                                                 IReadAccessControlledValue<TWrapped>,
+                                                                 ISharedWriteAccessControlledValue<TWrapped>,
+                                                                 IExclusiveWriteAccessControlledValue<TWrapped>
+    {
+        /// <summary>
+        /// Given the base value <see cref="TBase"/> produces the <see cref="TWrapped"/> to deliver to the consumer
+        /// of this instance.
+        /// </summary>
+        public delegate TWrapped WrapBaseValueDelegate(TBase baseValue);
+
+        private readonly AccessControlledValue<TBase> m_BaseACV;
+        private readonly WrapBaseValueDelegate m_WrapBaseValue;
+
+        /// <summary>
+        /// Creates a new instance of a <see cref="WrappedAccessControlledValue{TWrapped,TBase}"/>.
+        /// </summary>
+        /// <param name="baseACV">The base <see cref="AccessControlledValue{T}"/> to drive access.</param>
+        /// <param name="wrapBaseValue">Given the base value produces the wrapper value to deliver to the consumer.</param>
+        public WrappedAccessControlledValue(AccessControlledValue<TBase> baseACV, WrapBaseValueDelegate wrapBaseValue)
+        {
+            m_BaseACV = baseACV;
+            m_WrapBaseValue = wrapBaseValue;
+        }
+
+        /// <inheritdoc cref="IReadAccessControlledValue{T}.AcquireWithReadHandle"/>
+        public AccessControlledValue<TWrapped>.AccessHandle AcquireWithReadHandle()
+        {
+            var handle = m_BaseACV.AcquireWithReadHandle();
+            TWrapped wrappedValue = m_WrapBaseValue(handle.Value);
+
+            return AccessControlledValue<TWrapped>.AccessHandle.CreateDerived(handle, wrappedValue);
+        }
+
+        /// <inheritdoc cref="ISharedWriteAccessControlledValue{T}.AcquireWithSharedWriteHandle"/>
+        public AccessControlledValue<TWrapped>.AccessHandle AcquireWithSharedWriteHandle()
+        {
+            var handle = m_BaseACV.AcquireWithSharedWriteHandle();
+            TWrapped wrappedValue = m_WrapBaseValue(handle.Value);
+
+            return AccessControlledValue<TWrapped>.AccessHandle.CreateDerived(handle, wrappedValue);
+        }
+
+        /// <inheritdoc cref="IExclusiveWriteAccessControlledValue{T}.AcquireWithExclusiveWriteHandle"/>
+        public AccessControlledValue<TWrapped>.AccessHandle AcquireWithExclusiveWriteHandle()
+        {
+            var handle = m_BaseACV.AcquireWithExclusiveWriteHandle();
+            TWrapped wrappedValue = m_WrapBaseValue(handle.Value);
+
+            return AccessControlledValue<TWrapped>.AccessHandle.CreateDerived(handle, wrappedValue);
+        }
+
+        /// <inheritdoc cref="IAccessControlledValue{T}.AcquireWithHandle"/>
+        public AccessControlledValue<TWrapped>.AccessHandle AcquireWithHandle(AccessType accessType)
+        {
+            var handle = m_BaseACV.AcquireWithHandle(accessType);
+            TWrapped wrappedValue = m_WrapBaseValue(handle.Value);
+
+            return AccessControlledValue<TWrapped>.AccessHandle.CreateDerived(handle, wrappedValue);
+        }
+
+
+        /// <inheritdoc cref="IReadAccessControlledValue{T}.AcquireRead"/>
+        public TWrapped AcquireRead()
+        {
+            return m_WrapBaseValue(m_BaseACV.AcquireRead());
+        }
+
+        /// <inheritdoc cref="ISharedWriteAccessControlledValue{T}.AcquireSharedWrite"/>
+        public TWrapped AcquireSharedWrite()
+        {
+            return m_WrapBaseValue(m_BaseACV.AcquireSharedWrite());
+        }
+
+        /// <inheritdoc cref="IExclusiveWriteAccessControlledValue{T}.AcquireExclusiveWrite"/>
+        public TWrapped AcquireExclusiveWrite()
+        {
+            return m_WrapBaseValue(m_BaseACV.AcquireExclusiveWrite());
+        }
+
+        /// <inheritdoc cref="IAccessControlledValue{T}.Acquire"/>
+        public TWrapped Acquire(AccessType accessType)
+        {
+            return m_WrapBaseValue(m_BaseACV.Acquire(accessType));
+        }
+
+
+        /// <inheritdoc cref="IReadAccessControlledValue{T}.AcquireReadAsync"/>
+        public JobHandle AcquireReadAsync(out TWrapped value)
+        {
+            JobHandle handle = m_BaseACV.AcquireReadAsync(out TBase baseValue);
+            value = m_WrapBaseValue(baseValue);
+            return handle;
+        }
+
+        /// <inheritdoc cref="ISharedWriteAccessControlledValue{T}.AcquireSharedWriteAsync"/>
+        public JobHandle AcquireSharedWriteAsync(out TWrapped value)
+        {
+            JobHandle handle = m_BaseACV.AcquireSharedWriteAsync(out TBase baseValue);
+            value = m_WrapBaseValue(baseValue);
+            return handle;
+        }
+
+        /// <inheritdoc cref="IExclusiveWriteAccessControlledValue{T}.AcquireExclusiveWriteAsync"/>
+        public JobHandle AcquireExclusiveWriteAsync(out TWrapped value)
+        {
+            JobHandle handle = m_BaseACV.AcquireExclusiveWriteAsync(out TBase baseValue);
+            value = m_WrapBaseValue(baseValue);
+            return handle;
+        }
+
+        /// <inheritdoc cref="IAccessControlledValue{T}.AcquireAsync"/>
+        public JobHandle AcquireAsync(AccessType accessType, out TWrapped value)
+        {
+            JobHandle handle = m_BaseACV.AcquireAsync(accessType, out TBase baseValue);
+            value = m_WrapBaseValue(baseValue);
+            return handle;
+        }
+
+
+        /// <inheritdoc cref="IAccessControlledValue{T}.Release"/>
+        public void Release()
+        {
+            m_BaseACV.Release();
+        }
+
+        /// <inheritdoc cref="IAccessControlledValue{T}.ReleaseAsync"/>
+        public void ReleaseAsync(JobHandle releaseAccessDependency)
+        {
+            m_BaseACV.ReleaseAsync(releaseAccessDependency);
+        }
+    }
+}

--- a/Scripts/Runtime/Job/AccessControl/WrappedAccessControlledValue.cs.meta
+++ b/Scripts/Runtime/Job/AccessControl/WrappedAccessControlledValue.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 77a1126713974cc494d920ba0e8a4134
+timeCreated: 1683050376

--- a/Scripts/Runtime/Job/AccessControl/WrappedReadAccessControlledValue.cs
+++ b/Scripts/Runtime/Job/AccessControl/WrappedReadAccessControlledValue.cs
@@ -1,0 +1,73 @@
+using Anvil.CSharp.Core;
+using Unity.Jobs;
+
+namespace Anvil.Unity.DOTS.Jobs
+{
+    /// <summary>
+    /// Wraps an <see cref="IReadAccessControlledValue{T}"/> and allows the controlled value to be transformed
+    /// before delivering a <see cref="TWrapped"/> instance to the consumer.
+    ///
+    /// This is an effective way of providing a constrained view of a broader internal access controlled value.
+    /// Ex: A reader to an internal stream.
+    /// </summary>
+    /// <typeparam name="TWrapped">The type of the wrapped instance delivered to the consumer.</typeparam>
+    /// <typeparam name="TBase">The base access controlled value that is being wrapped.</typeparam>
+    public class WrappedReadAccessControlledValue<TWrapped, TBase> : AbstractAnvilBase,
+                                                                     IReadAccessControlledValue<TWrapped>
+    {
+        /// <summary>
+        /// Given the base value <see cref="TBase"/> produces the <see cref="TWrapped"/> to deliver to the consumer
+        /// of this instance.
+        /// </summary>
+        public delegate TWrapped WrapBaseValueDelegate(TBase baseValue);
+
+        private readonly IReadAccessControlledValue<TBase> m_BaseACV;
+        private readonly WrapBaseValueDelegate m_WrapBaseValue;
+
+        /// <summary>
+        /// Creates a new instance of a <see cref="WrappedReadAccessControlledValue{TWrapped,TBase}"/>.
+        /// </summary>
+        /// <param name="baseACV">The base <see cref="IReadAccessControlledValue{T}"/> to drive access.</param>
+        /// <param name="wrapBaseValue">Given the base value produces the wrapper value to deliver to the consumer.</param>
+        public WrappedReadAccessControlledValue(IReadAccessControlledValue<TBase> baseACV, WrapBaseValueDelegate wrapBaseValue)
+        {
+            m_BaseACV = baseACV;
+            m_WrapBaseValue = wrapBaseValue;
+        }
+
+        /// <inheritdoc cref="IReadAccessControlledValue{T}.AcquireWithReadHandle"/>
+        public AccessControlledValue<TWrapped>.AccessHandle AcquireWithReadHandle()
+        {
+            var handle = m_BaseACV.AcquireWithReadHandle();
+            TWrapped wrappedValue = m_WrapBaseValue(handle.Value);
+
+            return AccessControlledValue<TWrapped>.AccessHandle.CreateDerived(handle, wrappedValue);
+        }
+
+        /// <inheritdoc cref="IReadAccessControlledValue{T}.AcquireRead"/>
+        public TWrapped AcquireRead()
+        {
+            return m_WrapBaseValue(m_BaseACV.AcquireRead());
+        }
+
+        /// <inheritdoc cref="IReadAccessControlledValue{T}.AcquireReadAsync"/>
+        public JobHandle AcquireReadAsync(out TWrapped value)
+        {
+            JobHandle handle = m_BaseACV.AcquireReadAsync(out TBase baseValue);
+            value = m_WrapBaseValue(baseValue);
+            return handle;
+        }
+
+        /// <inheritdoc cref="IReadAccessControlledValue{T}.Release"/>
+        public void Release()
+        {
+            m_BaseACV.Release();
+        }
+
+        /// <inheritdoc cref="IReadAccessControlledValue{T}.ReleaseAsync"/>
+        public void ReleaseAsync(JobHandle releaseAccessDependency)
+        {
+            m_BaseACV.ReleaseAsync(releaseAccessDependency);
+        }
+    }
+}

--- a/Scripts/Runtime/Job/AccessControl/WrappedReadAccessControlledValue.cs.meta
+++ b/Scripts/Runtime/Job/AccessControl/WrappedReadAccessControlledValue.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: a812ccf6e5394494980c14ac6a820425
+timeCreated: 1683051791


### PR DESCRIPTION
Provide a type to wrap and transform another ACV in an ACV compatible format.

### What is the current behaviour?

If you'd like to expose a variant of an access controlled value it involves implementing a new type that implements at least one of the access controlled value interfaces. Most of this type is generic boilerplate with only the logic transforming the base type to the variant being unique.

### What is the new behaviour?

`WrappedAccessControlledValue` and `WrappedReadAccessControlledValue` provide generic implementations that allow the developer to pass in the base ACV and a delegate that transforms the type from the base to desired type.

#### Example
##### Common
``` csharp
private readonly AccessControlledValue<Dictionary<string, int>> m_MyLookup = new AccessControlledValue<Dictionary<string, int>>(new Dictionary<string, int>());

public readonly struct LookupPresenceReader
{
   private Dictionary<string, int> m_Lookup;

   public bool IsPresent(string key)
      => m_Lookup.Contains(key);

   public LookupPresenceReader(Dictionary<string, int> lookup)
   {
      m_Lookup = lookup;
   }
}
```

##### Old
``` csharp
public IReadAccessControlledValue<LookupPresenceReader> IsInLookup { get; } 
   = new PresenceLookup(m_MyLookup);

private class PresenceLookup : AbstractAnvilBase, IReadAccessControlledValue<LookupPresenceReader>
{
   private readonly IReadAccessControlledValue<Dictionary<string, int>> m_Lookup;

    public PresenceLookup(IReadAccessControlledValue<Dictionary<string, int>> lookup)
    {
        m_Lookup = lookup;
    }

    public AccessControlledValue<LookupPresenceReader>.AccessHandle AcquireWithReadHandle()
    {
        var handle = m_Lookup.AcquireWithReadHandle();
        LookupPresenceReader reader = new LookupPresenceReader(handle.Value);

        return AccessControlledValue<LookupPresenceReader>.AccessHandle.CreateDerived(handle, reader);
    }

    public LookupPresenceReader AcquireRead()
    {
        return new LookupPresenceReader(m_Lookup.AcquireRead());
    }

    public JobHandle AcquireReadAsync(out LookupPresenceReader value)
    {
        JobHandle handle = m_Lookup.AcquireReadAsync(out var lookup);
        value = new LookupPresenceReader(lookup);
        return handle;
    }

    public void Release()
    {
        m_Lookup.Release();
    }

    public void ReleaseAsync(JobHandle releaseAccessDependency)
    {
        m_Lookup.ReleaseAsync(releaseAccessDependency);
    }
}
```

##### NEW - With wrapped ACV
``` csharp
public IReadAccessControlledValue<LookupPresenceReader> IsInLookup { get; } 
   = new WrappedReadAccessControlledValue<LookupPresenceReader, Dictionary<string, int>>(m_MyLookup);
```
### What issues does this resolve?
 - None

### What PRs does this depend on?
 - None

### Does this introduce a breaking change?
 - [ ] Yes <!-- If so, what are the migration considerations? -->
 - [x] No
