### PR TITLE
IJobConfig - Add require exclusive write for EPD and CDFE + Cleanup

### DIFF
--- a/Scripts/Runtime/Entities/TaskDriver/TaskSet/Job/JobConfig/AbstractJobConfig.cs
+++ b/Scripts/Runtime/Entities/TaskDriver/TaskSet/Job/JobConfig/AbstractJobConfig.cs
@@ -148,7 +148,7 @@ namespace Anvil.Unity.DOTS.Entities.TaskDriver
 
 
         //*************************************************************************************************************
-        // CONFIGURATION - REQUIRED DATA - DATA STREAM
+        // CONFIGURATION - REQUIRED DATA - Data Stream
         //*************************************************************************************************************
 
         /// <inheritdoc cref="IJobConfig.RequireDataStreamForWrite{TInstance}"/>
@@ -169,26 +169,9 @@ namespace Anvil.Unity.DOTS.Entities.TaskDriver
             return this;
         }
 
-        /// <inheritdoc cref="IJobConfig.RequestCancelFor"/>
-        public IJobConfig RequestCancelFor(AbstractTaskDriver taskDriver)
-        {
-            AddAccessWrapper(new CancelRequestsPendingAccessWrapper(taskDriver.TaskSet.CancelRequestsDataStream, AccessType.SharedWrite, Usage.RequestCancel));
-            return this;
-        }
 
         //*************************************************************************************************************
-        // CONFIGURATION - REQUIRED DATA - ENTITY SPAWNER
-        //*************************************************************************************************************
-
-        /// <inheritdoc cref="IJobConfig.RequireEntitySpawner"/>
-        public IJobConfig RequireEntitySpawner(EntitySpawnSystem entitySpawnSystem)
-        {
-            AddAccessWrapper(new EntitySpawnSystemWrapper(entitySpawnSystem, AccessType.SharedWrite, Usage.Default));
-            return this;
-        }
-
-        //*************************************************************************************************************
-        // CONFIGURATION - REQUIRED DATA - GENERIC DATA
+        // CONFIGURATION - REQUIRED DATA - Generic Data
         //*************************************************************************************************************
 
         /// <inheritdoc cref="IJobConfig.RequireGenericDataForRead{TData}"/>
@@ -215,8 +198,62 @@ namespace Anvil.Unity.DOTS.Entities.TaskDriver
             return this;
         }
 
+
         //*************************************************************************************************************
-        // CONFIGURATION - REQUIRED DATA - ENTITY QUERY
+        // CONFIGURATION - REQUIRED DATA - Persistent Data
+        //*************************************************************************************************************
+
+        /// <inheritdoc cref="IJobConfig.RequireThreadPersistentDataForRead{TData}"/>
+        public IJobConfig RequireThreadPersistentDataForRead<TData>(IThreadPersistentData<TData> threadPersistentData)
+            where TData : unmanaged, IThreadPersistentDataInstance
+        {
+            AddAccessWrapper(new PersistentDataAccessWrapper<ThreadPersistentData<TData>>((ThreadPersistentData<TData>)threadPersistentData, AccessType.SharedRead, Usage.Default));
+
+            return this;
+        }
+
+        /// <inheritdoc cref="IJobConfig.RequireThreadPersistentDataForWrite{TData}"/>
+        public IJobConfig RequireThreadPersistentDataForWrite<TData>(IThreadPersistentData<TData> threadPersistentData)
+            where TData : unmanaged, IThreadPersistentDataInstance
+        {
+            AddAccessWrapper(new PersistentDataAccessWrapper<ThreadPersistentData<TData>>((ThreadPersistentData<TData>)threadPersistentData, AccessType.SharedWrite, Usage.Default));
+
+            return this;
+        }
+
+        /// <inheritdoc cref="IJobConfig.RequireEntityPersistentDataForRead{TData}"/>
+        public IJobConfig RequireEntityPersistentDataForRead<TData>(IReadOnlyEntityPersistentData<TData> entityPersistentData)
+            where TData : unmanaged, IEntityPersistentDataInstance
+        {
+            EntityPersistentData<TData> data = (EntityPersistentData<TData>)entityPersistentData;
+            AddAccessWrapper(new PersistentDataAccessWrapper<EntityPersistentData<TData>>(data, AccessType.SharedRead, Usage.Default));
+
+            return this;
+        }
+
+        /// <inheritdoc cref="IJobConfig.RequireEntityPersistentDataForSharedWrite{TData}"/>
+        public IJobConfig RequireEntityPersistentDataForSharedWrite<TData>(IEntityPersistentData<TData> entityPersistentData)
+            where TData : unmanaged, IEntityPersistentDataInstance
+        {
+            EntityPersistentData<TData> data = (EntityPersistentData<TData>)entityPersistentData;
+            AddAccessWrapper(new PersistentDataAccessWrapper<EntityPersistentData<TData>>(data, AccessType.SharedWrite, Usage.Default));
+
+            return this;
+        }
+
+        /// <inheritdoc cref="IJobConfig.RequireEntityPersistentDataForExclusiveWrite{TData}"/>
+        public IJobConfig RequireEntityPersistentDataForExclusiveWrite<TData>(IEntityPersistentData<TData> entityPersistentData)
+            where TData : unmanaged, IEntityPersistentDataInstance
+        {
+            EntityPersistentData<TData> data = (EntityPersistentData<TData>)entityPersistentData;
+            AddAccessWrapper(new PersistentDataAccessWrapper<EntityPersistentData<TData>>(data, AccessType.ExclusiveWrite, Usage.Default));
+
+            return this;
+        }
+
+
+        //*************************************************************************************************************
+        // CONFIGURATION - REQUIRED DATA - EntityQuery
         //*************************************************************************************************************
 
         /// <inheritdoc cref="IJobConfig.RequireEntityNativeArrayFromQueryForRead"/>
@@ -245,6 +282,31 @@ namespace Anvil.Unity.DOTS.Entities.TaskDriver
             return this;
         }
 
+
+        //*************************************************************************************************************
+        // CONFIGURATION - REQUIRED DATA - Cancel
+        //*************************************************************************************************************
+
+        /// <inheritdoc cref="IJobConfig.RequestCancelFor"/>
+        public IJobConfig RequestCancelFor(AbstractTaskDriver taskDriver)
+        {
+            AddAccessWrapper(new CancelRequestsPendingAccessWrapper(taskDriver.TaskSet.CancelRequestsDataStream, AccessType.SharedWrite, Usage.RequestCancel));
+            return this;
+        }
+
+
+        //*************************************************************************************************************
+        // CONFIGURATION - REQUIRED DATA - ENTITY SPAWNER
+        //*************************************************************************************************************
+
+        /// <inheritdoc cref="IJobConfig.RequireEntitySpawner"/>
+        public IJobConfig RequireEntitySpawner(EntitySpawnSystem entitySpawnSystem)
+        {
+            AddAccessWrapper(new EntitySpawnSystemWrapper(entitySpawnSystem, AccessType.SharedWrite, Usage.Default));
+            return this;
+        }
+
+
         //*************************************************************************************************************
         // CONFIGURATION - REQUIRED DATA - ComponentDataFromEntity (CDFE)
         //*************************************************************************************************************
@@ -257,12 +319,20 @@ namespace Anvil.Unity.DOTS.Entities.TaskDriver
             return this;
         }
 
-        /// <inheritdoc cref="IJobConfig.RequireCDFEForWrite{T}"/>
-        public IJobConfig RequireCDFEForWrite<T>() where T : struct, IComponentData
+        /// <inheritdoc cref="IJobConfig.RequireCDFEForSystemSharedWrite{T}"/>
+        public IJobConfig RequireCDFEForSystemSharedWrite<T>() where T : struct, IComponentData
         {
             AddAccessWrapper(new CDFEAccessWrapper<T>(AccessType.SharedWrite, Usage.Default, TaskSetOwner.TaskDriverSystem));
             return this;
         }
+
+        /// <inheritdoc cref="IJobConfig.RequireCDFEForExclusiveWrite{T}"/>
+        public IJobConfig RequireCDFEForExclusiveWrite<T>() where T : struct, IComponentData
+        {
+            AddAccessWrapper(new CDFEAccessWrapper<T>(AccessType.ExclusiveWrite, Usage.Default, TaskSetOwner.TaskDriverSystem));
+            return this;
+        }
+
 
         //*************************************************************************************************************
         // CONFIGURATION - REQUIRED DATA - DynamicBuffer
@@ -276,6 +346,13 @@ namespace Anvil.Unity.DOTS.Entities.TaskDriver
             return this;
         }
 
+        /// <inheritdoc cref="IJobConfig.RequireDBFEForSystemSharedWrite{T}"/>
+        public IJobConfig RequireDBFEForSystemSharedWrite<T>() where T : struct, IBufferElementData
+        {
+            AddAccessWrapper(new DynamicBufferAccessWrapper<T>(AccessType.SharedWrite, Usage.Default, TaskSetOwner.TaskDriverSystem));
+            return this;
+        }
+
         /// <inheritdoc cref="IJobConfig.RequireDBFEForExclusiveWrite{T}"/>
         public IJobConfig RequireDBFEForExclusiveWrite<T>() where T : struct, IBufferElementData
         {
@@ -283,51 +360,6 @@ namespace Anvil.Unity.DOTS.Entities.TaskDriver
             return this;
         }
 
-
-        /// <inheritdoc cref="IJobConfig.RequireThreadPersistentDataForWrite{TData}"/>
-        public IJobConfig RequireThreadPersistentDataForWrite<TData>(IThreadPersistentData<TData> threadPersistentData)
-            where TData : unmanaged, IThreadPersistentDataInstance
-        {
-            AddAccessWrapper(new PersistentDataAccessWrapper<ThreadPersistentData<TData>>((ThreadPersistentData<TData>)threadPersistentData, AccessType.SharedWrite, Usage.Default));
-
-            return this;
-        }
-
-        /// <inheritdoc cref="IJobConfig.RequireThreadPersistentDataForRead{TData}"/>
-        public IJobConfig RequireThreadPersistentDataForRead<TData>(IThreadPersistentData<TData> threadPersistentData)
-            where TData : unmanaged, IThreadPersistentDataInstance
-        {
-            AddAccessWrapper(new PersistentDataAccessWrapper<ThreadPersistentData<TData>>((ThreadPersistentData<TData>)threadPersistentData, AccessType.SharedRead, Usage.Default));
-
-            return this;
-        }
-
-        /// <inheritdoc cref="IJobConfig.RequireEntityPersistentDataForWrite{TData}"/>
-        public IJobConfig RequireEntityPersistentDataForWrite<TData>(IEntityPersistentData<TData> entityPersistentData)
-            where TData : unmanaged, IEntityPersistentDataInstance
-        {
-            EntityPersistentData<TData> data = (EntityPersistentData<TData>)entityPersistentData;
-            AddAccessWrapper(new PersistentDataAccessWrapper<EntityPersistentData<TData>>(data, AccessType.SharedWrite, Usage.Default));
-
-            return this;
-        }
-
-        /// <inheritdoc cref="IJobConfig.RequireEntityPersistentDataForRead{TData}"/>
-        public IJobConfig RequireEntityPersistentDataForRead<TData>(IReadOnlyEntityPersistentData<TData> entityPersistentData)
-            where TData : unmanaged, IEntityPersistentDataInstance
-        {
-            EntityPersistentData<TData> data = (EntityPersistentData<TData>)entityPersistentData;
-            AddAccessWrapper(new PersistentDataAccessWrapper<EntityPersistentData<TData>>(data, AccessType.SharedRead, Usage.Default));
-
-            return this;
-        }
-
-        /// <inheritdoc cref="IJobConfig.AddRequirementsFrom{T}"/>
-        public IJobConfig AddRequirementsFrom<T>(T taskDriver, IJobConfig.ConfigureJobRequirementsDelegate<T> configureRequirements)
-            where T : AbstractTaskDriver
-        {
-            return configureRequirements(taskDriver, this);
-        }
 
         //*************************************************************************************************************
         // CONFIGURATION - REQUIRED DATA - EntityCommandBuffer
@@ -338,6 +370,19 @@ namespace Anvil.Unity.DOTS.Entities.TaskDriver
 
             return this;
         }
+
+
+        //*************************************************************************************************************
+        // CONFIGURATION - REQUIRED DATA - External Requirements
+        //*************************************************************************************************************
+
+        /// <inheritdoc cref="IJobConfig.AddRequirementsFrom{T}"/>
+        public IJobConfig AddRequirementsFrom<T>(T taskDriver, IJobConfig.ConfigureJobRequirementsDelegate<T> configureRequirements)
+            where T : AbstractTaskDriver
+        {
+            return configureRequirements(taskDriver, this);
+        }
+
 
         //*************************************************************************************************************
         // HARDEN

--- a/Scripts/Runtime/Entities/TaskDriver/TaskSet/Job/JobConfig/Interface/IJobConfig.cs
+++ b/Scripts/Runtime/Entities/TaskDriver/TaskSet/Job/JobConfig/Interface/IJobConfig.cs
@@ -245,7 +245,7 @@ namespace Anvil.Unity.DOTS.Entities.TaskDriver
 
         /// <summary>
         /// Specifies a <see cref="BufferFromEntity{T}"/> to be written to in a system scoped shared-write context.
-        /// This means that write access is shared between all Task Driver instances of the same type in the same &lt;see cref="World"/&gt;.
+        /// This means that write access is shared between all Task Driver instances of the same type in the same <see cref="World"/>.
         /// </summary>
         /// <typeparam name="T">The type of <see cref="IBufferElementData"/> in the DBFE.</typeparam>
         /// <returns>A reference to itself to continue chaining configuration methods.</returns>

--- a/Scripts/Runtime/Entities/TaskDriver/TaskSet/Job/JobConfig/Interface/IJobConfig.cs
+++ b/Scripts/Runtime/Entities/TaskDriver/TaskSet/Job/JobConfig/Interface/IJobConfig.cs
@@ -44,6 +44,11 @@ namespace Anvil.Unity.DOTS.Entities.TaskDriver
         /// <returns>A reference to itself to continue chaining configuration methods.</returns>
         public IJobConfig RunOnce();
 
+
+        //*************************************************************************************************************
+        // CONFIGURATION - REQUIRED DATA - Data Stream
+        //*************************************************************************************************************
+
         /// <summary>
         /// Specifies a <see cref="IAbstractDataStream{TInstance}"/> to be written to in a shared-write context.
         /// </summary>
@@ -65,6 +70,11 @@ namespace Anvil.Unity.DOTS.Entities.TaskDriver
         /// <returns>A reference to itself to continue chaining configuration methods.</returns>
         public IJobConfig RequireDataStreamForRead<TInstance>(IAbstractDataStream<TInstance> dataStream)
             where TInstance : unmanaged, IEntityKeyedTask;
+
+
+        //*************************************************************************************************************
+        // CONFIGURATION - REQUIRED DATA - Generic Data
+        //*************************************************************************************************************
 
         /// <summary>
         /// Specifies a generic struct to be read from in a shared-read context.
@@ -93,19 +103,6 @@ namespace Anvil.Unity.DOTS.Entities.TaskDriver
         public IJobConfig RequireGenericDataForSharedWrite<TData>(ISharedWriteAccessControlledValue<TData> data)
             where TData : struct;
 
-
-        public IJobConfig RequireThreadPersistentDataForWrite<TData>(IThreadPersistentData<TData> threadPersistentData)
-            where TData : unmanaged, IThreadPersistentDataInstance;
-
-        public IJobConfig RequireThreadPersistentDataForRead<TData>(IThreadPersistentData<TData> threadPersistentData)
-            where TData : unmanaged, IThreadPersistentDataInstance;
-
-        public IJobConfig RequireEntityPersistentDataForWrite<TData>(IEntityPersistentData<TData> entityPersistentData)
-            where TData : unmanaged, IEntityPersistentDataInstance;
-
-        public IJobConfig RequireEntityPersistentDataForRead<TData>(IReadOnlyEntityPersistentData<TData> entityPersistentData)
-            where TData : unmanaged, IEntityPersistentDataInstance;
-
         /// <summary>
         /// Specifies a generic struct to be written to in an exclusive-write context.
         /// The entire struct will be written to by only one thread at a time.
@@ -119,6 +116,31 @@ namespace Anvil.Unity.DOTS.Entities.TaskDriver
         /// <returns>A reference to itself to continue chaining configuration methods.</returns>
         public IJobConfig RequireGenericDataForExclusiveWrite<TData>(IExclusiveWriteAccessControlledValue<TData> data)
             where TData : struct;
+
+
+        //*************************************************************************************************************
+        // CONFIGURATION - REQUIRED DATA - Persistent Data
+        //*************************************************************************************************************
+
+        public IJobConfig RequireThreadPersistentDataForRead<TData>(IThreadPersistentData<TData> threadPersistentData)
+            where TData : unmanaged, IThreadPersistentDataInstance;
+
+        public IJobConfig RequireThreadPersistentDataForWrite<TData>(IThreadPersistentData<TData> threadPersistentData)
+            where TData : unmanaged, IThreadPersistentDataInstance;
+
+        public IJobConfig RequireEntityPersistentDataForRead<TData>(IReadOnlyEntityPersistentData<TData> entityPersistentData)
+            where TData : unmanaged, IEntityPersistentDataInstance;
+
+        public IJobConfig RequireEntityPersistentDataForSharedWrite<TData>(IEntityPersistentData<TData> entityPersistentData)
+            where TData : unmanaged, IEntityPersistentDataInstance;
+
+        public IJobConfig RequireEntityPersistentDataForExclusiveWrite<TData>(IEntityPersistentData<TData> entityPersistentData)
+            where TData : unmanaged, IEntityPersistentDataInstance;
+
+
+        //*************************************************************************************************************
+        // CONFIGURATION - REQUIRED DATA - EntityQuery
+        //*************************************************************************************************************
 
         /// <summary>
         /// Specifies an <see cref="EntityQuery"/> to be transformed into a <see cref="NativeArray{Entity}"/> and read
@@ -154,20 +176,34 @@ namespace Anvil.Unity.DOTS.Entities.TaskDriver
         public IJobConfig RequireIComponentDataNativeArrayFromQueryForRead<T>(EntityQuery entityQuery)
             where T : struct, IComponentData;
 
+
+        //*************************************************************************************************************
+        // CONFIGURATION - REQUIRED DATA - Cancel
+        //*************************************************************************************************************
+
         /// <summary>
         /// Requests cancellation for specific <see cref="Entity"/> in a given <see cref="AbstractTaskDriver"/>.
         /// </summary>
         /// <param name="taskDriver">The <see cref="AbstractTaskDriver"/> to cancel.</param>
         /// <returns>A reference to itself to continue chaining configuration methods.</returns>
         public IJobConfig RequestCancelFor(AbstractTaskDriver taskDriver);
-        
-       
+
+
+        //*************************************************************************************************************
+        // CONFIGURATION - REQUIRED DATA - ENTITY SPAWNER
+        //*************************************************************************************************************
+
         /// <summary>
         /// Requires an <see cref="EntitySpawner"/> from a given <see cref="EntitySpawnSystem"/>
         /// </summary>
         /// <param name="entitySpawnSystem">The <see cref="EntitySpawnSystem"/> to acquire from.</param>
         /// <returns>A reference to itself to continue chaining configuration methods</returns>
         public IJobConfig RequireEntitySpawner(EntitySpawnSystem entitySpawnSystem);
+
+
+        //*************************************************************************************************************
+        // CONFIGURATION - REQUIRED DATA - ComponentDataFromEntity (CDFE)
+        //*************************************************************************************************************
 
         /// <summary>
         /// Specifies a <see cref="ComponentDataFromEntity{T}"/> to be read from in a shared-read context.
@@ -178,12 +214,26 @@ namespace Anvil.Unity.DOTS.Entities.TaskDriver
             where T : struct, IComponentData;
 
         /// <summary>
-        /// Specifies a <see cref="ComponentDataFromEntity{T}"/> to be written to in a shared-write context.
+        /// Specifies a <see cref="ComponentDataFromEntity{T}"/> to be written to in a system scoped shared-write context.
+        /// This means that write access is shared between all Task Driver instances of the same type in the same <see cref="World"/>.
         /// </summary>
         /// <typeparam name="T">The type of <see cref="IComponentData"/> in the CDFE.</typeparam>
         /// <returns>A reference to itself to continue chaining configuration methods.</returns>
-        public IJobConfig RequireCDFEForWrite<T>()
+        public IJobConfig RequireCDFEForSystemSharedWrite<T>()
             where T : struct, IComponentData;
+
+        /// <summary>
+        /// Specifies a <see cref="ComponentDataFromEntity{T}"/> to be written to in an exclusive write context.
+        /// </summary>
+        /// <typeparam name="T">The type of <see cref="IComponentData"/> in the CDFE.</typeparam>
+        /// <returns>A reference to itself to continue chaining configuration methods.</returns>
+        public IJobConfig RequireCDFEForExclusiveWrite<T>()
+            where T : struct, IComponentData;
+
+
+        //*************************************************************************************************************
+        // CONFIGURATION - REQUIRED DATA - DynamicBuffer
+        //*************************************************************************************************************
 
         /// <summary>
         /// Specifies a <see cref="BufferFromEntity{T}"/> to be read from in a shared-read context.
@@ -194,12 +244,26 @@ namespace Anvil.Unity.DOTS.Entities.TaskDriver
             where T : struct, IBufferElementData;
 
         /// <summary>
+        /// Specifies a <see cref="BufferFromEntity{T}"/> to be written to in a system scoped shared-write context.
+        /// This means that write access is shared between all Task Driver instances of the same type in the same &lt;see cref="World"/&gt;.
+        /// </summary>
+        /// <typeparam name="T">The type of <see cref="IBufferElementData"/> in the DBFE.</typeparam>
+        /// <returns>A reference to itself to continue chaining configuration methods.</returns>
+        public IJobConfig RequireDBFEForSystemSharedWrite<T>()
+            where T : struct, IBufferElementData;
+
+        /// <summary>
         /// Specifies a <see cref="BufferFromEntity{T}"/> to be written to in an exclusive-write context.
         /// </summary>
         /// <typeparam name="T">The type of <see cref="IBufferElementData"/> in the DBFE.</typeparam>
         /// <returns>A reference to itself to continue chaining configuration methods.</returns>
         public IJobConfig RequireDBFEForExclusiveWrite<T>()
             where T : struct, IBufferElementData;
+
+
+        //*************************************************************************************************************
+        // CONFIGURATION - REQUIRED DATA - EntityCommandBuffer
+        //*************************************************************************************************************
 
         /// <summary>
         /// Specifies a <see cref="EntityCommandBuffer"/> to be populated.
@@ -209,6 +273,11 @@ namespace Anvil.Unity.DOTS.Entities.TaskDriver
         /// </param>
         /// <returns>A reference to itself to continue chaining configuration methods.</returns>
         IJobConfig RequireECB(EntityCommandBufferSystem ecbSystem);
+
+
+        //*************************************************************************************************************
+        // CONFIGURATION - REQUIRED DATA - External Requirements
+        //*************************************************************************************************************
 
         /// <summary>
         /// Specifies a delegate to call to add additional requirements.

--- a/Scripts/Runtime/Entities/TaskDriver/TaskSet/Job/JobConfig/NoOpJobConfig.cs
+++ b/Scripts/Runtime/Entities/TaskDriver/TaskSet/Job/JobConfig/NoOpJobConfig.cs
@@ -46,6 +46,46 @@ namespace Anvil.Unity.DOTS.Entities.TaskDriver
             return this;
         }
 
+
+        public IResolvableJobConfigRequirements RequireResolveTarget<TResolveTargetType>()
+            where TResolveTargetType : unmanaged, IEntityKeyedTask
+        {
+            return this;
+        }
+
+
+        public IJobConfig RequireThreadPersistentDataForRead<TData>(IThreadPersistentData<TData> threadPersistentData)
+            where TData : unmanaged, IThreadPersistentDataInstance
+        {
+            return this;
+        }
+
+        public IJobConfig RequireThreadPersistentDataForWrite<TData>(IThreadPersistentData<TData> threadPersistentData)
+            where TData : unmanaged, IThreadPersistentDataInstance
+        {
+            return this;
+        }
+
+
+        public IJobConfig RequireEntityPersistentDataForRead<TData>(IReadOnlyEntityPersistentData<TData> entityPersistentData)
+            where TData : unmanaged, IEntityPersistentDataInstance
+        {
+            return this;
+        }
+
+        public IJobConfig RequireEntityPersistentDataForSharedWrite<TData>(IEntityPersistentData<TData> entityPersistentData)
+            where TData : unmanaged, IEntityPersistentDataInstance
+        {
+            return this;
+        }
+
+        public IJobConfig RequireEntityPersistentDataForExclusiveWrite<TData>(IEntityPersistentData<TData> entityPersistentData)
+            where TData : unmanaged, IEntityPersistentDataInstance
+        {
+            return this;
+        }
+
+
         public IJobConfig RequireEntityNativeArrayFromQueryForRead(EntityQuery entityQuery)
         {
             return this;
@@ -57,19 +97,45 @@ namespace Anvil.Unity.DOTS.Entities.TaskDriver
             return this;
         }
 
+
+        public IJobConfig RequestCancelFor(AbstractTaskDriver taskDriver)
+        {
+            return this;
+        }
+
+
+        public IJobConfig RequireEntitySpawner(EntitySpawnSystem entitySpawnSystem)
+        {
+            return this;
+        }
+
+
         public IJobConfig RequireCDFEForRead<T>()
             where T : struct, IComponentData
         {
             return this;
         }
 
-        public IJobConfig RequireCDFEForWrite<T>()
+        public IJobConfig RequireCDFEForSystemSharedWrite<T>()
             where T : struct, IComponentData
         {
             return this;
         }
 
+        public IJobConfig RequireCDFEForExclusiveWrite<T>()
+            where T : struct, IComponentData
+        {
+            return this;
+        }
+
+
         public IJobConfig RequireDBFEForRead<T>()
+            where T : struct, IBufferElementData
+        {
+            return this;
+        }
+
+        public IJobConfig RequireDBFEForSystemSharedWrite<T>()
             where T : struct, IBufferElementData
         {
             return this;
@@ -81,50 +147,12 @@ namespace Anvil.Unity.DOTS.Entities.TaskDriver
             return this;
         }
 
-        public IResolvableJobConfigRequirements RequireResolveTarget<TResolveTargetType>()
-            where TResolveTargetType : unmanaged, IEntityKeyedTask
-        {
-            return this;
-        }
-
-        public IJobConfig RequestCancelFor(AbstractTaskDriver taskDriver)
-        {
-            return this;
-        }
-
-        public IJobConfig RequireThreadPersistentDataForWrite<TData>(IThreadPersistentData<TData> threadPersistentData)
-            where TData : unmanaged, IThreadPersistentDataInstance
-        {
-            return this;
-        }
-
-        public IJobConfig RequireThreadPersistentDataForRead<TData>(IThreadPersistentData<TData> threadPersistentData)
-            where TData : unmanaged, IThreadPersistentDataInstance
-        {
-            return this;
-        }
-
-        public IJobConfig RequireEntityPersistentDataForWrite<TData>(IEntityPersistentData<TData> entityPersistentData)
-            where TData : unmanaged, IEntityPersistentDataInstance
-        {
-            return this;
-        }
-
-        public IJobConfig RequireEntityPersistentDataForRead<TData>(IReadOnlyEntityPersistentData<TData> entityPersistentData)
-            where TData : unmanaged, IEntityPersistentDataInstance
-        {
-            return this;
-        }
 
         public IJobConfig RequireECB(EntityCommandBufferSystem ecbSystem)
         {
             return this;
         }
 
-        public IJobConfig RequireEntitySpawner(EntitySpawnSystem entitySpawnSystem)
-        {
-            return this;
-        }
 
         public IJobConfig AddRequirementsFrom<T>(T taskDriver, IJobConfig.ConfigureJobRequirementsDelegate<T> configureRequirements)
             where T : AbstractTaskDriver


### PR DESCRIPTION
 - Add require methods for
    - Exclusive `EntityPersistentData` write
    - Exclusive CDFE write
    - Shared DBFE write
 - Cleanup `IJobConfig` and implementations 

### What is the current behaviour?

Within an TaskDriver there is no way to:
 - Get exclusive write access to `EntityPersistentData`
 - Get exclusive write access to a CDFE
 - Get shared write access to a DBFE

As the use of Task Drivers has expanded well beyond the simple use cases originally imaged the the method naming for write access requirements has become ambiguous. Depending on the type, "Write" in a method name (Ex: `RequireEntityPersistentDataForWrite` could mean that the access handle is shared between all other concurrent write requests globally, all concurrent write requests associated with a Task Driver type's `TaskDriverSystem`, or something else. It's easy to forget or assume what type of access a you're getting as a developer. Shared vs Exclusive needs to be spell explicitly and new terminology needs to be devised to describe the unique write access provided to Unity ECS backed types (CDFE, DBFE, etc..)

### What is the new behaviour?

IJobConfig: Rename require methods to better describe provided access
 - Introduce the key term "SystemShared" for Unity ECS backed type requests (Ex: CDFE, DBFE, etc...)
   - "SystemShared" denotes that the shared write fence is on the TaskDriver system vs a normal SharedWrite that shares write access across all access scopes. This is due to the way Unity handles component dependencies.
 - Rename RequireCDFEForWrite to RequireCDFEForSystemSharedWrite.
 - Rename RequireEntityPersistentDataForWrite to RequireEntityPersistentDataForSharedWrite

IJobConfig: Additional require types
 - Add RequireEntityPersistentDataForExclusiveWrite
 - Add RequireCDFEForExclusiveWrite
 - Add RequireDBFEForSystemSharedWrite

IJobConfig + Implementations: Cleanup
 - Add comment headers to all sections
 - Reorder methods to consistently declare require methods in the order read, shared write, exclusive write
 - Refactor implementations to match the method order defined in IJobConfig

**Notes:**
The following methods were left as is for the reasons given below. I'm not against changing their names if you think it would be beneficial and have some naming ideas.
 - `RequireThreadPersistentDataForWrite` has been left as is since there is no concept of shared vs exclusive access.
 - `RequireDataStreamForWrite` has been left as is since exclusive writing isn't a user space operation that should ever be performed.

### What issues does this resolve?
 - None

### What PRs does this depend on?
 - None

### Does this introduce a breaking change?
 - [x] Yes - See the method renames above.
 - [ ] No
