### PR TITLE
DataStreamActiveReader implement `IEnumerable<T>`

### DIFF
--- a/Scripts/Runtime/Entities/TaskDriver/TaskSet/TaskData/JobDataInteraction/DataStreamActiveReader.cs
+++ b/Scripts/Runtime/Entities/TaskDriver/TaskSet/TaskData/JobDataInteraction/DataStreamActiveReader.cs
@@ -26,5 +26,10 @@ namespace Anvil.Unity.DOTS.Entities.TaskDriver
         {
             get => m_Active[index].Payload;
         }
+
+        public int Length
+        {
+            get => m_Active.Length;
+        }
     }
 }

--- a/Scripts/Runtime/Entities/TaskDriver/TaskSet/TaskData/JobDataInteraction/DataStreamActiveReader.cs
+++ b/Scripts/Runtime/Entities/TaskDriver/TaskSet/TaskData/JobDataInteraction/DataStreamActiveReader.cs
@@ -1,3 +1,6 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
 using Unity.Collections;
 
 namespace Anvil.Unity.DOTS.Entities.TaskDriver
@@ -8,7 +11,7 @@ namespace Anvil.Unity.DOTS.Entities.TaskDriver
     /// </summary>
     /// <typeparam name="TInstance">They type of <see cref="IEntityProxyInstance"/> to read</typeparam>
     [BurstCompatible]
-    public readonly struct DataStreamActiveReader<TInstance>
+    public readonly struct DataStreamActiveReader<TInstance> : IEnumerable<TInstance>
         where TInstance : unmanaged, IEntityProxyInstance
     {
         [ReadOnly] private readonly NativeArray<EntityProxyInstanceWrapper<TInstance>> m_Active;
@@ -27,9 +30,60 @@ namespace Anvil.Unity.DOTS.Entities.TaskDriver
             get => m_Active[index].Payload;
         }
 
+        /// <summary>
+        /// Gets the length of the backing array.
+        /// </summary>
         public int Length
         {
             get => m_Active.Length;
+        }
+
+        /// <inheritdoc cref="IEnumerable"/>
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+
+        /// <inheritdoc cref="IEnumerable{T}.GetEnumerator"/>
+        public IEnumerator<TInstance> GetEnumerator()
+        {
+            return new Enumerator(m_Active.GetEnumerator());
+        }
+
+        // ----- Enumerator ----- //
+        internal struct Enumerator : IEnumerator<TInstance>, IEnumerator, IDisposable
+        {
+            private NativeArray<EntityProxyInstanceWrapper<TInstance>>.Enumerator m_InnerEnumerator;
+
+            public Enumerator(NativeArray<EntityProxyInstanceWrapper<TInstance>>.Enumerator innerEnumerator)
+            {
+                m_InnerEnumerator = innerEnumerator;
+            }
+
+            public bool MoveNext()
+            {
+                return m_InnerEnumerator.MoveNext();
+            }
+
+            public void Reset()
+            {
+                m_InnerEnumerator.Reset();
+            }
+
+            object IEnumerator.Current
+            {
+                get => m_InnerEnumerator.Current.Payload;
+            }
+
+            public void Dispose()
+            {
+                m_InnerEnumerator.Dispose();
+            }
+
+            public TInstance Current
+            {
+                get => m_InnerEnumerator.Current.Payload;
+            }
         }
     }
 }


### PR DESCRIPTION
Allow `DataStreamActiveReader` to be iterated either using `foreach` or `for`

### What is the current behaviour?

There is no way to iterate over all of the data represented by an `DataStreamActiveReader` instance.

### What is the new behaviour?

`DataStreamActiveReader`
 - Exposes a `Length` getter so that the collection may be iterated by index
 - Implements `IEnumerable<T>` so that the collection may be iterated by `Enumerator<T>`
    - The enumerator implementation is a proxy of `NativeArray<T>.Enumerator` but it selects the relevant payload data out of each `EntityProxyInstanceWrapper<TInstance>` instance.

### What issues does this resolve?
 - None

### What PRs does this depend on?
 - None

### Does this introduce a breaking change?
 - [ ] Yes <!-- If so, what are the migration considerations? -->
 - [x] No
