### PR TITLE
Remove `IComponentData` from `PrototypeVariant`

### DIFF
--- a/Scripts/Runtime/Entities/Lifecycle/PrototypeVariant.cs
+++ b/Scripts/Runtime/Entities/Lifecycle/PrototypeVariant.cs
@@ -3,20 +3,19 @@ using Anvil.Unity.DOTS.Util;
 using System;
 using Unity.Burst;
 using Unity.Collections;
-using Unity.Entities;
 using UnityEngine;
 
 namespace Anvil.Unity.DOTS.Entities
 {
     /// <summary>
     /// A typed wrapper for an <see cref="int"/> to denote a variant for a <see cref="IEntitySpawnDefinition"/>'s a
-    /// associated prototype. 
+    /// associated prototype.
     /// </summary>
     public readonly struct PrototypeVariant : IEquatable<PrototypeVariant>,
                                               IToFixedString<FixedString32Bytes>
     {
         public static readonly int UNSET_VALUE = default;
-        
+
         /// <summary>
         /// Converts an enum's underlying value into a <see cref="PrototypeVariant"/> instance.
         /// </summary>
@@ -46,7 +45,7 @@ namespace Anvil.Unity.DOTS.Entities
             // an uninitialized PrototypeVariant may conflict with a valid ID.
             Debug.Assert(new PrototypeVariant().VariantID == UNSET_VALUE);
         }
-        
+
         /// <summary>
         /// The backing int ID the prototype is associated with
         /// </summary>
@@ -69,9 +68,9 @@ namespace Anvil.Unity.DOTS.Entities
             Debug.Assert(variantID != UNSET_VALUE);
             VariantID = variantID;
         }
-        
+
         /// <summary>
-        /// Helper function to calculate a unique has for a
+        /// Helper function to calculate a unique hash for a
         /// <see cref="IEntitySpawnDefinition"/>/<see cref="PrototypeVariant"/> pair.
         /// </summary>
         /// <typeparam name="TEntitySpawnDefinition">The type of <see cref="IEntitySpawnDefinition"/></typeparam>

--- a/Scripts/Runtime/Entities/Lifecycle/PrototypeVariant.cs
+++ b/Scripts/Runtime/Entities/Lifecycle/PrototypeVariant.cs
@@ -13,7 +13,6 @@ namespace Anvil.Unity.DOTS.Entities
     /// associated prototype. 
     /// </summary>
     public readonly struct PrototypeVariant : IEquatable<PrototypeVariant>,
-                                              IComponentData,
                                               IToFixedString<FixedString32Bytes>
     {
         public static readonly int UNSET_VALUE = default;


### PR DESCRIPTION
Remove `IComponentData` from `PrototypeVariant`. If projects want to store the variant on their entities they can create their own component object with `PrototypeVariant` as a field.

Also performed some misc formatting cleanup + spelling in docs.

@jkeon Should `PrototypeVariant` get moved into our app project? I don't see it referenced by anything in `anvil-unity-dots`

### What is the current behaviour?

`PrototypeVariant` implements `IComponentData`

### What is the new behaviour?

`PrototypeVariant` no longer implements `IComponentData`

### What issues does this resolve?
 - None

### What PRs does this depend on?
 - None

### Does this introduce a breaking change?
 - [x] Yes - Create your own `IComponentData` implementation to wrap a `PrototypeVariant` value.
 - [ ] No
