### PR TITLE
HashCodeUtil - Fix Docs, Add overloads for more params

### DIFF
--- a/Scripts/Runtime/Util/HashCodeUtil.cs
+++ b/Scripts/Runtime/Util/HashCodeUtil.cs
@@ -4,7 +4,7 @@ using Unity.Burst;
 namespace Anvil.Unity.DOTS.Util
 {
     /// <summary>
-    /// Helper class for generating hash codes that is Burst compatible.
+    /// Helper class for generating a hash code that is Burst compatible.
     /// </summary>
     [BurstCompile]
     public static class HashCodeUtil

--- a/Scripts/Runtime/Util/HashCodeUtil.cs
+++ b/Scripts/Runtime/Util/HashCodeUtil.cs
@@ -1,19 +1,24 @@
+using System.Runtime.CompilerServices;
+using Unity.Burst;
+
 namespace Anvil.Unity.DOTS.Util
 {
     /// <summary>
-    /// Helper class for generating hashcodes that are Burst compatible.
+    /// Helper class for generating hash codes that is Burst compatible.
     /// </summary>
+    [BurstCompile]
     public static class HashCodeUtil
     {
         /// <summary>
-        /// Returns a HashCode that combines two initial hash codes.
+        /// Returns a hash code that combines two initial hash codes.
         /// </summary>
         /// <param name="h1">The first hash code</param>
         /// <param name="h2">The second hash code</param>
-        /// <returns></returns>
+        /// <returns>A combined hash code</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static int GetHashCode(int h1, int h2)
         {
-            //Taken from ValueTuple.cs GetHashCode. 
+            //Taken from ValueTuple.cs GetHashCode.
             //https://github.com/dotnet/roslyn/blob/main/src/Compilers/Test/Resources/Core/NetFX/ValueTuple/ValueTuple.cs
             //Licence is a-ok as per the top of the linked file:
             // - Licensed to the .NET Foundation under one or more agreements.
@@ -22,6 +27,37 @@ namespace Anvil.Unity.DOTS.Util
             //Unfortunately we can't use directly because it has a static Random class it creates which doesn't jive with Burst
             uint rol5 = ((uint)h1 << 5) | ((uint)h1 >> 27);
             return ((int)rol5 + h1) ^ h2;
+        }
+
+        /// <summary>
+        /// Returns a hash code that combines three initial hash codes.
+        /// </summary>
+        /// <param name="h1">The first hash code</param>
+        /// <param name="h2">The second hash code</param>
+        /// <param name="h3">The third hash code</param>
+        /// <returns>A combined hash code</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static int GetHashCode(int h1, int h2, int h3)
+        {
+            return GetHashCode(
+                GetHashCode(h1, h2),
+                h3);
+        }
+
+        /// <summary>
+        /// Returns a hash code that combines four initial hash codes.
+        /// </summary>
+        /// <param name="h1">The first hash code</param>
+        /// <param name="h2">The second hash code</param>
+        /// <param name="h3">The third hash code</param>
+        /// <param name="h4">The fourth hash code</param>
+        /// <returns>A combined hash code</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static int GetHashCode(int h1, int h2, int h3, int h4)
+        {
+            return GetHashCode(
+                GetHashCode(h1, h2),
+                GetHashCode(h3, h4));
         }
     }
 }


### PR DESCRIPTION
 - Improve docs in `HashCodeUtil`
 - Add convenience overloads to accept 3 and 4 hash codes to combine.
 - Add hint to inline the utility methods
 - Add burst compile attribute to ensure class remains burstable.

### What is the current behaviour?

There are no overloads to combine more than two hash codes.

### What is the new behaviour?

`GetHashCode()` for three and four parameters has been added.

### What issues does this resolve?
 - None

### What PRs does this depend on?
 - None

### Does this introduce a breaking change?
 - [ ] Yes <!-- If so, what are the migration considerations? -->
 - [x] No
