### PR TITLE
Supporting spawning Prototype Variants

### DIFF
--- a/Scripts/Runtime/Entities/Lifecycle/EntitySpawnSystem.cs
+++ b/Scripts/Runtime/Entities/Lifecycle/EntitySpawnSystem.cs
@@ -126,16 +126,16 @@ namespace Anvil.Unity.DOTS.Entities
         // PROTOTYPE REGISTRATION
         //*************************************************************************************************************
 
-        public void RegisterEntityPrototypeForDefinition<TEntitySpawnDefinition>(Entity prototype, int variant = default)
+        public void RegisterEntityPrototypeForDefinition<TEntitySpawnDefinition>(Entity prototype, PrototypeVariant variant = default)
             where TEntitySpawnDefinition : unmanaged, IEntitySpawnDefinition
         {
             using var handle = m_EntityPrototypes.AcquireWithHandle(AccessType.ExclusiveWrite);
-            int hash = HashCodeUtil.GetHashCode(BurstRuntime.GetHashCode32<TEntitySpawnDefinition>(), variant);
+            int hash = variant.GetVariantHashForDefinition<TEntitySpawnDefinition>();
             DEBUG_EnsurePrototypeIsNotRegistered(typeof(TEntitySpawnDefinition), hash, handle.Value);
             handle.Value.Add(hash, prototype);
         }
 
-        public void UnregisterEntityPrototypeForDefinition<TEntitySpawnDefinition>(bool shouldDestroy, int variant = default)
+        public void UnregisterEntityPrototypeForDefinition<TEntitySpawnDefinition>(bool shouldDestroy, PrototypeVariant variant = default)
             where TEntitySpawnDefinition : unmanaged, IEntitySpawnDefinition
         {
             //If we're tearing down and this system was destroyed before whoever was trying to unregister, we
@@ -146,7 +146,7 @@ namespace Anvil.Unity.DOTS.Entities
             }
 
             using var handle = m_EntityPrototypes.AcquireWithHandle(AccessType.ExclusiveWrite);
-            int hash = HashCodeUtil.GetHashCode(BurstRuntime.GetHashCode32<TEntitySpawnDefinition>(), variant);
+            int hash = variant.GetVariantHashForDefinition<TEntitySpawnDefinition>();
             DEBUG_EnsurePrototypeIsRegistered(typeof(TEntitySpawnDefinition), hash, handle.Value);
             if (handle.Value.Remove(hash, out Entity prototype) && shouldDestroy)
             {

--- a/Scripts/Runtime/Entities/Lifecycle/EntitySpawnSystem.cs
+++ b/Scripts/Runtime/Entities/Lifecycle/EntitySpawnSystem.cs
@@ -126,16 +126,16 @@ namespace Anvil.Unity.DOTS.Entities
         // PROTOTYPE REGISTRATION
         //*************************************************************************************************************
 
-        public void RegisterEntityPrototypeForDefinition<TEntitySpawnDefinition>(Entity prototype, int context)
+        public void RegisterEntityPrototypeForDefinition<TEntitySpawnDefinition>(Entity prototype, int variant = default)
             where TEntitySpawnDefinition : unmanaged, IEntitySpawnDefinition
         {
             using var handle = m_EntityPrototypes.AcquireWithHandle(AccessType.ExclusiveWrite);
-            int hash = HashCodeUtil.GetHashCode(BurstRuntime.GetHashCode32<TEntitySpawnDefinition>(), context);
+            int hash = HashCodeUtil.GetHashCode(BurstRuntime.GetHashCode32<TEntitySpawnDefinition>(), variant);
             DEBUG_EnsurePrototypeIsNotRegistered(typeof(TEntitySpawnDefinition), hash, handle.Value);
             handle.Value.Add(hash, prototype);
         }
 
-        public void UnregisterEntityPrototypeForDefinition<TEntitySpawnDefinition>(bool shouldDestroy, int context)
+        public void UnregisterEntityPrototypeForDefinition<TEntitySpawnDefinition>(bool shouldDestroy, int variant = default)
             where TEntitySpawnDefinition : unmanaged, IEntitySpawnDefinition
         {
             //If we're tearing down and this system was destroyed before whoever was trying to unregister, we
@@ -146,7 +146,7 @@ namespace Anvil.Unity.DOTS.Entities
             }
 
             using var handle = m_EntityPrototypes.AcquireWithHandle(AccessType.ExclusiveWrite);
-            int hash = HashCodeUtil.GetHashCode(BurstRuntime.GetHashCode32<TEntitySpawnDefinition>(), context);
+            int hash = HashCodeUtil.GetHashCode(BurstRuntime.GetHashCode32<TEntitySpawnDefinition>(), variant);
             DEBUG_EnsurePrototypeIsRegistered(typeof(TEntitySpawnDefinition), hash, handle.Value);
             if (handle.Value.Remove(hash, out Entity prototype) && shouldDestroy)
             {

--- a/Scripts/Runtime/Entities/Lifecycle/EntitySpawnSystem.cs
+++ b/Scripts/Runtime/Entities/Lifecycle/EntitySpawnSystem.cs
@@ -2,6 +2,7 @@ using Anvil.CSharp.Data;
 using Anvil.CSharp.Logging;
 using Anvil.Unity.DOTS.Data;
 using Anvil.Unity.DOTS.Jobs;
+using Anvil.Unity.DOTS.Util;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -31,7 +32,7 @@ namespace Anvil.Unity.DOTS.Entities
     [UseCommandBufferSystem(typeof(EndSimulationEntityCommandBufferSystem))]
     public partial class EntitySpawnSystem : AbstractAnvilSystemBase
     {
-        private readonly AccessControlledValue<NativeParallelHashMap<long, Entity>> m_EntityPrototypes;
+        private readonly AccessControlledValue<NativeParallelHashMap<int, Entity>> m_EntityPrototypes;
         private readonly HashSet<EntitySpawner> m_ActiveSpawners;
         private readonly List<EntitySpawner> m_PendingReleaseSpawners;
         private readonly uint m_SystemID;
@@ -40,7 +41,7 @@ namespace Anvil.Unity.DOTS.Entities
         private int m_LargestInstanceIDIssued;
 
         private EntityCommandBufferSystem m_CommandBufferSystem;
-        private NativeParallelHashMap<long, EntityArchetype> m_EntityArchetypes;
+        private NativeParallelHashMap<int, EntityArchetype> m_EntityArchetypes;
 
         public EntitySpawnSystem()
         {
@@ -49,9 +50,9 @@ namespace Anvil.Unity.DOTS.Entities
             m_InstanceIDQueue = new Queue<int>();
             m_LargestInstanceIDIssued = -1;
 
-            m_EntityArchetypes = new NativeParallelHashMap<long, EntityArchetype>(ChunkUtil.MaxElementsPerChunk<EntityArchetype>(), Allocator.Persistent);
-            m_EntityPrototypes = new AccessControlledValue<NativeParallelHashMap<long, Entity>>(
-                new NativeParallelHashMap<long, Entity>(
+            m_EntityArchetypes = new NativeParallelHashMap<int, EntityArchetype>(ChunkUtil.MaxElementsPerChunk<EntityArchetype>(), Allocator.Persistent);
+            m_EntityPrototypes = new AccessControlledValue<NativeParallelHashMap<int, Entity>>(
+                new NativeParallelHashMap<int, Entity>(
                     ChunkUtil.MaxElementsPerChunk<Entity>(),
                     Allocator.Persistent));
             m_SystemID = s_EntitySpawnSystemIDProvider.GetNextID();
@@ -99,7 +100,7 @@ namespace Anvil.Unity.DOTS.Entities
         {
             foreach ((Type definitionType, IEntitySpawnDefinition entitySpawnDefinition) in EntitySpawnSystemReflectionHelper.SPAWN_DEFINITION_TYPES)
             {
-                long entityArchetypeHash = BurstRuntime.GetHashCode64(definitionType);
+                int entityArchetypeHash = BurstRuntime.GetHashCode32(definitionType);
                 if (m_EntityArchetypes.TryGetValue(entityArchetypeHash, out EntityArchetype entityArchetype))
                 {
                     continue;
@@ -125,16 +126,16 @@ namespace Anvil.Unity.DOTS.Entities
         // PROTOTYPE REGISTRATION
         //*************************************************************************************************************
 
-        public void RegisterEntityPrototypeForDefinition<TEntitySpawnDefinition>(Entity prototype)
+        public void RegisterEntityPrototypeForDefinition<TEntitySpawnDefinition>(Entity prototype, int context)
             where TEntitySpawnDefinition : unmanaged, IEntitySpawnDefinition
         {
             using var handle = m_EntityPrototypes.AcquireWithHandle(AccessType.ExclusiveWrite);
-            long hash = BurstRuntime.GetHashCode64<TEntitySpawnDefinition>();
+            int hash = HashCodeUtil.GetHashCode(BurstRuntime.GetHashCode32<TEntitySpawnDefinition>(), context);
             DEBUG_EnsurePrototypeIsNotRegistered(typeof(TEntitySpawnDefinition), hash, handle.Value);
             handle.Value.Add(hash, prototype);
         }
 
-        public void UnregisterEntityPrototypeForDefinition<TEntitySpawnDefinition>(bool shouldDestroy)
+        public void UnregisterEntityPrototypeForDefinition<TEntitySpawnDefinition>(bool shouldDestroy, int context)
             where TEntitySpawnDefinition : unmanaged, IEntitySpawnDefinition
         {
             //If we're tearing down and this system was destroyed before whoever was trying to unregister, we
@@ -145,7 +146,7 @@ namespace Anvil.Unity.DOTS.Entities
             }
 
             using var handle = m_EntityPrototypes.AcquireWithHandle(AccessType.ExclusiveWrite);
-            long hash = BurstRuntime.GetHashCode64<TEntitySpawnDefinition>();
+            int hash = HashCodeUtil.GetHashCode(BurstRuntime.GetHashCode32<TEntitySpawnDefinition>(), context);
             DEBUG_EnsurePrototypeIsRegistered(typeof(TEntitySpawnDefinition), hash, handle.Value);
             if (handle.Value.Remove(hash, out Entity prototype) && shouldDestroy)
             {
@@ -207,7 +208,7 @@ namespace Anvil.Unity.DOTS.Entities
             ReleaseSpawner(entitySpawner);
         }
 
-        private EntitySpawner AcquireSpawner(bool isDeferred, NativeParallelHashMap<long, Entity> prototypeLookup)
+        private EntitySpawner AcquireSpawner(bool isDeferred, NativeParallelHashMap<int, Entity> prototypeLookup)
         {
             EntityCommandBuffer entityCommandBuffer = isDeferred ? m_CommandBufferSystem.CreateCommandBuffer() : new EntityCommandBuffer(Allocator.TempJob);
 
@@ -374,7 +375,7 @@ namespace Anvil.Unity.DOTS.Entities
         //*************************************************************************************************************
 
         [Conditional("ANVIL_DEBUG_SAFETY")]
-        private void DEBUG_EnsurePrototypeIsRegistered(Type type, long hash, NativeParallelHashMap<long, Entity> prototypes)
+        private void DEBUG_EnsurePrototypeIsRegistered(Type type, int hash, NativeParallelHashMap<int, Entity> prototypes)
         {
             if (!prototypes.ContainsKey(hash))
             {
@@ -383,7 +384,7 @@ namespace Anvil.Unity.DOTS.Entities
         }
 
         [Conditional("ANVIL_DEBUG_SAFETY")]
-        private void DEBUG_EnsurePrototypeIsNotRegistered(Type type, long hash, NativeParallelHashMap<long, Entity> prototypes)
+        private void DEBUG_EnsurePrototypeIsNotRegistered(Type type, int hash, NativeParallelHashMap<int, Entity> prototypes)
         {
             if (prototypes.ContainsKey(hash))
             {

--- a/Scripts/Runtime/Entities/Lifecycle/IEntitySpawnDefinitionExtension.cs
+++ b/Scripts/Runtime/Entities/Lifecycle/IEntitySpawnDefinitionExtension.cs
@@ -26,10 +26,10 @@ namespace Anvil.Unity.DOTS.Entities
         /// <param name="definition">The definition to create and populate an instance from.</param>
         /// <param name="entitySpawner">The <see cref="EntitySpawner"/> helper struct</param>
         /// <typeparam name="TDefinition">The type of the definition that implements <see cref="IEntitySpawnDefinition"/>.</typeparam>
-        public static void CreateAndPopulateWithPrototype<TDefinition>(ref this TDefinition definition, in EntitySpawner entitySpawner)
+        public static void CreateAndPopulateWithPrototype<TDefinition>(ref this TDefinition definition, in EntitySpawner entitySpawner, int context)
             where TDefinition : unmanaged, IEntitySpawnDefinition
         {
-            Entity entity = entitySpawner.SpawnDeferredEntityWithPrototype(definition);
+            Entity entity = entitySpawner.SpawnDeferredEntityWithPrototype(definition, context);
             definition.PopulateOnEntity(entity, entitySpawner);
         }
     }

--- a/Scripts/Runtime/Entities/Lifecycle/IEntitySpawnDefinitionExtension.cs
+++ b/Scripts/Runtime/Entities/Lifecycle/IEntitySpawnDefinitionExtension.cs
@@ -27,7 +27,7 @@ namespace Anvil.Unity.DOTS.Entities
         /// <param name="entitySpawner">The <see cref="EntitySpawner"/> helper struct</param>
         /// <param name="variant">An optional key to identify a prototype variant for this definition</param>
         /// <typeparam name="TDefinition">The type of the definition that implements <see cref="IEntitySpawnDefinition"/>.</typeparam>
-        public static void CreateAndPopulateWithPrototype<TDefinition>(ref this TDefinition definition, in EntitySpawner entitySpawner, int variant = default)
+        public static void CreateAndPopulateWithPrototype<TDefinition>(ref this TDefinition definition, in EntitySpawner entitySpawner, PrototypeVariant variant = default)
             where TDefinition : unmanaged, IEntitySpawnDefinition
         {
             Entity entity = entitySpawner.SpawnDeferredEntityWithPrototype(definition, variant);

--- a/Scripts/Runtime/Entities/Lifecycle/IEntitySpawnDefinitionExtension.cs
+++ b/Scripts/Runtime/Entities/Lifecycle/IEntitySpawnDefinitionExtension.cs
@@ -25,11 +25,12 @@ namespace Anvil.Unity.DOTS.Entities
         /// </summary>
         /// <param name="definition">The definition to create and populate an instance from.</param>
         /// <param name="entitySpawner">The <see cref="EntitySpawner"/> helper struct</param>
+        /// <param name="variant">An optional key to identify a prototype variant for this definition</param>
         /// <typeparam name="TDefinition">The type of the definition that implements <see cref="IEntitySpawnDefinition"/>.</typeparam>
-        public static void CreateAndPopulateWithPrototype<TDefinition>(ref this TDefinition definition, in EntitySpawner entitySpawner, int context)
+        public static void CreateAndPopulateWithPrototype<TDefinition>(ref this TDefinition definition, in EntitySpawner entitySpawner, int variant = default)
             where TDefinition : unmanaged, IEntitySpawnDefinition
         {
-            Entity entity = entitySpawner.SpawnDeferredEntityWithPrototype(definition, context);
+            Entity entity = entitySpawner.SpawnDeferredEntityWithPrototype(definition, variant);
             definition.PopulateOnEntity(entity, entitySpawner);
         }
     }

--- a/Scripts/Runtime/Entities/Lifecycle/JobInteraction/EntitySpawner.cs
+++ b/Scripts/Runtime/Entities/Lifecycle/JobInteraction/EntitySpawner.cs
@@ -98,23 +98,24 @@ namespace Anvil.Unity.DOTS.Entities
             definition.PopulateOnEntity(entity, this);
             return entity;
         }
-        
+
         /// <summary>
         /// Spawns an <see cref="Entity"/> based on the passed in <see cref="IEntitySpawnDefinition"/> and uses
         /// a prototype which was registered with <see cref="EntitySpawnSystem.RegisterEntityPrototypeForDefinition"/>.
         /// This will be actually spawned with the corresponding <see cref="EntityCommandBufferSystem"/> executes.
         /// </summary>
         /// <param name="definition">The <see cref="IEntitySpawnDefinition"/> to use</param>
+        /// <param name="variant">An optional key for a variant prototype associated with this definition</param>
         /// <typeparam name="TDefinition">The type of <see cref="IEntitySpawnDefinition"/></typeparam>
         /// <returns>
         /// A deferred <see cref="Entity"/>.
         /// This Entity is invalid but will be patched when the corresponding <see cref="EntityCommandBufferSystem"/>
         /// executes. Any references to this entity must be used/stored via commands run on this instance.
         /// </returns>
-        public Entity SpawnDeferredEntityWithPrototype<TDefinition>(TDefinition definition, int context)
+        public Entity SpawnDeferredEntityWithPrototype<TDefinition>(TDefinition definition, int variant = default)
             where TDefinition : unmanaged, IEntitySpawnDefinition
         {
-            Entity prototype = GetPrototypeEntityForDefinition<TDefinition>(context);
+            Entity prototype = GetPrototypeEntityForDefinition<TDefinition>(variant);
             Entity entity = m_ECBWriter.Instantiate(ID.InstanceID, prototype);
             definition.PopulateOnEntity(entity, this);
             return entity;
@@ -234,10 +235,10 @@ namespace Anvil.Unity.DOTS.Entities
         /// </summary>
         /// <typeparam name="TDefinition">The type of <see cref="IEntitySpawnDefinition"/></typeparam>
         /// <returns>The <see cref="Entity"/> prototype</returns>
-        internal Entity GetPrototypeEntityForDefinition<TDefinition>(int context)
+        internal Entity GetPrototypeEntityForDefinition<TDefinition>(int variant)
             where TDefinition : unmanaged, IEntitySpawnDefinition
         {
-            int hash = HashCodeUtil.GetHashCode(BurstRuntime.GetHashCode32<TDefinition>(), context);
+            int hash = HashCodeUtil.GetHashCode(BurstRuntime.GetHashCode32<TDefinition>(), variant);
             return GetPrototypeEntityForDefinition(hash);
         }
 

--- a/Scripts/Runtime/Entities/Lifecycle/JobInteraction/EntitySpawner.cs
+++ b/Scripts/Runtime/Entities/Lifecycle/JobInteraction/EntitySpawner.cs
@@ -112,7 +112,7 @@ namespace Anvil.Unity.DOTS.Entities
         /// This Entity is invalid but will be patched when the corresponding <see cref="EntityCommandBufferSystem"/>
         /// executes. Any references to this entity must be used/stored via commands run on this instance.
         /// </returns>
-        public Entity SpawnDeferredEntityWithPrototype<TDefinition>(TDefinition definition, int variant = default)
+        public Entity SpawnDeferredEntityWithPrototype<TDefinition>(TDefinition definition, PrototypeVariant variant = default)
             where TDefinition : unmanaged, IEntitySpawnDefinition
         {
             Entity prototype = GetPrototypeEntityForDefinition<TDefinition>(variant);
@@ -235,10 +235,10 @@ namespace Anvil.Unity.DOTS.Entities
         /// </summary>
         /// <typeparam name="TDefinition">The type of <see cref="IEntitySpawnDefinition"/></typeparam>
         /// <returns>The <see cref="Entity"/> prototype</returns>
-        internal Entity GetPrototypeEntityForDefinition<TDefinition>(int variant)
+        internal Entity GetPrototypeEntityForDefinition<TDefinition>(PrototypeVariant variant)
             where TDefinition : unmanaged, IEntitySpawnDefinition
         {
-            int hash = HashCodeUtil.GetHashCode(BurstRuntime.GetHashCode32<TDefinition>(), variant);
+            int hash = variant.GetVariantHashForDefinition<TDefinition>();
             return GetPrototypeEntityForDefinition(hash);
         }
 

--- a/Scripts/Runtime/Entities/Lifecycle/JobInteraction/EntitySpawner.cs
+++ b/Scripts/Runtime/Entities/Lifecycle/JobInteraction/EntitySpawner.cs
@@ -42,8 +42,8 @@ namespace Anvil.Unity.DOTS.Entities
         //TODO: #86 - Once we upgrade to Entities 1.0 we won't have to hide the ECB or ECB.ParallelWriter inside here
         //      and we can expose it or make two separate Spawner structs. One for parallel and one for single.        
         [NativeDisableContainerSafetyRestriction] private readonly EntityCommandBuffer.ParallelWriter m_ECBWriter;
-        [ReadOnly] private readonly NativeParallelHashMap<long, EntityArchetype> m_ArchetypeLookup;
-        [ReadOnly] private readonly NativeParallelHashMap<long, Entity> m_PrototypeLookup;
+        [ReadOnly] private readonly NativeParallelHashMap<int, EntityArchetype> m_ArchetypeLookup;
+        [ReadOnly] private readonly NativeParallelHashMap<int, Entity> m_PrototypeLookup;
         
         
         /// <summary>
@@ -58,8 +58,8 @@ namespace Anvil.Unity.DOTS.Entities
         internal EntitySpawner(
             SpawnerID id,
             EntityCommandBuffer ecb,
-            NativeParallelHashMap<long, EntityArchetype> archetypeLookup,
-            NativeParallelHashMap<long, Entity> prototypeLookup)
+            NativeParallelHashMap<int, EntityArchetype> archetypeLookup,
+            NativeParallelHashMap<int, Entity> prototypeLookup)
         {
             ID = id;
             m_ECB = ecb;
@@ -111,10 +111,10 @@ namespace Anvil.Unity.DOTS.Entities
         /// This Entity is invalid but will be patched when the corresponding <see cref="EntityCommandBufferSystem"/>
         /// executes. Any references to this entity must be used/stored via commands run on this instance.
         /// </returns>
-        public Entity SpawnDeferredEntityWithPrototype<TDefinition>(TDefinition definition)
+        public Entity SpawnDeferredEntityWithPrototype<TDefinition>(TDefinition definition, int context)
             where TDefinition : unmanaged, IEntitySpawnDefinition
         {
-            Entity prototype = GetPrototypeEntityForDefinition<TDefinition>();
+            Entity prototype = GetPrototypeEntityForDefinition<TDefinition>(context);
             Entity entity = m_ECBWriter.Instantiate(ID.InstanceID, prototype);
             definition.PopulateOnEntity(entity, this);
             return entity;
@@ -213,17 +213,17 @@ namespace Anvil.Unity.DOTS.Entities
         internal EntityArchetype GetEntityArchetypeForDefinition<TDefinition>()
             where TDefinition : unmanaged, IEntitySpawnDefinition
         {
-            long hash = BurstRuntime.GetHashCode64<TDefinition>();
+            int hash = BurstRuntime.GetHashCode32<TDefinition>();
             return GetEntityArchetypeForDefinition(hash);
         }
 
         /// <summary>
         /// Gets the <see cref="EntityArchetype"/> for a given <see cref="IEntitySpawnDefinition"/>
-        /// based on the hash derived from <see cref="BurstRuntime.GetHashCode64"/>
+        /// based on the hash derived from <see cref="BurstRuntime.GetHashCode32"/>
         /// </summary>
         /// <param name="hash">The hash to lookup</param>
         /// <returns>The <see cref="EntityArchetype"/></returns>
-        internal EntityArchetype GetEntityArchetypeForDefinition(long hash)
+        internal EntityArchetype GetEntityArchetypeForDefinition(int hash)
         {
             Debug_EnsureArchetypeIsRegistered(hash);
             return m_ArchetypeLookup[hash];
@@ -234,20 +234,20 @@ namespace Anvil.Unity.DOTS.Entities
         /// </summary>
         /// <typeparam name="TDefinition">The type of <see cref="IEntitySpawnDefinition"/></typeparam>
         /// <returns>The <see cref="Entity"/> prototype</returns>
-        internal Entity GetPrototypeEntityForDefinition<TDefinition>()
+        internal Entity GetPrototypeEntityForDefinition<TDefinition>(int context)
             where TDefinition : unmanaged, IEntitySpawnDefinition
         {
-            long hash = BurstRuntime.GetHashCode64<TDefinition>();
+            int hash = HashCodeUtil.GetHashCode(BurstRuntime.GetHashCode32<TDefinition>(), context);
             return GetPrototypeEntityForDefinition(hash);
         }
 
         /// <summary>
         /// Gets the <see cref="Entity"/> prototype for a given <see cref="IEntitySpawnDefinition"/>
-        /// based on the hash derived from <see cref="BurstRuntime.GetHashCode64"/>
+        /// based on the hash derived from <see cref="BurstRuntime.GetHashCode32"/>
         /// </summary>
         /// <param name="hash">The hash to lookup</param>
         /// <returns>The <see cref="Entity"/> prototype</returns>
-        internal Entity GetPrototypeEntityForDefinition(long hash)
+        internal Entity GetPrototypeEntityForDefinition(int hash)
         {
             Debug_EnsurePrototypeIsRegistered(hash);
             return m_PrototypeLookup[hash];
@@ -277,7 +277,7 @@ namespace Anvil.Unity.DOTS.Entities
         //*************************************************************************************************************
 
         [Conditional("ANVIL_DEBUG_SAFETY")]
-        private void Debug_EnsureArchetypeIsRegistered(long hash)
+        private void Debug_EnsureArchetypeIsRegistered(int hash)
         {
             if (!m_ArchetypeLookup.ContainsKey(hash))
             {
@@ -286,7 +286,7 @@ namespace Anvil.Unity.DOTS.Entities
         }
 
         [Conditional("ANVIL_DEBUG_SAFETY")]
-        private void Debug_EnsurePrototypeIsRegistered(long hash)
+        private void Debug_EnsurePrototypeIsRegistered(int hash)
         {
             if (!m_PrototypeLookup.ContainsKey(hash))
             {

--- a/Scripts/Runtime/Entities/Lifecycle/PrototypeVariant.cs
+++ b/Scripts/Runtime/Entities/Lifecycle/PrototypeVariant.cs
@@ -1,0 +1,75 @@
+using Anvil.Unity.DOTS.Core;
+using Anvil.Unity.DOTS.Util;
+using System;
+using Unity.Burst;
+using Unity.Collections;
+using Unity.Entities;
+using UnityEngine;
+
+namespace Anvil.Unity.DOTS.Entities
+{
+    public readonly struct PrototypeVariant : IEquatable<PrototypeVariant>,
+                                              IComponentData,
+                                              IToFixedString<FixedString32Bytes>
+    {
+        public static readonly int UNSET_VALUE = default;
+
+        public static PrototypeVariant FromEnum<T>(T enumValue)
+            where T : unmanaged, Enum
+        {
+            return new PrototypeVariant((int)enumValue.ToBurstValue());
+        }
+
+        public static bool operator ==(PrototypeVariant lhs, PrototypeVariant rhs)
+        {
+            return lhs.Value == rhs.Value;
+        }
+
+        public static bool operator !=(PrototypeVariant lhs, PrototypeVariant rhs)
+        {
+            return lhs.Value != rhs.Value;
+        }
+
+        static PrototypeVariant()
+        {
+            // Make sure that the default actor ID matches an unset ID. Otherwise
+            // an uninitialized ActorID may conflict with a valid ID.
+            Debug.Assert(new PrototypeVariant().Value == UNSET_VALUE);
+        }
+
+        public readonly int Value;
+
+        public bool IsUnset
+        {
+            get => Value == UNSET_VALUE;
+        }
+
+        public PrototypeVariant(int variant)
+        {
+            Debug.Assert(variant != UNSET_VALUE);
+            Value = variant;
+        }
+        
+        public int GetVariantHashForDefinition<TEntitySpawnDefinition>()
+            where TEntitySpawnDefinition : unmanaged, IEntitySpawnDefinition
+        {
+            return HashCodeUtil.GetHashCode(BurstRuntime.GetHashCode32<TEntitySpawnDefinition>(), GetHashCode());
+        }
+
+        public bool Equals(PrototypeVariant other) => other.Value == Value;
+
+        public override bool Equals(object compare) => compare is PrototypeVariant variant && Equals(variant);
+
+        public override int GetHashCode() => Value;
+
+        public override string ToString()
+        {
+            return Value.ToString();
+        }
+
+        public FixedString32Bytes ToFixedString()
+        {
+            return $"{Value}";
+        }
+    }
+}

--- a/Scripts/Runtime/Entities/Lifecycle/PrototypeVariant.cs.meta
+++ b/Scripts/Runtime/Entities/Lifecycle/PrototypeVariant.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 6c6fd130d37244f0acfe0cbf632fa245
+timeCreated: 1688655678

--- a/Scripts/Runtime/Util/EnumExtension.cs
+++ b/Scripts/Runtime/Util/EnumExtension.cs
@@ -10,6 +10,12 @@ namespace Anvil.Unity.DOTS.Util
     /// </summary>
     public static class EnumExtension
     {
+        public static int ToBurstInt<TEnum>(this TEnum value)
+            where TEnum : unmanaged, Enum
+        {
+            return (int)value.ToBurstValue();
+        }
+
         /// <summary>
         /// Converts an enum to a value that burst will actually print out.
         /// Without this method enums print out their fully qualified type name in burst compiled code.

--- a/Scripts/Runtime/Util/EnumExtension.cs
+++ b/Scripts/Runtime/Util/EnumExtension.cs
@@ -10,12 +10,6 @@ namespace Anvil.Unity.DOTS.Util
     /// </summary>
     public static class EnumExtension
     {
-        public static int ToBurstInt<TEnum>(this TEnum value)
-            where TEnum : unmanaged, Enum
-        {
-            return (int)value.ToBurstValue();
-        }
-
         /// <summary>
         /// Converts an enum to a value that burst will actually print out.
         /// Without this method enums print out their fully qualified type name in burst compiled code.


### PR DESCRIPTION
For a given `Definition`, there may be multiple `Prototypes` that fit that definition as "Variants". 

They are not structurally different (same components etc) but their values differ such that general configuration is not sufficient and it's better to duplicate an existing prototype instead. 

Ex. RenderMeshes which have a bunch of SharedComponents to point to the right Mesh/Material combo. 

### What is the current behaviour?

- There is no support for allowing a Variant to be chosen for a given definition.
- You'd have to make more specific definitions which doesn't scale.

### What is the new behaviour?

- You can optionally choose to register a `Prototype` with a Variant key.
- The Variant keys are `PrototypeVariant` structs (which are just wrapped ints) to allow for Burst to work without polymorphism.

### What issues does this resolve?
- None

### What PRs does this depend on?
 - None

### Does this introduce a breaking change?
 - [ ] Yes
 - [x] No
