### PR TITLE
Allow EntityCommandBuffers to be required on Task Driver Jobs

### DIFF
--- a/Scripts/Runtime/Entities/TaskDriver/TaskSet/Job/JobConfig/AbstractJobConfig.cs
+++ b/Scripts/Runtime/Entities/TaskDriver/TaskSet/Job/JobConfig/AbstractJobConfig.cs
@@ -317,6 +317,16 @@ namespace Anvil.Unity.DOTS.Entities.TaskDriver
         }
 
         //*************************************************************************************************************
+        // CONFIGURATION - REQUIRED DATA - EntityCommandBuffer
+        //*************************************************************************************************************
+        public IJobConfig RequireECB(EntityCommandBufferSystem ecbSystem)
+        {
+            AddAccessWrapper(new ECBAccessWrapper(ecbSystem, Usage.Default));
+
+            return this;
+        }
+
+        //*************************************************************************************************************
         // HARDEN
         //*************************************************************************************************************
 
@@ -534,6 +544,18 @@ namespace Anvil.Unity.DOTS.Entities.TaskDriver
         {
             DynamicBufferAccessWrapper<T> dynamicBufferAccessWrapper = GetAccessWrapper<DynamicBufferAccessWrapper<T>>(Usage.Default);
             instance = dynamicBufferAccessWrapper.CreateDynamicBufferExclusiveWriter();
+        }
+
+        internal void Fulfill(out EntityCommandBuffer instance)
+        {
+            ECBAccessWrapper ecbAccessWrapper = GetAccessWrapper<ECBAccessWrapper>(Usage.Default);
+            instance = ecbAccessWrapper.CommandBuffer;
+        }
+
+        internal void Fulfill(out EntityCommandBuffer.ParallelWriter instance)
+        {
+            ECBAccessWrapper ecbAccessWrapper = GetAccessWrapper<ECBAccessWrapper>(Usage.Default);
+            instance = ecbAccessWrapper.CommandBuffer.AsParallelWriter();
         }
 
         //*************************************************************************************************************

--- a/Scripts/Runtime/Entities/TaskDriver/TaskSet/Job/JobConfig/Interface/IJobConfig.cs
+++ b/Scripts/Runtime/Entities/TaskDriver/TaskSet/Job/JobConfig/Interface/IJobConfig.cs
@@ -19,7 +19,7 @@ namespace Anvil.Unity.DOTS.Entities.TaskDriver
         /// task driver specific references.
         /// </param>
         /// <param name="jobConfig">The job config instance to set requirements on.</param>
-        /// <typeparam name="T">The concrete type of the <see cref="AbstractTaskDriver"/></typeparam>
+        /// <typeparam name="T">The concrete type of the <see cref="AbstractTaskDriver"/>.</typeparam>
         /// <returns>
         /// A reference to the <see cref="IJobConfig"/> instance passed in to continue chaining configuration methods.
         /// </returns>
@@ -41,15 +41,16 @@ namespace Anvil.Unity.DOTS.Entities.TaskDriver
         /// <remarks>
         /// This is useful for the initial setup jobs or to run once after making some structural changes.
         /// </remarks>
-        /// <returns>A reference to itself to continue chaining configuration methods</returns>
+        /// <returns>A reference to itself to continue chaining configuration methods.</returns>
         public IJobConfig RunOnce();
 
         /// <summary>
         /// Specifies a <see cref="IAbstractDataStream{TInstance}"/> to be written to in a shared-write context.
         /// </summary>
         /// <param name="dataStream">The <see cref="IAbstractDataStream{TInstance}"/> to write to.</param>
-        /// <typeparam name="TInstance">The type of <see cref="IEntityProxyInstance"/> data in
-        /// the <see cref="IAbstractDataStream{TInstance}"/></typeparam>
+        /// <typeparam name="TInstance">
+        /// The type of <see cref="IEntityProxyInstance"/> data in the <see cref="IAbstractDataStream{TInstance}"/>.
+        /// </typeparam>
         /// <returns>A reference to itself to continue chaining configuration methods</returns>
         public IJobConfig RequireDataStreamForWrite<TInstance>(IAbstractDataStream<TInstance> dataStream)
             where TInstance : unmanaged, IEntityProxyInstance;
@@ -58,22 +59,23 @@ namespace Anvil.Unity.DOTS.Entities.TaskDriver
         /// Specifies a <see cref="IAbstractDataStream{TInstance}"/> to be read from in a shared-read context.
         /// </summary>
         /// <param name="dataStream">The <see cref="IAbstractDataStream{TInstance}"/> to read from.</param>
-        /// <typeparam name="TInstance">The type of <see cref="IEntityProxyInstance"/> data in
-        /// the <see cref="IAbstractDataStream{TInstance}"/></typeparam>
-        /// <returns>A reference to itself to continue chaining configuration methods</returns>
+        /// <typeparam name="TInstance">
+        /// The type of <see cref="IEntityProxyInstance"/> data in the <see cref="IAbstractDataStream{TInstance}"/>.
+        /// </typeparam>
+        /// <returns>A reference to itself to continue chaining configuration methods.</returns>
         public IJobConfig RequireDataStreamForRead<TInstance>(IAbstractDataStream<TInstance> dataStream)
             where TInstance : unmanaged, IEntityProxyInstance;
 
         /// <summary>
         /// Specifies a generic struct to be read from in a shared-read context.
         /// </summary>
-        /// <param name="data">An <see cref="IReadAccessControlledValue{T}"/> of the data to be read</param>
-        /// <typeparam name="TData">The struct inside the <see cref="IReadAccessControlledValue{T}"/></typeparam>
+        /// <param name="data">An <see cref="IReadAccessControlledValue{T}"/> of the data to be read.</param>
+        /// <typeparam name="TData">The struct inside the <see cref="IReadAccessControlledValue{T}"/>.</typeparam>
         /// <remarks>
         /// This is generally used to wrap a Native Collection like a <see cref="NativeArray{T}"/> or other collection
         /// for use in your job.
         /// </remarks>
-        /// <returns>A reference to itself to continue chaining configuration methods</returns>
+        /// <returns>A reference to itself to continue chaining configuration methods.</returns>
         public IJobConfig RequireGenericDataForRead<TData>(IReadAccessControlledValue<TData> data)
             where TData : struct;
 
@@ -82,12 +84,12 @@ namespace Anvil.Unity.DOTS.Entities.TaskDriver
         /// Sections of the struct will be written to by different threads at the same time.
         /// </summary>
         /// <param name="data">An <see cref="IAccessControlledValue{T}"/> of the data to be written to.</param>
-        /// <typeparam name="TData">The struct inside the <see cref="IAccessControlledValue{T}"/></typeparam>
+        /// <typeparam name="TData">The struct inside the <see cref="IAccessControlledValue{T}"/>.</typeparam>
         /// <remarks>
         /// This is generally used to wrap a Native Collection like a <see cref="NativeArray{T}"/> or other collection
         /// for use in your job.
         /// </remarks>
-        /// <returns>A reference to itself to continue chaining configuration methods</returns>
+        /// <returns>A reference to itself to continue chaining configuration methods.</returns>
         public IJobConfig RequireGenericDataForSharedWrite<TData>(ISharedWriteAccessControlledValue<TData> data)
             where TData : struct;
 
@@ -109,12 +111,12 @@ namespace Anvil.Unity.DOTS.Entities.TaskDriver
         /// The entire struct will be written to by only one thread at a time.
         /// </summary>
         /// <param name="data">An <see cref="IAccessControlledValue{T}"/> of the data to be written to.</param>
-        /// <typeparam name="TData">The struct inside the <see cref="IAccessControlledValue{T}"/></typeparam>
+        /// <typeparam name="TData">The struct inside the <see cref="IAccessControlledValue{T}"/>.</typeparam>
         /// <remarks>
         /// This is generally used to wrap a Native Collection like a <see cref="NativeArray{T}"/> or other collection
         /// for use in your job.
         /// </remarks>
-        /// <returns>A reference to itself to continue chaining configuration methods</returns>
+        /// <returns>A reference to itself to continue chaining configuration methods.</returns>
         public IJobConfig RequireGenericDataForExclusiveWrite<TData>(IExclusiveWriteAccessControlledValue<TData> data)
             where TData : struct;
 
@@ -131,7 +133,7 @@ namespace Anvil.Unity.DOTS.Entities.TaskDriver
         /// Please ensure you create all <see cref="EntityQuery"/>s for use with the Task system via
         /// <see cref="ComponentSystemBase.GetEntityQuery"/>.
         /// </remarks>
-        /// <returns>A reference to itself to continue chaining configuration methods</returns>
+        /// <returns>A reference to itself to continue chaining configuration methods.</returns>
         public IJobConfig RequireEntityNativeArrayFromQueryForRead(EntityQuery entityQuery);
 
         /// <summary>
@@ -148,46 +150,46 @@ namespace Anvil.Unity.DOTS.Entities.TaskDriver
         /// Please ensure you create all <see cref="EntityQuery"/>s for use with the Task system via
         /// <see cref="ComponentSystemBase.GetEntityQuery"/>.
         /// </remarks>
-        /// <returns>A reference to itself to continue chaining configuration methods</returns>
+        /// <returns>A reference to itself to continue chaining configuration methods.</returns>
         public IJobConfig RequireIComponentDataNativeArrayFromQueryForRead<T>(EntityQuery entityQuery)
             where T : struct, IComponentData;
 
         /// <summary>
-        /// Requests cancellation for specific <see cref="Entity"/> in a given <see cref="AbstractTaskDriver"/>
+        /// Requests cancellation for specific <see cref="Entity"/> in a given <see cref="AbstractTaskDriver"/>.
         /// </summary>
         /// <param name="taskDriver">The <see cref="AbstractTaskDriver"/> to cancel.</param>
-        /// <returns>A reference to itself to continue chaining configuration methods</returns>
+        /// <returns>A reference to itself to continue chaining configuration methods.</returns>
         public IJobConfig RequestCancelFor(AbstractTaskDriver taskDriver);
 
         /// <summary>
         /// Specifies a <see cref="ComponentDataFromEntity{T}"/> to be read from in a shared-read context.
         /// </summary>
-        /// <typeparam name="T">The type of <see cref="IComponentData"/> in the CDFE</typeparam>
-        /// <returns>A reference to itself to continue chaining configuration methods</returns>
+        /// <typeparam name="T">The type of <see cref="IComponentData"/> in the CDFE.</typeparam>
+        /// <returns>A reference to itself to continue chaining configuration methods.</returns>
         public IJobConfig RequireCDFEForRead<T>()
             where T : struct, IComponentData;
 
         /// <summary>
         /// Specifies a <see cref="ComponentDataFromEntity{T}"/> to be written to in a shared-write context.
         /// </summary>
-        /// <typeparam name="T">The type of <see cref="IComponentData"/> in the CDFE</typeparam>
-        /// <returns>A reference to itself to continue chaining configuration methods</returns>
+        /// <typeparam name="T">The type of <see cref="IComponentData"/> in the CDFE.</typeparam>
+        /// <returns>A reference to itself to continue chaining configuration methods.</returns>
         public IJobConfig RequireCDFEForWrite<T>()
             where T : struct, IComponentData;
 
         /// <summary>
         /// Specifies a <see cref="BufferFromEntity{T}"/> to be read from in a shared-read context.
         /// </summary>
-        /// <typeparam name="T">The type of <see cref="IBufferElementData"/> in the DBFE</typeparam>
-        /// <returns>A reference to itself to continue chaining configuration methods</returns>
+        /// <typeparam name="T">The type of <see cref="IBufferElementData"/> in the DBFE.</typeparam>
+        /// <returns>A reference to itself to continue chaining configuration methods.</returns>
         public IJobConfig RequireDBFEForRead<T>()
             where T : struct, IBufferElementData;
 
         /// <summary>
         /// Specifies a <see cref="BufferFromEntity{T}"/> to be written to in an exclusive-write context.
         /// </summary>
-        /// <typeparam name="T">The type of <see cref="IBufferElementData"/> in the DBFE</typeparam>
-        /// <returns>A reference to itself to continue chaining configuration methods</returns>
+        /// <typeparam name="T">The type of <see cref="IBufferElementData"/> in the DBFE.</typeparam>
+        /// <returns>A reference to itself to continue chaining configuration methods.</returns>
         public IJobConfig RequireDBFEForExclusiveWrite<T>()
             where T : struct, IBufferElementData;
 
@@ -199,7 +201,7 @@ namespace Anvil.Unity.DOTS.Entities.TaskDriver
         /// <param name="taskDriver">The task driver instance that the job is being configured on. (usually this)</param>
         /// <param name="configureRequirements">The delegate to call to configure requirements.</param>
         /// <typeparam name="T">The type of the task driver instance.</typeparam>
-        /// <returns>A reference to itself to continue chaining configuration methods</returns>
+        /// <returns>A reference to itself to continue chaining configuration methods.</returns>
         IJobConfig AddRequirementsFrom<T>(T taskDriver, ConfigureJobRequirementsDelegate<T> configureRequirements)
             where T : AbstractTaskDriver;
     }

--- a/Scripts/Runtime/Entities/TaskDriver/TaskSet/Job/JobConfig/Interface/IJobConfig.cs
+++ b/Scripts/Runtime/Entities/TaskDriver/TaskSet/Job/JobConfig/Interface/IJobConfig.cs
@@ -194,6 +194,15 @@ namespace Anvil.Unity.DOTS.Entities.TaskDriver
             where T : struct, IBufferElementData;
 
         /// <summary>
+        /// Specifies a <see cref="EntityCommandBuffer"/> to be populated.
+        /// </summary>
+        /// <param name="ecbSystem">
+        /// The <see cref="EntityCommandBufferSystem"/> to create the <see cref="EntityCommandBuffer"/> from.
+        /// </param>
+        /// <returns>A reference to itself to continue chaining configuration methods.</returns>
+        IJobConfig RequireECB(EntityCommandBufferSystem ecbSystem);
+
+        /// <summary>
         /// Specifies a delegate to call to add additional requirements.
         /// This allows requirements to be defined by a static method on the job rather than at the configuration call
         /// site.

--- a/Scripts/Runtime/Entities/TaskDriver/TaskSet/Job/JobConfig/NoOpJobConfig.cs
+++ b/Scripts/Runtime/Entities/TaskDriver/TaskSet/Job/JobConfig/NoOpJobConfig.cs
@@ -116,6 +116,11 @@ namespace Anvil.Unity.DOTS.Entities.TaskDriver
             return this;
         }
 
+        public IJobConfig RequireECB(EntityCommandBufferSystem ecbSystem)
+        {
+            return this;
+        }
+
         public IJobConfig AddRequirementsFrom<T>(T taskDriver, IJobConfig.ConfigureJobRequirementsDelegate<T> configureRequirements)
             where T : AbstractTaskDriver
         {

--- a/Scripts/Runtime/Entities/TaskDriver/TaskSet/Job/JobData/AbstractJobData.cs
+++ b/Scripts/Runtime/Entities/TaskDriver/TaskSet/Job/JobData/AbstractJobData.cs
@@ -192,5 +192,25 @@ namespace Anvil.Unity.DOTS.Entities.TaskDriver
         {
             m_JobConfig.Fulfill(out instance);
         }
+
+        //*************************************************************************************************************
+        // ENTITY COMMAND BUFFER
+        //*************************************************************************************************************
+
+        /// <summary>
+        /// Fulfills an instance of the provided type for the job.
+        /// </summary>
+        public void Fulfill(out EntityCommandBuffer instance)
+        {
+            m_JobConfig.Fulfill(out instance);
+        }
+
+        /// <summary>
+        /// Fulfills an instance of the provided type for the job.
+        /// </summary>
+        public void Fulfill(out EntityCommandBuffer.ParallelWriter instance)
+        {
+            m_JobConfig.Fulfill(out instance);
+        }
     }
 }

--- a/Scripts/Runtime/Entities/TaskDriver/TaskSet/Job/JobData/AbstractJobData.cs
+++ b/Scripts/Runtime/Entities/TaskDriver/TaskSet/Job/JobData/AbstractJobData.cs
@@ -31,12 +31,18 @@ namespace Anvil.Unity.DOTS.Entities.TaskDriver
             World = m_JobConfig.TaskSetOwner.World;
         }
 
+        /// <summary>
+        /// Fulfills an instance of the provided type for the job.
+        /// </summary>
         public void Fulfill(out CancelRequestsWriter instance)
         {
             CancelRequestsDataStream cancelRequestDataStream = m_JobConfig.GetCancelRequestsDataStream();
             instance = cancelRequestDataStream.CreateCancelRequestsWriter();
         }
 
+        /// <summary>
+        /// Fulfills an instance of the provided type for the job.
+        /// </summary>
         public void Fulfill<TInstance>(out DataStreamPendingWriter<TInstance> instance)
             where TInstance : unmanaged, IEntityProxyInstance
         {
@@ -44,6 +50,9 @@ namespace Anvil.Unity.DOTS.Entities.TaskDriver
             instance = dataStream.CreateDataStreamPendingWriter();
         }
 
+        /// <summary>
+        /// Fulfills an instance of the provided type for the job.
+        /// </summary>
         public void Fulfill<TInstance>(out DataStreamActiveReader<TInstance> instance)
             where TInstance : unmanaged, IEntityProxyInstance
         {
@@ -90,7 +99,7 @@ namespace Anvil.Unity.DOTS.Entities.TaskDriver
         }
 
         /// <summary>
-        /// Fulfills assigns an instance of the provided type for the job.
+        /// Fulfills an instance of the provided type for the job.
         /// </summary>
         public void Fulfill<TData>(out ThreadPersistentDataAccessor<TData> instance)
             where TData : unmanaged, IThreadPersistentDataInstance
@@ -100,7 +109,7 @@ namespace Anvil.Unity.DOTS.Entities.TaskDriver
         }
 
         /// <summary>
-        /// Fulfills assigns an instance of the provided type for the job.
+        /// Fulfills an instance of the provided type for the job.
         /// </summary>
         public void Fulfill<TData>(out EntityPersistentDataReader<TData> instance)
             where TData : unmanaged, IEntityPersistentDataInstance
@@ -110,7 +119,7 @@ namespace Anvil.Unity.DOTS.Entities.TaskDriver
         }
 
         /// <summary>
-        /// Fulfills assigns an instance of the provided type for the job.
+        /// Fulfills an instance of the provided type for the job.
         /// </summary>
         public void Fulfill<TData>(out EntityPersistentDataWriter<TData> instance)
             where TData : unmanaged, IEntityPersistentDataInstance
@@ -149,7 +158,7 @@ namespace Anvil.Unity.DOTS.Entities.TaskDriver
 
         //TODO: #86 - Revisit this section after Entities 1.0 upgrade for name changes to CDFE
         /// <summary>
-        /// Fulfills assigns an instance of the provided type for the job.
+        /// Fulfills an instance of the provided type for the job.
         /// </summary>
         public void Fulfill<T>(out CDFEReader<T> instance)
             where T : struct, IComponentData
@@ -158,7 +167,7 @@ namespace Anvil.Unity.DOTS.Entities.TaskDriver
         }
 
         /// <summary>
-        /// Fulfills assigns an instance of the provided type for the job.
+        /// Fulfills an instance of the provided type for the job.
         /// </summary>
         public void Fulfill<T>(out CDFEWriter<T> instance)
             where T : struct, IComponentData
@@ -167,7 +176,7 @@ namespace Anvil.Unity.DOTS.Entities.TaskDriver
         }
 
         /// <summary>
-        /// Fulfills assigns an instance of the provided type for the job.
+        /// Fulfills an instance of the provided type for the job.
         /// </summary>
         public void Fulfill<T>(out DBFEForRead<T> instance)
             where T : struct, IBufferElementData
@@ -176,7 +185,7 @@ namespace Anvil.Unity.DOTS.Entities.TaskDriver
         }
 
         /// <summary>
-        /// Fulfills assigns an instance of the provided type for the job.
+        /// Fulfills an instance of the provided type for the job.
         /// </summary>
         public void Fulfill<T>(out DBFEForExclusiveWrite<T> instance)
             where T : struct, IBufferElementData

--- a/Scripts/Runtime/Entities/TaskDriver/TaskSet/Job/Wrapper/ECBAccessWrapper.cs
+++ b/Scripts/Runtime/Entities/TaskDriver/TaskSet/Job/Wrapper/ECBAccessWrapper.cs
@@ -1,0 +1,35 @@
+using Anvil.Unity.DOTS.Jobs;
+using Unity.Entities;
+using Unity.Jobs;
+using UnityEngine;
+
+namespace Anvil.Unity.DOTS.Entities.TaskDriver
+{
+    internal class ECBAccessWrapper : AbstractAccessWrapper
+    {
+        private readonly EntityCommandBufferSystem m_ECBSystem;
+
+        public EntityCommandBuffer CommandBuffer
+        {
+            get => m_ECBSystem.CreateCommandBuffer();
+        }
+
+
+        // Note: The AccessType value doesn't really matter since there isn't access control on an ECB. You're getting
+        // one instance per Acquire and the system is aggregating dependencies on release.
+        public ECBAccessWrapper(EntityCommandBufferSystem ecbSystem, AbstractJobConfig.Usage usage) : base(AccessType.ExclusiveWrite, usage)
+        {
+            m_ECBSystem = ecbSystem;
+        }
+
+        public override JobHandle AcquireAsync()
+        {
+            return default;
+        }
+
+        public override void ReleaseAsync(JobHandle dependsOn)
+        {
+            m_ECBSystem.AddJobHandleForProducer(dependsOn);
+        }
+    }
+}

--- a/Scripts/Runtime/Entities/TaskDriver/TaskSet/Job/Wrapper/ECBAccessWrapper.cs.meta
+++ b/Scripts/Runtime/Entities/TaskDriver/TaskSet/Job/Wrapper/ECBAccessWrapper.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 73515db8b97447f9895a988d469a96ef
+timeCreated: 1685545206


### PR DESCRIPTION
Task driver jobs can now "Require" an ECB for their job and fulfill off the `jobData`.

#### Tag Along
 - Fixed a bunch of docs ion `IJobConfig` and `AbstractJobData`

### What is the current behaviour?

Developers must manually override the `Schedule` delegate to acquire and pass in an `EntityCommandBuffer` when desired in the job.

### What is the new behaviour?

Developers may now use the same "Require"/"Fulfill" API that they do for all other job dependencies.

### What issues does this resolve?
 - None

### What PRs does this depend on?
 - None

### Does this introduce a breaking change?
 - [ ] Yes <!-- If so, what are the migration considerations? -->
 - [x] No
