### PR TITLE
EntityProxyDataStream - Fix empty array on main thread access

### DIFF
--- a/Scripts/Runtime/Data/Collections/DeferredNativeArray.cs
+++ b/Scripts/Runtime/Data/Collections/DeferredNativeArray.cs
@@ -459,7 +459,7 @@ namespace Anvil.Unity.DOTS.Data
 #if ENABLE_UNITY_COLLECTIONS_CHECKS
             AtomicSafetyHandle.CheckExistsAndThrow(m_Safety);
 #endif
-            NativeArray<T> array = NativeArrayUnsafeUtility.ConvertExistingDataToNativeArray<T>(m_BufferInfo->Buffer, m_BufferInfo->Length, Allocator.Invalid);
+            NativeArray<T> array = NativeArrayUnsafeUtility.ConvertExistingDataToNativeArray<T>(m_BufferInfo->Buffer, m_BufferInfo->Length, m_BufferInfo->DeferredAllocator);
 
 #if ENABLE_UNITY_COLLECTIONS_CHECKS
             NativeArrayUnsafeUtility.SetAtomicSafetyHandle(ref array, m_Safety);

--- a/Scripts/Runtime/Data/Collections/DeferredNativeArray.cs
+++ b/Scripts/Runtime/Data/Collections/DeferredNativeArray.cs
@@ -453,6 +453,21 @@ namespace Anvil.Unity.DOTS.Data
             return array;
         }
 
+        public unsafe NativeArray<T> AsArray()
+        {
+            //This whole function taken from NativeList.AsDeferredJobArray
+#if ENABLE_UNITY_COLLECTIONS_CHECKS
+            AtomicSafetyHandle.CheckExistsAndThrow(m_Safety);
+#endif
+            NativeArray<T> array = NativeArrayUnsafeUtility.ConvertExistingDataToNativeArray<T>(m_BufferInfo->Buffer, m_BufferInfo->Length, Allocator.Invalid);
+
+#if ENABLE_UNITY_COLLECTIONS_CHECKS
+            NativeArrayUnsafeUtility.SetAtomicSafetyHandle(ref array, m_Safety);
+#endif
+
+            return array;
+        }
+
         internal unsafe void* GetBufferPointer()
         {
             return m_BufferInfo;

--- a/Scripts/Runtime/Entities/TaskDriver/TaskSet/TaskData/DataStream/DataSource/Data/AbstractData.cs
+++ b/Scripts/Runtime/Entities/TaskDriver/TaskSet/TaskData/DataStream/DataSource/Data/AbstractData.cs
@@ -13,7 +13,7 @@ namespace Anvil.Unity.DOTS.Entities.TaskDriver
                                            IWorldUniqueID<DataTargetID>
     {
         private static readonly Type ABSTRACT_DATA_TYPE = typeof(AbstractData);
-        
+
         public static DataTargetID GenerateWorldUniqueID(IDataOwner dataOwner, Type abstractDataType, string uniqueContextIdentifier)
         {
             Debug.Assert(dataOwner == null || dataOwner.WorldUniqueID.IsValid);
@@ -21,7 +21,7 @@ namespace Anvil.Unity.DOTS.Entities.TaskDriver
             string idPath = $"{(dataOwner != null ? dataOwner.WorldUniqueID : string.Empty)}/{abstractDataType.AssemblyQualifiedName}{uniqueContextIdentifier ?? string.Empty}";
             return new DataTargetID(idPath.GetBurstHashCode32());
         }
-        
+
         private readonly AccessController m_AccessController;
 
         public DataTargetID WorldUniqueID { get; }
@@ -81,6 +81,12 @@ namespace Anvil.Unity.DOTS.Entities.TaskDriver
         public void Release()
         {
             m_AccessController.Release();
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public JobHandle GetDependency(AccessType accessType)
+        {
+            return m_AccessController.GetDependencyFor(accessType);
         }
     }
 }

--- a/Scripts/Runtime/Entities/TaskDriver/TaskSet/TaskData/DataStream/DataSource/Data/ActiveArrayData.cs
+++ b/Scripts/Runtime/Entities/TaskDriver/TaskSet/TaskData/DataStream/DataSource/Data/ActiveArrayData.cs
@@ -25,15 +25,20 @@ namespace Anvil.Unity.DOTS.Entities.TaskDriver
             get => m_Active;
         }
 
+        public NativeArray<T> CurrentArray
+        {
+            get => m_Active.AsArray();
+        }
+
         public ActiveArrayData(
-            IDataOwner dataOwner, 
-            CancelRequestBehaviour cancelRequestBehaviour, 
+            IDataOwner dataOwner,
+            CancelRequestBehaviour cancelRequestBehaviour,
             AbstractData pendingCancelActiveData,
-            string uniqueContextIdentifier) 
+            string uniqueContextIdentifier)
             : base(
-                dataOwner, 
-                cancelRequestBehaviour, 
-                pendingCancelActiveData, 
+                dataOwner,
+                cancelRequestBehaviour,
+                pendingCancelActiveData,
                 uniqueContextIdentifier)
         {
             m_Active = new DeferredNativeArray<T>(Allocator.Persistent);

--- a/Scripts/Runtime/Entities/TaskDriver/TaskSet/TaskData/DataStream/EntityProxyDataStream.cs
+++ b/Scripts/Runtime/Entities/TaskDriver/TaskSet/TaskData/DataStream/EntityProxyDataStream.cs
@@ -169,6 +169,10 @@ namespace Anvil.Unity.DOTS.Entities.TaskDriver
 
         public DataStreamActiveReader<TInstance> CreateDataStreamActiveReader()
         {
+            // A deferred array is only required if we're still waiting on the data to be readable.
+            // If our read job handle is ready now then the data is too and we should read from the current array.
+            // Using the deferred array would produce invalid results because the deferred array gets resolved when the
+            // data is written and in this case the writing is complete.
             bool isDeferredRequired = !m_ActiveArrayData.GetDependency(AccessType.SharedRead).IsCompleted;
             NativeArray<EntityProxyInstanceWrapper<TInstance>> sourceArray
                 = isDeferredRequired ? m_ActiveArrayData.DeferredJobArray : m_ActiveArrayData.CurrentArray;

--- a/Scripts/Runtime/Entities/TaskDriver/TaskSet/TaskData/DataStream/EntityProxyDataStream.cs
+++ b/Scripts/Runtime/Entities/TaskDriver/TaskSet/TaskData/DataStream/EntityProxyDataStream.cs
@@ -2,6 +2,7 @@ using Anvil.Unity.DOTS.Data;
 using Anvil.Unity.DOTS.Jobs;
 using System;
 using System.Runtime.CompilerServices;
+using Unity.Collections;
 using Unity.Collections.LowLevel.Unsafe;
 using Unity.Jobs;
 
@@ -168,7 +169,10 @@ namespace Anvil.Unity.DOTS.Entities.TaskDriver
 
         public DataStreamActiveReader<TInstance> CreateDataStreamActiveReader()
         {
-            return new DataStreamActiveReader<TInstance>(m_ActiveArrayData.DeferredJobArray);
+            bool isDeferredRequired = !m_ActiveArrayData.GetDependency(AccessType.SharedRead).IsCompleted;
+            NativeArray<EntityProxyInstanceWrapper<TInstance>> sourceArray
+                = isDeferredRequired ? m_ActiveArrayData.DeferredJobArray : m_ActiveArrayData.CurrentArray;
+            return new DataStreamActiveReader<TInstance>(sourceArray);
         }
 
         public DataStreamUpdater<TInstance> CreateDataStreamUpdater(ResolveTargetTypeLookup resolveTargetTypeLookup)


### PR DESCRIPTION
@jkeon Feel free to tag this for further improvement or future fixing in an issue. This was a naive attempt at fixing the issue.

### What is the current behaviour?

Using the deferred array in a synchronous context always results in a 0 length array.

### What is the new behaviour?

`EntityProxyDataStream` now correctly detects when the read dependency is complete and constructs a normal `NativeArray<T>` and passes that into the `DataStreamActiveReader`.

### What issues does this resolve?
 - None

### What PRs does this depend on?
 - None

### Does this introduce a breaking change?
 - [ ] Yes <!-- If so, what are the migration considerations? -->
 - [x] No
