### PR TITLE
AbstractAnvilSystemBase - Expose GetEntityQuery(EntityQueryDesc)

### DIFF
--- a/Scripts/Runtime/Entities/AbstractAnvilSystemBase.cs
+++ b/Scripts/Runtime/Entities/AbstractAnvilSystemBase.cs
@@ -130,5 +130,13 @@ namespace Anvil.Unity.DOTS.Entities
         {
             return base.GetEntityQuery(componentTypes);
         }
+
+        //Used often for getting a query from a specific system from the outside so that the
+        //query is associated to that system's dependency. Unity already does this but for
+        //the API where you pass in an EntityQueryBuilder
+        public new EntityQuery GetEntityQuery(params EntityQueryDesc[] queryDesc)
+        {
+            return base.GetEntityQuery(queryDesc);
+        }
     }
 }


### PR DESCRIPTION
Publicly expose `GetEntityQuery(EntityQueryDesc)` on `AbstractAnvilSystemBase` so that types that uses the "OwningSystem" pattern can get queries that set define `EntityQueryOptions`

### What is the current behaviour?

There is no way to specify `EntityQueryOptions` with the more common `GetEntityQuery(`ComponentType<T>`) overload.

### What is the new behaviour?

Developers have access to `GetEntityQuery(EntityQueryDesc)` so that more advanced queries can be defined for creation.

### What issues does this resolve?
 - None

### What PRs does this depend on?
 - None

### Does this introduce a breaking change?
 - [ ] Yes <!-- If so, what are the migration considerations? -->
 - [x] No
