### PR TITLE
EntitySpawner - Add SpawnImmediate for collections

### DIFF
--- a/Scripts/Runtime/Entities/Lifecycle/Spawner/EntitySpawner.cs
+++ b/Scripts/Runtime/Entities/Lifecycle/Spawner/EntitySpawner.cs
@@ -196,18 +196,20 @@ namespace Anvil.Unity.DOTS.Entities
         /// <returns>A collection of all the entities spawned.</returns>
         public NativeArray<Entity> SpawnImmediate(NativeArray<TEntitySpawnDefinition> spawnDefinitions, Allocator entitiesAllocator)
         {
-            NativeArray<Entity> entities = new NativeArray<Entity>(spawnDefinitions.Length, entitiesAllocator, NativeArrayOptions.UninitializedMemory);
             EntityCommandBuffer ecb = new EntityCommandBuffer(Allocator.Temp);
             // We're using the EntityManager directly so that we have a valid Entity, but we use the ECB to set
             // the values so that we can conform to the IEntitySpawnDefinitionInterface and developers
             // don't have to implement twice.
             EntitySpawnHelper helper = AcquireEntitySpawnHelper();
 
+            NativeArray<Entity> entities = m_EntityManager.CreateEntity(
+                helper.GetEntityArchetypeForDefinition<TEntitySpawnDefinition>(),
+                spawnDefinitions.Length,
+                entitiesAllocator);
+
             for (int i = 0; i < spawnDefinitions.Length; i++)
             {
-                Entity entity = m_EntityManager.CreateEntity(helper.GetEntityArchetypeForDefinition<TEntitySpawnDefinition>());
-                entities[i] = entity;
-                spawnDefinitions[i].PopulateOnEntity(entity, ref ecb, helper);
+                spawnDefinitions[i].PopulateOnEntity(entities[i], ref ecb, helper);
             }
 
             ecb.Playback(m_EntityManager);


### PR DESCRIPTION
Add `SpawnImmediate` for collections of definitions.

### What is the current behaviour?

There are `SpawnDeferred` overloads for collections of definitions but only individual entities may be spawned immediately.

### What is the new behaviour?

 - An overload of `SpawnImmediate` that accepts a `NativeArray<TDefinition>`
 - An overload of `SpawnImmediate` that accepts a `NativeArray<TDefinition>` and returns a `NativeArray<Entity>` of spawned entities.

### What issues does this resolve?
 - None

### What PRs does this depend on?
 - None

### Does this introduce a breaking change?
 - [ ] Yes <!-- If so, what are the migration considerations? -->
 - [x] No
