### PR TITLE
WorldExtension - Sequential Create

### DIFF
--- a/Scripts/Runtime/Entities/Util/WorldExtension.cs
+++ b/Scripts/Runtime/Entities/Util/WorldExtension.cs
@@ -1,0 +1,57 @@
+using Anvil.CSharp.Logging;
+using System;
+using System.Collections.Generic;
+using Unity.Entities;
+using UnityEngine;
+
+namespace Anvil.Unity.DOTS.Entities
+{
+    /// <summary>
+    /// A collection of extension methods for <see cref="World"/>.
+    /// </summary>
+    /// <remarks>
+    /// Note: Most utilities are in <see cref="WorldUtil"/>. These methods are extension for better discoverability
+    ///       of replacement or supplemental behaviour to what <see cref="World"/> already offers.
+    /// </remarks>
+    public static class WorldExtension
+    {
+        /// <summary>
+        /// Creates (if required) the provided system types in the world sequentially and logs any errors during creation.
+        /// Creating systems sequentially allows each system to get through <see cref="ComponentSystemBase.OnCreate"/>
+        /// before the next system in the list is created. This allows systems to safely call
+        /// <see cref="World.GetOrCreateSystem"/> from their own <see cref="ComponentSystemBase.OnCreate"/> and assume
+        /// the returned instance has gone through its <see cref="ComponentSystemBase.OnCreate"/>
+        ///
+        /// In contrast, <see cref="World.GetOrCreateSystemsAndLogException"/> instantiates all system
+        /// instances before looping through and calling <see cref="ComponentSystemBase.OnCreate"/> on each of them.
+        /// This means that <see cref="World.GetOrCreateSystem"/> will return instances that have not had
+        /// <see cref="ComponentSystemBase.OnCreate"/> called on them.
+        /// </summary>
+        /// <param name="world">The world to create the systems on.</param>
+        /// <exception cref="InvalidOperationException">
+        /// Thrown if the type does not derive from a valid type.
+        /// (<see cref="ComponentSystemBase"/> or <see cref="ISystem"/>)
+        /// </exception>
+        public static void GetOrCreateSystemsSequentiallyAndLogExceptions(this World world, IEnumerable<Type> systemList)
+        {
+            foreach (Type systemType in systemList)
+            {
+                try
+                {
+                    if (typeof(ComponentSystemBase).IsAssignableFrom(systemType))
+                        world.GetOrCreateSystem(systemType);
+                    else if (typeof(ISystem).IsAssignableFrom(systemType))
+                        world.GetOrCreateUnmanagedSystem(systemType);
+                    else
+                        throw new InvalidOperationException($"Invalid system type. Type:{systemType.GetReadableName()}");
+                }
+                catch (Exception ex)
+                {
+                    Log.GetStaticLogger(typeof(WorldUtil))
+                        .Error($"Error creating system: {systemType.GetReadableName()} Error: (see next)");
+                    Debug.LogException(ex);
+                }
+            }
+        }
+    }
+}

--- a/Scripts/Runtime/Entities/Util/WorldExtension.cs
+++ b/Scripts/Runtime/Entities/Util/WorldExtension.cs
@@ -39,11 +39,17 @@ namespace Anvil.Unity.DOTS.Entities
                 try
                 {
                     if (typeof(ComponentSystemBase).IsAssignableFrom(systemType))
+                    {
                         world.GetOrCreateSystem(systemType);
+                    }
                     else if (typeof(ISystem).IsAssignableFrom(systemType))
+                    {
                         world.GetOrCreateUnmanagedSystem(systemType);
+                    }
                     else
+                    {
                         throw new InvalidOperationException($"Invalid system type. Type:{systemType.GetReadableName()}");
+                    }
                 }
                 catch (Exception ex)
                 {

--- a/Scripts/Runtime/Entities/Util/WorldExtension.cs.meta
+++ b/Scripts/Runtime/Entities/Util/WorldExtension.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 62e9e4d34f83465da556b41bca9cb25d
+timeCreated: 1684873039

--- a/Scripts/Runtime/Entities/Util/WorldUtil.cs
+++ b/Scripts/Runtime/Entities/Util/WorldUtil.cs
@@ -142,8 +142,10 @@ namespace Anvil.Unity.DOTS.Entities
         /// </param>
         /// <returns>A collection of the system groups created.</returns>
         /// <remarks>
-        /// Groups must not already exist in the world. This is a limitation of our ability to detect whether a system
-        /// has already been added to the player loop.
+        /// Groups must not already exist in the Player Loop. This is a limitation of our ability to detect whether a
+        /// system has already been added to the player loop.
+        ///
+        /// This is a safer alternative to <see cref="ScriptBehaviourUpdateOrder.AppendWorldToCurrentPlayerLoop"/>.
         /// </remarks>
         public static ComponentSystemGroup[] SetupTopLevelGroupsInCurrentPlayerLoop(
             World world,


### PR DESCRIPTION
Create `WorldExtension` and a method to bulk create systems sequentially ensuring each system has completed `OnCreate` before moving to the next system.

#### Tag Alongs
 - `WorldUtil.SetupTopLevelGroupsInCurrentPlayerLoop` Improve docs
    - Incorrectly specified that system couldn't already exist
    - Highlight difference to `ScriptBehaviourUpdateOrder.AppendWorldToCurrentPlayerLoop`

### What is the current behaviour?

Unity's existing solution `World.GetOrCreateSystemsAndLogException` instantiates all system's before calling `ComponentSystemBase.OnCreate` on each system.

This means that systems calling `world.GetOrCreateSystem` in their own `OnCreate` method may get back a system instance that has not yet had `OnCreate` called.

This is particularly problematic for `TaskDriver` instances that need system references to be fully initialized to configure jobs against the system's exposed data.

### What is the new behaviour?

Executing `world.GetOrCreateSystemsSequentiallyAndLogExceptions` will create each system in the list sequentially (if required) calling `ComponentSystemBase.OnComplete` on the system before progressing to the next system.

### What issues does this resolve?
 - None

### What PRs does this depend on?
 - None

### Does this introduce a breaking change?
 - [ ] Yes <!-- If so, what are the migration considerations? -->
 - [x] No
