### PR TITLE
Exposing the ability to schedule Vanilla Unity jobs off of DataStreams

### DIFF
--- a/Scripts/Runtime/Entities/TaskDriver/TaskSet/TaskData/DataStream/Cancellation/CancelRequestsDataStream.cs
+++ b/Scripts/Runtime/Entities/TaskDriver/TaskSet/TaskData/DataStream/Cancellation/CancelRequestsDataStream.cs
@@ -23,6 +23,7 @@ namespace Anvil.Unity.DOTS.Entities.TaskDriver
             get => m_DataSource;
         }
         
+        /// <inheritdoc cref="IAbstractDataStream.ActiveDataVersion"/>
         public uint ActiveDataVersion
         {
             get => ActiveLookupData.Version;
@@ -88,6 +89,7 @@ namespace Anvil.Unity.DOTS.Entities.TaskDriver
             ReleasePending();
         }
         
+        /// <inheritdoc cref="IAbstractDataStream.IsActiveDataInvalidated"/>
         public bool IsActiveDataInvalidated(uint lastVersion)
         {
             return ActiveLookupData.IsDataInvalidated(lastVersion);

--- a/Scripts/Runtime/Entities/TaskDriver/TaskSet/TaskData/DataStream/Cancellation/CancelRequestsDataStream.cs
+++ b/Scripts/Runtime/Entities/TaskDriver/TaskSet/TaskData/DataStream/Cancellation/CancelRequestsDataStream.cs
@@ -22,6 +22,11 @@ namespace Anvil.Unity.DOTS.Entities.TaskDriver
         {
             get => m_DataSource;
         }
+        
+        public uint ActiveDataVersion
+        {
+            get => ActiveLookupData.Version;
+        }
 
         public CancelRequestsDataStream(ITaskSetOwner taskSetOwner) : base(taskSetOwner)
         {
@@ -81,6 +86,11 @@ namespace Anvil.Unity.DOTS.Entities.TaskDriver
         public void ReleaseCancelRequestsWriter()
         {
             ReleasePending();
+        }
+        
+        public bool IsActiveDataInvalidated(uint lastVersion)
+        {
+            return ActiveLookupData.IsDataInvalidated(lastVersion);
         }
     }
 }

--- a/Scripts/Runtime/Entities/TaskDriver/TaskSet/TaskData/DataStream/DataSource/Data/AbstractData.cs
+++ b/Scripts/Runtime/Entities/TaskDriver/TaskSet/TaskData/DataStream/DataSource/Data/AbstractData.cs
@@ -31,18 +31,7 @@ namespace Anvil.Unity.DOTS.Entities.TaskDriver
 
         public AbstractData ActiveCancelData { get; }
 
-        /// <summary>
-        /// The version of the data. This value is incremented each time write access is granted to the data allowing
-        /// consumers to check whether the data may have changed since the last time the consumer read it.
-        /// </summary>
-        /// <remarks>
-        /// Store this value at the time of read access and on next potential read use <see cref="IsDataInvalidated"/>
-        /// to check whether the data has potentially changed. This is the safest option as it accounts for other potential
-        /// conditions in the data.
-        ///
-        /// If comparing version numbers directly make sure to always use an equality check. The version number can
-        /// theoretically wrap and overflow so it's possible for the current value to be less than the previous value.
-        /// </remarks>
+        /// <inheritdoc cref="IAbstractDataStream.ActiveDataVersion"/>
         public uint Version { get; private set; }
 
         private DataTargetID m_WorldUniqueID;
@@ -73,12 +62,7 @@ namespace Anvil.Unity.DOTS.Entities.TaskDriver
 
         protected abstract void DisposeData();
 
-        /// <summary>
-        /// Whether the underlying data has potentially been updated by something getting write access to it.
-        /// </summary>
-        /// <param name="lastVersion">
-        /// A write version at the last read.
-        /// </param>
+        /// <inheritdoc cref="IAbstractDataStream.IsActiveDataInvalidated"/>
         public virtual bool IsDataInvalidated(uint lastVersion)
         {
             // If the current data version has changed from what we last stored, then someone has written here

--- a/Scripts/Runtime/Entities/TaskDriver/TaskSet/TaskData/DataStream/IAbstractDataStream.cs
+++ b/Scripts/Runtime/Entities/TaskDriver/TaskSet/TaskData/DataStream/IAbstractDataStream.cs
@@ -79,5 +79,29 @@ namespace Anvil.Unity.DOTS.Entities.TaskDriver
     /// The first is a parallel writable collection to be able to write pending instances to.
     /// The second is a narrow array collection for reading.
     /// </summary>
-    public interface IAbstractDataStream { }
+    public interface IAbstractDataStream
+    {
+        /// <summary>
+        /// The version of the data. This value is incremented each time write access is granted to the data allowing
+        /// consumers to check whether the data may have changed since the last time the consumer read it.
+        /// </summary>
+        /// <remarks>
+        /// Store this value at the time of read access and on next potential read use <see cref="IsActiveDataInvalidated"/>
+        /// to check whether the data has potentially changed. This is the safest option as it accounts for other potential
+        /// conditions in the data.
+        ///
+        /// If comparing version numbers directly make sure to always use an equality check. The version number can
+        /// theoretically wrap and overflow so it's possible for the current value to be less than the previous value.
+        /// </remarks>
+        public uint ActiveDataVersion { get; }
+        
+        /// <summary>
+        /// Whether the underlying data has potentially been updated by something getting write access to it.
+        /// </summary>
+        /// <param name="lastVersion">
+        /// A write version at the last read.
+        /// </param>
+        /// <returns>true if the data has potentially been updated, false if not</returns>
+        public bool IsActiveDataInvalidated(uint lastVersion);
+    }
 }

--- a/Scripts/Runtime/Entities/TaskDriver/TaskSet/TaskData/DataStream/UnityJobCompatibility.meta
+++ b/Scripts/Runtime/Entities/TaskDriver/TaskSet/TaskData/DataStream/UnityJobCompatibility.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: a2ed1fae8a094810a23a318fc9e3430b
+timeCreated: 1687443956

--- a/Scripts/Runtime/Entities/TaskDriver/TaskSet/TaskData/DataStream/UnityJobCompatibility/DataStreamJobScheduler.cs
+++ b/Scripts/Runtime/Entities/TaskDriver/TaskSet/TaskData/DataStream/UnityJobCompatibility/DataStreamJobScheduler.cs
@@ -1,0 +1,51 @@
+using Unity.Entities;
+using Unity.Jobs;
+
+namespace Anvil.Unity.DOTS.Entities.TaskDriver
+{
+    /// <summary>
+    /// Helper class to allow for easy job scheduling on a <see cref="IAbstractDataStream"/> when not running through
+    /// a <see cref="AbstractTaskDriver"/>. Ex. A regular Unity <see cref="ComponentSystemBase"/>.
+    /// </summary>
+    /// <typeparam name="TInstance">The data inside the data stream.</typeparam>
+    public class DataStreamJobScheduler<TInstance>
+        where TInstance : unmanaged, IEntityProxyInstance
+    {
+        /// <summary>
+        /// A scheduling delegate to perform custom scheduling of the job that will the use the data stream
+        /// to run off of.
+        /// </summary>
+        public delegate JobHandle ScheduleFunction(IAbstractDataStream<TInstance> dataStream, JobHandle dependsOn);
+        
+        private uint m_LastVersion;
+        private readonly IAbstractDataStream<TInstance> m_DataStream;
+        private readonly ScheduleFunction m_ScheduleFunction;
+        
+        public DataStreamJobScheduler(IAbstractDataStream<TInstance> dataStream, ScheduleFunction scheduleFunction) 
+        {
+            m_DataStream = dataStream;
+            m_ScheduleFunction = scheduleFunction;
+            m_LastVersion = m_DataStream.ActiveDataVersion;
+        }
+
+        /// <summary>
+        /// Will schedule the job if the underlying data stream has potentially been written to since the last
+        /// time this function was called. 
+        /// </summary>
+        /// <param name="dependsOn">The <see cref="JobHandle"/> to wait upon</param>
+        /// <returns>The <see cref="JobHandle"/> that represents the work that was scheduled</returns>
+        public JobHandle ScheduleIfNecessary(JobHandle dependsOn)
+        {
+            if (!m_DataStream.IsActiveDataInvalidated(m_LastVersion))
+            {
+                return dependsOn;
+            }
+
+            dependsOn = m_ScheduleFunction(m_DataStream, dependsOn);
+
+            m_LastVersion = m_DataStream.ActiveDataVersion;
+
+            return dependsOn;
+        }
+    }
+}

--- a/Scripts/Runtime/Entities/TaskDriver/TaskSet/TaskData/DataStream/UnityJobCompatibility/DataStreamJobScheduler.cs.meta
+++ b/Scripts/Runtime/Entities/TaskDriver/TaskSet/TaskData/DataStream/UnityJobCompatibility/DataStreamJobScheduler.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 523fb17c7f92443f85c14926fe81a562
+timeCreated: 1687443985


### PR DESCRIPTION
TaskDrivers utilize DataStreams to do their work but sometimes you need to run a job in a Vanilla Unity system based on those datastreams. 

### What is the current behaviour?

No nice way to handle this.

### What is the new behaviour?

Introducing a wrapper for a DataStream to manage scheduling a job off of a DataStream while checking if the data has possibly been invalidated or not. This makes it easy to include in your system and not have to worry about managing the last known version etc.

### What issues does this resolve?
- None

### What PRs does this depend on?
 - None

### Does this introduce a breaking change?
 - [ ] Yes
 - [x] No
