### PR TITLE
Adding patch information for EntityProxyInstanceID

### DIFF
--- a/Scripts/Runtime/Entities/TaskDriver/TaskDriverManagementSystem.cs
+++ b/Scripts/Runtime/Entities/TaskDriver/TaskDriverManagementSystem.cs
@@ -55,6 +55,7 @@ namespace Anvil.Unity.DOTS.Entities.TaskDriver
             m_TaskDriverMigrationData.AddDataSource(m_CancelCompleteDataSource);
             
             EntityProxyInstanceID.Debug_EnsureOffsetsAreCorrect();
+            EntityWorldMigrationSystem.RegisterForEntityPatching<EntityProxyInstanceID>();
         }
 
         protected override void OnCreate()


### PR DESCRIPTION
Forgot to add patching information for `EntityProxyInstanceID`

### What is the current behaviour?

If you have data in the CancelRequest or CancelProgress streams and then migrate you will run into an error.

### What is the new behaviour?

You will no longer run into the error because we have patch information now.

### What issues does this resolve?
- None

### What PRs does this depend on?
 - None

### Does this introduce a breaking change?
 - [ ] Yes
 - [x] No
