### PR TITLE
IAbstractDataStream - Expose configured CancelBehaviour

### DIFF
--- a/Scripts/Runtime/Entities/TaskDriver/TaskSet/TaskData/DataStream/EntityProxyDataStream.cs
+++ b/Scripts/Runtime/Entities/TaskDriver/TaskSet/TaskData/DataStream/EntityProxyDataStream.cs
@@ -40,6 +40,11 @@ namespace Anvil.Unity.DOTS.Entities.TaskDriver
 
         public Type InstanceType { get; }
 
+        public CancelRequestBehaviour CancelBehaviour
+        {
+            get => m_ActiveArrayData.CancelRequestBehaviour;
+        }
+
         //TODO: #136 - Not good to expose these just for the CancelComplete case.
         public UnsafeTypedStream<EntityProxyInstanceWrapper<TInstance>>.Writer PendingWriter { get; }
         public PendingData<EntityProxyInstanceWrapper<TInstance>> PendingData { get; }
@@ -60,7 +65,7 @@ namespace Anvil.Unity.DOTS.Entities.TaskDriver
             }
 
             ScheduleInfo = m_ActiveArrayData.ScheduleInfo;
-            
+
             InstanceType = typeof(TInstance);
         }
 
@@ -76,7 +81,7 @@ namespace Anvil.Unity.DOTS.Entities.TaskDriver
             //TODO: #136 - Not good to expose these just for the CancelComplete case.
             PendingData = systemDataStream.PendingData;
             PendingWriter = systemDataStream.PendingWriter;
-            
+
             InstanceType = typeof(TInstance);
         }
 
@@ -91,7 +96,7 @@ namespace Anvil.Unity.DOTS.Entities.TaskDriver
             //TODO: #136 - Not good to expose these just for the CancelComplete case.
             PendingWriter = m_DataSource.PendingWriter;
             PendingData = m_DataSource.PendingData;
-            
+
             InstanceType = typeof(TInstance);
         }
 

--- a/Scripts/Runtime/Entities/TaskDriver/TaskSet/TaskData/DataStream/IAbstractDataStream.cs
+++ b/Scripts/Runtime/Entities/TaskDriver/TaskSet/TaskData/DataStream/IAbstractDataStream.cs
@@ -10,6 +10,11 @@ namespace Anvil.Unity.DOTS.Entities.TaskDriver
         where TInstance : unmanaged, IEntityProxyInstance
     {
         /// <summary>
+        /// Gets the configured <see cref="CancelRequestBehaviour"/> for the data stream.
+        /// </summary>
+        public CancelRequestBehaviour CancelBehaviour { get; }
+
+        /// <summary>
         /// Gets a <see cref="DataStreamActiveReader{TInstance}"/> for use in a job outside the Task Driver context.
         /// Requires a call to <see cref="ReleaseActiveReaderAsync"/> after scheduling the job.
         /// </summary>


### PR DESCRIPTION
Add the ability to get the configured `CancelRequestBehaviour` from an `IAbstractDataStream`

### What is the current behaviour?

There is no way to read the `CancelRequestBehaviour` configured on an `IAbstractDataStream`

### What is the new behaviour?

A `CancelBehaviour` getter has been added to `IAbstractDataStream` and all anvil implementations of the interface have been updated to conform.

### What issues does this resolve?
 - None

### What PRs does this depend on?
 - None

### Does this introduce a breaking change?
 - [x] Yes  - If you have any `IAbstractDataStream` they must now implement a getter that returns the configured cancel behaviour of the stream.
 - [ ] No
