### PR TITLE
EntityLifecycleStatus - Expose Arrival/Departure ACVs directly

### DIFF
--- a/Scripts/Runtime/Entities/Lifecycle/EntityLifecycleStatus.cs
+++ b/Scripts/Runtime/Entities/Lifecycle/EntityLifecycleStatus.cs
@@ -18,6 +18,16 @@ namespace Anvil.Unity.DOTS.Entities
 
         private EntityQuery m_Query;
 
+        public IReadAccessControlledValue<NativeList<Entity>> ArrivedEntities
+        {
+            get => m_ArrivedEntities;
+        }
+
+        public IReadAccessControlledValue<NativeList<Entity>> DepartedEntities
+        {
+            get => m_DepartedEntities;
+        }
+
         //TODO: Support EntityQueryDesc as well.
         public EntityLifecycleStatus(AbstractEntityLifecycleStatusSystem owningSystem, params ComponentType[] queryComponentTypes)
         {
@@ -46,11 +56,11 @@ namespace Anvil.Unity.DOTS.Entities
             m_Query = m_OwningSystem.GetEntityQuery(m_QueryComponentTypes);
             m_Query.SetOrderVersionFilter();
         }
-        
+
         //*************************************************************************************************************
         // PUBLIC API
         //*************************************************************************************************************
-        
+
         //TODO: #195 - Get rid of these and expose as IReadOnlyAccessControlledValue
         /// <inheritdoc cref="IEntityLifecycleStatus.AcquireArrivalsAsync"/>
         public JobHandle AcquireArrivalsAsync(out NativeList<Entity> arrivals)
@@ -91,7 +101,7 @@ namespace Anvil.Unity.DOTS.Entities
         //*************************************************************************************************************
         // UPDATES
         //*************************************************************************************************************
-        
+
         public JobHandle UpdateAsync(
             JobHandle dependsOn,
             ref NativeArray<Entity>.ReadOnly destroyedEntities)

--- a/Scripts/Runtime/Entities/Lifecycle/IEntityLifecycleStatus.cs
+++ b/Scripts/Runtime/Entities/Lifecycle/IEntityLifecycleStatus.cs
@@ -7,46 +7,18 @@ namespace Anvil.Unity.DOTS.Entities
 {
     /// <summary>
     /// Gives Arrival (Created or Imported) and Departure (Destroyed or Evicted) information about entities
-    /// for a given world for a give frame. <seealso cref="AbstractEntityLifecycleStatusSystem"/>
+    /// for a given world and frame. <seealso cref="AbstractEntityLifecycleStatusSystem"/>
     /// </summary>
     public interface IEntityLifecycleStatus
     {
         /// <summary>
         /// Gets access to any Arrivals this frame.
         /// </summary>
-        /// <param name="arrivals">The entities that have arrived to this world this frame</param>
-        /// <returns>The <see cref="JobHandle"/> to wait upon</returns>
-        public JobHandle AcquireArrivalsAsync(out NativeList<Entity> arrivals);
+        public IReadAccessControlledValue<NativeList<Entity>> ArrivedEntities { get; }
 
         /// <summary>
         /// Gets access to any Departures this frame.
         /// </summary>
-        /// <param name="departures">The entities that have departed from this world this frame</param>
-        /// <returns>The <see cref="JobHandle"/> to wait upon</returns>
-        public JobHandle AcquireDeparturesAsync(out NativeList<Entity> departures);
-
-        /// <summary>
-        /// Releases access to the Arrivals so other jobs can access them.
-        /// </summary>
-        /// <param name="dependsOn">The <see cref="JobHandle"/> to wait upon</param>
-        public void ReleaseArrivalsAsync(JobHandle dependsOn);
-
-        /// <summary>
-        /// Releases access to the Departures so other jobs can access them.
-        /// </summary>
-        /// <param name="dependsOn">The <see cref="JobHandle"/> to wait upon</param>
-        public void ReleaseDeparturesAsync(JobHandle dependsOn);
-
-        /// <summary>
-        /// Gets access to any Arrivals this frame.
-        /// </summary>
-        /// <returns>The entities that have arrived to this world this frame</returns>
-        public AccessControlledValue<NativeList<Entity>>.AccessHandle AcquireArrivals();
-
-        /// <summary>
-        /// Gets access to any Departures this frame.
-        /// </summary>
-        /// <returns>The entities that have departed from this world this frame</returns>
-        public AccessControlledValue<NativeList<Entity>>.AccessHandle AcquireDepartures();
+        public IReadAccessControlledValue<NativeList<Entity>> DepartedEntities { get; }
     }
 }


### PR DESCRIPTION
Expose Arrival and Departure collections from `EntityLifecycleStatus` as ACV interfaces.

### What is the current behaviour?

Reading arrival and departure entities from `EntityLifecycleStatus` within a Task Driver job is cumbersome because the acquisition API doesn't conform to an ACV interface.

### What is the new behaviour?

Arrival and Departure lookups are exposed as `IReadAccessControlledValue<NativeList<Entity>>` getters.

### What issues does this resolve?
 - None

### What PRs does this depend on?
<!-- List PRs in other repos that need to be merged before this one -->
 - None

### Does this introduce a breaking change?
 - [x] Yes <!-- If so, what are the migration considerations? -->
 - [ ] No

Any use of the arrivals and departures collections will need to be adapted to use the new getters. The conversion should be familiar as they're just exposed ACVs
Ex: `entityStatus.AcquireArrivalsAsync(out var myList)` -> `entityStatus.ArrivedEntities.AcquireReadAsync(out var myList)`