### PR TITLE
System logger world context

### DIFF
--- a/Scripts/Runtime/Entities/AbstractAnvilSystemBase.cs
+++ b/Scripts/Runtime/Entities/AbstractAnvilSystemBase.cs
@@ -31,7 +31,7 @@ namespace Anvil.Unity.DOTS.Entities
         /// </summary>
         protected Logger Logger
         {
-            get => m_Logger ?? (m_Logger = Log.GetLogger(this)).Value;
+            get => m_Logger ?? (m_Logger = Log.GetLogger(this, $"({World.Name}) ")).Value;
             set => m_Logger = value;
         }
 
@@ -61,7 +61,7 @@ namespace Anvil.Unity.DOTS.Entities
         protected override void OnCreate()
         {
             base.OnCreate();
-            
+
             EnsureSystemIsInUpdateGroup();
         }
 
@@ -122,9 +122,9 @@ namespace Anvil.Unity.DOTS.Entities
             //default world init, so it's safe to just call to ensure we're part of the right update system.
             componentSystemGroup.AddSystemToUpdateList(this);
         }
-        
+
         //Used often for getting a query from a specific system from the outside so that the
-        //query is associated to that system's dependency. Unity already does this but for 
+        //query is associated to that system's dependency. Unity already does this but for
         //the API where you pass in an EntityQueryBuilder
         public new EntityQuery GetEntityQuery(params ComponentType[] componentTypes)
         {

--- a/Scripts/Runtime/Logging/BurstableLogger.cs
+++ b/Scripts/Runtime/Logging/BurstableLogger.cs
@@ -204,7 +204,7 @@ namespace Anvil.Unity.DOTS.Logging
             // exactly equal to capacity but it's the best we can do.
             if (message.Length == message.Capacity)
             {
-                UnityEngine.Debug.LogError($"The next logged message is too long and will be truncated. Consider using a larger FixedString type. MessageLength:{message.Length}, MaxLength: {message.Capacity}");
+                UnityEngine.Debug.LogError($"The next logged message is too long and will be truncated. Consider using a larger FixedString type. MaxLength: {message.Capacity}");
             }
 
             if (message.Length + MessagePrefix.Length > FixedString4096Bytes.UTF8MaxLengthInBytes)


### PR DESCRIPTION
Add world name prefix to `AbstractAnvilSystemBase.Logger`.

#### Tag Alongs
 - `BurstableLogger` - Remove redundant string length value when reporting that a string was truncated. We don't know the source string's length so this always matches the fixed string's capacity.

### What is the current behaviour?

When there are multiple worlds the developer must include the world name themselves or guess which world a system was a part of when emitting the log message.

### What is the new behaviour?

All log messages emitted from `AbstractAnvilSystemBase` instances automatically include the world name.
Ex: "(thread: 5) (Default World) [MySystem.OnUpdate] My message"

### What issues does this resolve?
 - None

### What PRs does this depend on?
<!-- List PRs in other repos that need to be merged before this one -->
 - None

### Does this introduce a breaking change?
 - [ ] Yes <!-- If so, what are the migration considerations? -->
 - [x] No
