### PR TITLE
CancelComplete - Implement `IToFixedString`

### DIFF
--- a/Scripts/Runtime/Entities/TaskDriver/TaskSet/TaskData/DataStream/Cancellation/CancelComplete.cs
+++ b/Scripts/Runtime/Entities/TaskDriver/TaskSet/TaskData/DataStream/Cancellation/CancelComplete.cs
@@ -1,3 +1,5 @@
+using Anvil.Unity.DOTS.Core;
+using Unity.Collections;
 using Unity.Entities;
 
 namespace Anvil.Unity.DOTS.Entities.TaskDriver
@@ -6,7 +8,7 @@ namespace Anvil.Unity.DOTS.Entities.TaskDriver
     /// Represents the completion of a Cancel Request from a generic perspective where only the <see cref="Entity"/>
     /// is returned that completed it's cancellation flow.
     /// </summary>
-    public readonly struct CancelComplete : IEntityProxyInstance
+    public readonly struct CancelComplete : IEntityProxyInstance, IToFixedString<FixedString128Bytes>
     {
         public static implicit operator Entity(CancelComplete cancelComplete) => cancelComplete.Entity;
         public static implicit operator CancelComplete(Entity entity) => new CancelComplete(entity);
@@ -19,6 +21,11 @@ namespace Anvil.Unity.DOTS.Entities.TaskDriver
         public CancelComplete(Entity entity)
         {
             Entity = entity;
+        }
+
+        public FixedString128Bytes ToFixedString()
+        {
+            return $"Entity:{Entity.ToFixedString()}";
         }
     }
 }


### PR DESCRIPTION
Have `CancelComplete` implement `IToFixedString<FixedString128Bytes>`

### What is the current behaviour?

`CancelComplete` cannot be easily represented as a fixed string.

### What is the new behaviour?

`.ToFixedString()` can now be called on a `CancelComplete` instance to get a fixed string representation of the instance.

### What issues does this resolve?
 - None

### What PRs does this depend on?
 - None

### Does this introduce a breaking change?
 - [ ] Yes <!-- If so, what are the migration considerations? -->
 - [x] No
