### PR TITLE
No box equals

### DIFF
--- a/Scripts/Runtime/Job/AccessControl/AccessController.cs
+++ b/Scripts/Runtime/Job/AccessControl/AccessController.cs
@@ -226,7 +226,7 @@ namespace Anvil.Unity.DOTS.Jobs
             }
 
             //TODO: #129 - Remove once we have unit tests.
-            Debug.Assert(acquiredHandle.Equals(GetDependencyFor(accessType)));
+            Debug.Assert(acquiredHandle.Equals_NoBox(GetDependencyFor(accessType)));
 
             m_LastHandleAcquired = acquiredHandle;
             CaptureAccessOperationStack();

--- a/Scripts/Runtime/Job/Util/JobHandleExtension.cs
+++ b/Scripts/Runtime/Job/Util/JobHandleExtension.cs
@@ -1,7 +1,13 @@
+using Anvil.Unity.DOTS.Util;
+using System.Runtime.CompilerServices;
+using Unity.Collections.LowLevel.Unsafe;
 using Unity.Jobs;
 
 namespace Anvil.Unity.DOTS.Jobs
 {
+    /// <summary>
+    /// A collection of extension methods for <see cref="JobHandle"/>.
+    /// </summary>
     public static class JobHandleExtension
     {
         /// <summary>
@@ -30,6 +36,18 @@ namespace Anvil.Unity.DOTS.Jobs
         public static bool IsDependencyOf(this JobHandle job, JobHandle candidateJob)
         {
             return JobHandle.CheckFenceIsDependencyOrDidSyncFence(job, candidateJob);
+        }
+
+        /// <summary>
+        /// Determines whether two <see cref="JobHandle"/> instances are equal without boxing.
+        /// </summary>
+        /// <param name="job1">The first <see cref="JobHandle"/> compare.</param>
+        /// <param name="job2">The second <see cref="JobHandle"/> compare.</param>
+        /// <returns>True if the <see cref="JobHandle"/>s are the same.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static unsafe bool Equals_NoBox(this in JobHandle job1, in JobHandle job2)
+        {
+            return UnsafeUtil.Equals_NoBox(in job1, in job2);
         }
     }
 }

--- a/Scripts/Runtime/Util/UnsafeUtil.cs
+++ b/Scripts/Runtime/Util/UnsafeUtil.cs
@@ -1,0 +1,30 @@
+using Unity.Collections.LowLevel.Unsafe;
+
+namespace Anvil.Unity.DOTS.Util
+{
+    /// <summary>
+    /// A collection of utilities that help with unsafe work.
+    /// </summary>
+    public unsafe class UnsafeUtil
+    {
+        /// <summary>
+        /// Determines whether two <see cref="{T}"/> instances are equal without boxing.
+        /// </summary>
+        /// <param name="value1">The first <see cref="{T}"/> compare.</param>
+        /// <param name="value2">The second <see cref="{T}"/> compare.</param>
+        /// <returns>True if the <see cref="{T}"/>s are the same.</returns>
+        /// <remarks>
+        /// Useful for situations where <see cref="System.IEquatable{T}"/> can't be implemented
+        /// (Ex: 3rd-party assemblies)
+        /// </remarks>
+        public static bool Equals_NoBox<T>(in T value1, in T value2)
+            where T : unmanaged
+        {
+            return UnsafeUtility.MemCmp(
+                    UnsafeUtilityExtensions.AddressOf(in value1),
+                    UnsafeUtilityExtensions.AddressOf(in value2),
+                    UnsafeUtility.SizeOf<T>())
+                == 0;
+        }
+    }
+}

--- a/Scripts/Runtime/Util/UnsafeUtil.cs.meta
+++ b/Scripts/Runtime/Util/UnsafeUtil.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 22f73d76df1649a8a4be54f626611a82
+timeCreated: 1685387608


### PR DESCRIPTION
Implement a generic equality check for `unmanaged` types that doesn't cause them to be boxed.
Leveraging this allows the assertion in `AccessController` to execute without any managed allocations.

### What is the current behaviour?

Trying to perform an equality check between `JobHandle` instances results in boxing. This applies to any value types that don't implement `IEquatable<T>` or the `==` operator.

`AccessController`'s assertion produces garbage on every execution.

### What is the new behaviour?

`UnsafeUtil.Equals_NoBox<T>()` provides a way to check the equality between two `unamanged` instances by directly comparing their memory.

`JobHandle.Equals_NoBox` provides a way to perform an equality check between two `JobHandle` instances without boxing.

`AccessController`'s assertion no longer produces garbage.

### What issues does this resolve?
 - None

### What PRs does this depend on?
 - None

### Does this introduce a breaking change?
 - [ ] Yes <!-- If so, what are the migration considerations? -->
 - [x] No
