### PR TITLE
Adding ECB Internal helper functions

### DIFF
--- a/Scripts/AssemblyInjections/Unity.Entities/EntityCommandBufferInternal.cs
+++ b/Scripts/AssemblyInjections/Unity.Entities/EntityCommandBufferInternal.cs
@@ -3,7 +3,7 @@ using Unity.Entities;
 namespace Anvil.Unity.DOTS.Entities
 {
     /// <summary>
-    /// Helper class to access the internals in an <see cref="EntityCommandBuffer"/>
+    /// Helper class to access the internals of an <see cref="EntityCommandBuffer"/>
     /// </summary>
     public static class EntityCommandBufferInternal
     {
@@ -11,10 +11,12 @@ namespace Anvil.Unity.DOTS.Entities
         /// Returns whether the <see cref="EntityCommandBuffer"/> has been played back or not.
         /// </summary>
         /// <param name="ecb">The <see cref="EntityCommandBuffer"/> to check.</param>
-        /// <returns>true if it has been played back, false if not</returns>
+        /// <returns>
+        /// true if it has not been disposed and has been played back, false otherwise.
+        /// </returns>
         public static unsafe bool DidPlayback(this EntityCommandBuffer ecb)
         {
-            return ecb.m_Data == null || ecb.m_Data->m_DidPlayback;
+            return ecb.IsCreated && ecb.m_Data->m_DidPlayback;
         }
     }
 }

--- a/Scripts/AssemblyInjections/Unity.Entities/EntityCommandBufferInternal.cs
+++ b/Scripts/AssemblyInjections/Unity.Entities/EntityCommandBufferInternal.cs
@@ -1,0 +1,20 @@
+using Unity.Entities;
+
+namespace Anvil.Unity.DOTS.Entities
+{
+    /// <summary>
+    /// Helper class to access the internals in an <see cref="EntityCommandBuffer"/>
+    /// </summary>
+    public static class EntityCommandBufferInternal
+    {
+        /// <summary>
+        /// Returns whether the <see cref="EntityCommandBuffer"/> has been played back or not.
+        /// </summary>
+        /// <param name="ecb">The <see cref="EntityCommandBuffer"/> to check.</param>
+        /// <returns>true if it has been played back, false if not</returns>
+        public static unsafe bool DidPlayback(this EntityCommandBuffer ecb)
+        {
+            return ecb.m_Data == null || ecb.m_Data->m_DidPlayback;
+        }
+    }
+}

--- a/Scripts/AssemblyInjections/Unity.Entities/EntityCommandBufferInternal.cs.meta
+++ b/Scripts/AssemblyInjections/Unity.Entities/EntityCommandBufferInternal.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 37e65abca5db4223b539572ee2809f5f
+timeCreated: 1685556429

--- a/Scripts/AssemblyInjections/Unity.Entities/EntityCommandBufferParallelWriterInternal.cs
+++ b/Scripts/AssemblyInjections/Unity.Entities/EntityCommandBufferParallelWriterInternal.cs
@@ -11,6 +11,12 @@ namespace Anvil.Unity.DOTS.Entities
         /// Sets the Thread Index on a <see cref="EntityCommandBuffer.ParallelWriter"/> so that commands are written
         /// to the correct Thread Chain
         /// </summary>
+        /// <remarks>
+        /// This is not normally required and should be rarely used.
+        /// A <see cref="EntityCommandBuffer.ParallelWriter"/> gets it's thread index only once it enters into the
+        /// executing job that it will be used in. When accessing this writer struct from within a collection, it will
+        /// not have gotten it's thread index assigned so this function serves as a way to inject it. 
+        /// </remarks>
         /// <param name="ecbParallelWriter">The <see cref="EntityCommandBuffer.ParallelWriter"/></param>
         /// <param name="threadIndex">The thread index to set</param>
         public static void SetThreadIndex(ref this EntityCommandBuffer.ParallelWriter ecbParallelWriter, int threadIndex)

--- a/Scripts/AssemblyInjections/Unity.Entities/EntityCommandBufferParallelWriterInternal.cs
+++ b/Scripts/AssemblyInjections/Unity.Entities/EntityCommandBufferParallelWriterInternal.cs
@@ -1,0 +1,21 @@
+using Unity.Entities;
+
+namespace Anvil.Unity.DOTS.Entities
+{
+    /// <summary>
+    /// Helper class to access the internals of a <see cref="EntityCommandBuffer.ParallelWriter"/>
+    /// </summary>
+    public static class EntityCommandBufferParallelWriterInternal
+    {
+        /// <summary>
+        /// Sets the Thread Index on a <see cref="EntityCommandBuffer.ParallelWriter"/> so that commands are written
+        /// to the correct Thread Chain
+        /// </summary>
+        /// <param name="ecbParallelWriter">The <see cref="EntityCommandBuffer.ParallelWriter"/></param>
+        /// <param name="threadIndex">The thread index to set</param>
+        public static void SetThreadIndex(ref this EntityCommandBuffer.ParallelWriter ecbParallelWriter, int threadIndex)
+        {
+            ecbParallelWriter.m_ThreadIndex = threadIndex;
+        }
+    }
+}

--- a/Scripts/AssemblyInjections/Unity.Entities/EntityCommandBufferParallelWriterInternal.cs.meta
+++ b/Scripts/AssemblyInjections/Unity.Entities/EntityCommandBufferParallelWriterInternal.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 9b0616badd4b4c0193030b43dbfdd009
+timeCreated: 1685556649


### PR DESCRIPTION
Adding some assembly injections to be able to access the internals of `EntityCommandBuffer` and `EntityCommandBuffer.ParallelWriter`

### What is the current behaviour?

We can't access some of the internals.

### What is the new behaviour?

We now can access the internals.

1. `EntityCommandBuffer.DidPlayback`
- Allows us to know if a given `EntityCommandBuffer` has been played back either manually or via the `EntityCommandBufferSystem`

2. `EntityCommandBuffer.ParallelWriter.SetThreadIndex`
- Allows us to set the thread index the writer points to so that it writes the correct `ThreadChain`

### What issues does this resolve?
- None

### What PRs does this depend on?
 - None

### Does this introduce a breaking change?
 - [ ] Yes
 - [x] No
