### PR TITLE
Add ability to unwind DriverDataStreams on cancel

### DIFF
--- a/Scripts/Runtime/Entities/TaskDriver/AbstractTaskDriver.cs
+++ b/Scripts/Runtime/Entities/TaskDriver/AbstractTaskDriver.cs
@@ -32,7 +32,7 @@ namespace Anvil.Unity.DOTS.Entities.TaskDriver
         private bool m_HasCancellableData;
 
         /// <summary>
-        /// Reference to the associated <see cref="World"/>
+        /// Reference to the associated <see cref="World"/>.
         /// </summary>
         public World World { get; }
 
@@ -43,7 +43,7 @@ namespace Anvil.Unity.DOTS.Entities.TaskDriver
         internal TaskSet TaskSet { get; }
 
         /// <summary>
-        /// Data Stream representing requests to Cancel an <see cref="Entity"/>
+        /// Data Stream representing requests to Cancel an <see cref="Entity"/>.
         /// </summary>
         public IDriverCancelRequestDataStream CancelRequestDataStream
         {
@@ -51,7 +51,7 @@ namespace Anvil.Unity.DOTS.Entities.TaskDriver
         }
 
         /// <summary>
-        /// Data Stream representing when Cancel Requests are Complete
+        /// Data Stream representing when Cancel Requests are Complete.
         /// </summary>
         public IDriverDataStream<CancelComplete> CancelCompleteDataStream
         {
@@ -95,7 +95,7 @@ namespace Anvil.Unity.DOTS.Entities.TaskDriver
         }
 
         /// <summary>
-        /// Creates a new instance of a <see cref="AbstractTaskDriver"/>
+        /// Creates a new instance of a <see cref="AbstractTaskDriver"/>.
         /// </summary>
         /// <param name="world">The <see cref="World"/> this Task Driver is a part of.</param>
         /// <param name="parent">The parent <see cref="AbstractTaskDriver"/> if it exists</param>
@@ -106,7 +106,7 @@ namespace Anvil.Unity.DOTS.Entities.TaskDriver
         /// ShootTaskDriver
         ///  - TimerTaskDriver (for time between shots)
         ///  - TimerTaskDriver (for reloading)
-        /// 
+        ///
         /// Both TimerTaskDriver's would conflict as being siblings of the ShootTaskDriver so they would need a unique
         /// context identifier to distinguish them for ensuring migration happens properly between worlds and data
         /// goes to the correct location.
@@ -220,7 +220,7 @@ namespace Anvil.Unity.DOTS.Entities.TaskDriver
         //*************************************************************************************************************
 
         /// <summary>
-        /// Configures a Job that is triggered by instances being present in the passed in <see cref="IDriverDataStream{TInstance}"/>
+        /// Configures a Job that is triggered by instances being present in the passed in <see cref="IDriverDataStream{TInstance}"/>.
         /// </summary>
         /// <param name="dataStream">The <see cref="IDriverDataStream{TInstance}"/> to trigger the job off of.</param>
         /// <param name="scheduleJobFunction">The scheduling function to call to schedule the job.</param>
@@ -264,7 +264,7 @@ namespace Anvil.Unity.DOTS.Entities.TaskDriver
 
         /// <summary>
         /// Configures a Job that is triggered by <see cref="Entity"/> or <see cref="IComponentData"/> being
-        /// present in the passed in <see cref="EntityQuery"/>
+        /// present in the passed in <see cref="EntityQuery"/>.
         /// </summary>
         /// <param name="entityQuery">The <see cref="EntityQuery"/> to trigger the job off of.</param>
         /// <param name="scheduleJobFunction">The scheduling function to call to schedule the job.</param>

--- a/Scripts/Runtime/Entities/TaskDriver/AbstractTaskDriver.cs
+++ b/Scripts/Runtime/Entities/TaskDriver/AbstractTaskDriver.cs
@@ -240,6 +240,29 @@ namespace Anvil.Unity.DOTS.Entities.TaskDriver
         }
 
         /// <summary>
+        /// Configures an <see cref="ITaskCancelJobForDefer{TInstance}"/> job to be run. This will operate
+        /// on data in a stream that has been requested to cancel with <see cref="CancelRequestBehaviour.Unwind"/>. It
+        /// provides the opportunity for the job to do the unwinding for however long that takes and to eventually
+        /// resolve to notify of a <see cref="CancelComplete"/>.
+        /// </summary>
+        /// <param name="dataStream">The <see cref="IDriverDataStream{TInstance}"/> to schedule the job on.</param>
+        /// <param name="scheduleJobFunction">The callback function to perform the scheduling</param>
+        /// <param name="batchStrategy">The <see cref="BatchStrategy"/> to use for scheduling</param>
+        /// <typeparam name="TInstance">The type of <see cref="IEntityProxyInstance"/> in the stream</typeparam>
+        /// <returns>A <see cref="IJobConfig"/> to allow for chaining more configuration options.</returns>
+        public IJobConfig ConfigureJobToCancel<TInstance>(
+            IDriverDataStream<TInstance> dataStream,
+            JobConfigScheduleDelegates.ScheduleCancelJobDelegate<TInstance> scheduleJobFunction,
+            BatchStrategy batchStrategy)
+            where TInstance : unmanaged, IEntityProxyInstance
+        {
+            return TaskSet.ConfigureJobToCancel(
+                (EntityProxyDataStream<TInstance>)dataStream,
+                scheduleJobFunction,
+                batchStrategy);
+        }
+
+        /// <summary>
         /// Configures a Job that is triggered by <see cref="Entity"/> or <see cref="IComponentData"/> being
         /// present in the passed in <see cref="EntityQuery"/>
         /// </summary>

--- a/Scripts/Runtime/Entities/TaskDriver/System/ITaskDriverSystem.cs
+++ b/Scripts/Runtime/Entities/TaskDriver/System/ITaskDriverSystem.cs
@@ -4,17 +4,17 @@ namespace Anvil.Unity.DOTS.Entities.TaskDriver
 {
     /// <summary>
     /// Represents a <see cref="AbstractTaskDriverSystem"/> through the context of the calling
-    /// <see cref="AbstractTaskDriver"/>. 
+    /// <see cref="AbstractTaskDriver"/>.
     /// </summary>
     public interface ITaskDriverSystem
     {
         /// <summary>
-        /// Data Stream representing requests to Cancel an <see cref="Entity"/> on the system
+        /// Data Stream representing requests to Cancel an <see cref="Entity"/> on the system.
         /// </summary>
         public ISystemCancelRequestDataStream CancelRequestDataStream { get; }
-        
+
         /// <summary>
-        /// Data Stream representing when Cancel Requests are Complete on the system
+        /// Data Stream representing when Cancel Requests are Complete on the system.
         /// </summary>
         public ISystemDataStream<CancelComplete> CancelCompleteDataStream { get; }
 
@@ -59,7 +59,7 @@ namespace Anvil.Unity.DOTS.Entities.TaskDriver
         /// Configures an <see cref="ITaskCancelJobForDefer{TInstance}"/> job to be run on the system. This will operate
         /// on data in a stream that has been requested to cancel with <see cref="CancelRequestBehaviour.Unwind"/>. It
         /// provides the opportunity for the job to do the unwinding for however long that takes and to eventually
-        /// resolve into a new data type and inherently notify of a <see cref="CancelComplete"/>
+        /// resolve into a new data type and inherently notify of a <see cref="CancelComplete"/>.
         /// </summary>
         /// <param name="dataStream">The <see cref="ISystemDataStream{TInstance}"/> to schedule the job on.</param>
         /// <param name="scheduleJobFunction">The callback function to perform the scheduling</param>
@@ -76,7 +76,7 @@ namespace Anvil.Unity.DOTS.Entities.TaskDriver
             where TInstance : unmanaged, IEntityProxyInstance;
 
         /// <summary>
-        /// Gets or Creates an <see cref="EntityQuery"/> tied to this system. 
+        /// Gets or Creates an <see cref="EntityQuery"/> tied to this system.
         /// </summary>
         /// <param name="componentTypes">The <see cref="ComponentType"/>s to construct the query.</param>
         /// <returns>The <see cref="EntityQuery"/> instance</returns>


### PR DESCRIPTION
Add the ability to configure a cancel job for `IDriverDataStream`s that are configured `CancelBehaviour.Unwind`

### What is the current behaviour?

Only `ISystemDataStream`s can have jobs configured to handle unwinding cancel requests.

This means that `IDriverDataStream`s configured with `CancelBehaviour.Unwind` would get stuck since the developer could not resolve the unwinding with a job.

### What is the new behaviour?

Developer can now call `ConfigureJobToCancel` on their task driver instance to handle unwinding a `IDriverDataStream` instnace.

### What issues does this resolve?
 - None? @jkeon did you have an issue for this?

### What PRs does this depend on?
 - None

### Does this introduce a breaking change?
 - [ ] Yes <!-- If so, what are the migration considerations? -->
 - [x] No
