### PR TITLE
EnumToFixedStringExtension and EnumerableToFixedStringExtension - Readonly

### DIFF
--- a/Scripts/Runtime/Data/Collections/Util/EnumEnumerableToFixedStringExtension.cs
+++ b/Scripts/Runtime/Data/Collections/Util/EnumEnumerableToFixedStringExtension.cs
@@ -30,11 +30,12 @@ namespace Anvil.Unity.DOTS.Data
         /// <inheritdoc cref="EnumerableToFixedStringExtension.ToFixedString{TCollection, TElement, TElementString, TOutputString}"/>
         /// </returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static TOutputString ToFixedString<TElement, TOutputString>(ref this UnsafeList<TElement> collection)
+        public static TOutputString ToFixedString<TElement, TOutputString>(in this UnsafeList<TElement> collection)
             where TElement : unmanaged, Enum
             where TOutputString : struct, INativeList<byte>, IUTF8Bytes
         {
-            return UnsafeUtility.As<UnsafeList<TElement>, UnsafeList<EnumWrapper<TElement>>>(ref collection)
+            var collectionAsRef = UnsafeUtilityExtensions.AsRef(in collection);
+            return UnsafeUtility.As<UnsafeList<TElement>, UnsafeList<EnumWrapper<TElement>>>(ref collectionAsRef)
                 .ToFixedString<EnumWrapper<TElement>, FixedString32Bytes, TOutputString>();
         }
 
@@ -52,11 +53,12 @@ namespace Anvil.Unity.DOTS.Data
         /// <inheritdoc cref="EnumerableToFixedStringExtension.ToFixedString{TCollection, TElement, TElementString, TOutputString}"/>
         /// </returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static TOutputString ToFixedString<TElement, TOutputString>(ref this NativeList<TElement> collection)
+        public static TOutputString ToFixedString<TElement, TOutputString>(in this NativeList<TElement> collection)
             where TElement : unmanaged, Enum
             where TOutputString : struct, INativeList<byte>, IUTF8Bytes
         {
-            return UnsafeUtility.As<NativeList<TElement>, NativeList<EnumWrapper<TElement>>>(ref collection)
+            var collectionAsRef = UnsafeUtilityExtensions.AsRef(in collection);
+            return UnsafeUtility.As<NativeList<TElement>, NativeList<EnumWrapper<TElement>>>(ref collectionAsRef)
                 .ToFixedString<EnumWrapper<TElement>, FixedString32Bytes, TOutputString>();
         }
 
@@ -73,11 +75,12 @@ namespace Anvil.Unity.DOTS.Data
         /// <returns>
         /// <inheritdoc cref="EnumerableToFixedStringExtension.ToFixedString{TCollection, TElement, TElementString, TOutputString}"/>
         /// </returns>
-        public static TOutputString ToFixedString<TElement, TOutputString>(ref this UnsafeArray<TElement> collection)
+        public static TOutputString ToFixedString<TElement, TOutputString>(in this UnsafeArray<TElement> collection)
             where TElement : unmanaged, Enum
             where TOutputString : struct, INativeList<byte>, IUTF8Bytes
         {
-            return UnsafeUtility.As<UnsafeArray<TElement>, UnsafeArray<EnumWrapper<TElement>>>(ref collection)
+            var collectionAsRef = UnsafeUtilityExtensions.AsRef(in collection);
+            return UnsafeUtility.As<UnsafeArray<TElement>, UnsafeArray<EnumWrapper<TElement>>>(ref collectionAsRef)
                 .ToFixedString<EnumWrapper<TElement>, FixedString32Bytes, TOutputString>();
         }
 
@@ -94,11 +97,12 @@ namespace Anvil.Unity.DOTS.Data
         /// <returns>
         /// <inheritdoc cref="EnumerableToFixedStringExtension.ToFixedString{TCollection, TElement, TElementString, TOutputString}"/>
         /// </returns>
-        public static TOutputString ToFixedString<TElement, TOutputString>(ref this NativeArray<TElement> collection)
+        public static TOutputString ToFixedString<TElement, TOutputString>(in this NativeArray<TElement> collection)
             where TElement : unmanaged, Enum
             where TOutputString : struct, INativeList<byte>, IUTF8Bytes
         {
-            return UnsafeUtility.As<NativeArray<TElement>, NativeArray<EnumWrapper<TElement>>>(ref collection)
+            var collectionAsRef = UnsafeUtilityExtensions.AsRef(in collection);
+            return UnsafeUtility.As<NativeArray<TElement>, NativeArray<EnumWrapper<TElement>>>(ref collectionAsRef)
                 .ToFixedString<EnumWrapper<TElement>, FixedString32Bytes, TOutputString>();
         }
 
@@ -115,33 +119,12 @@ namespace Anvil.Unity.DOTS.Data
         /// <returns>
         /// <inheritdoc cref="EnumerableToFixedStringExtension.ToFixedString{TCollection, TElement, TElementString, TOutputString}"/>
         /// </returns>
-        public static TOutputString ToFixedString<TElement, TOutputString>(ref this NativeArray<TElement>.ReadOnly collection)
+        public static TOutputString ToFixedString<TElement, TOutputString>(in this NativeArray<TElement>.ReadOnly collection)
             where TElement : unmanaged, Enum
             where TOutputString : struct, INativeList<byte>, IUTF8Bytes
         {
-            return UnsafeUtility.As<NativeArray<TElement>.ReadOnly, NativeArray<EnumWrapper<TElement>>.ReadOnly>(ref collection)
-                .ToFixedString<EnumWrapper<TElement>, FixedString32Bytes, TOutputString>();
-        }
-
-        /// <summary>
-        /// Returns a burst compatible string of the collection using
-        /// <see cref="EnumerableToFixedStringExtension.ToFixedString{TCollection, TElement, TElementString, TOutputString}"/>.
-        /// </summary>
-        /// <param name="collection">The collection to generate the string from.</param>
-        /// <typeparam name="TElement">The element's type. Must be an enum.</typeparam>
-        /// <typeparam name="TOutputString">
-        /// The output's string type. This must be large enough to contain the strings of all elements plus one byte
-        /// per element for the comma.
-        /// </typeparam>
-        /// <returns>
-        /// <inheritdoc cref="EnumerableToFixedStringExtension.ToFixedString{TCollection, TElement, TElementString, TOutputString}"/>
-        /// </returns>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static TOutputString ToFixedString<TElement, TOutputString>(ref this FixedList32Bytes<TElement> collection)
-            where TElement : unmanaged, Enum
-            where TOutputString : struct, INativeList<byte>, IUTF8Bytes
-        {
-            return UnsafeUtility.As<FixedList32Bytes<TElement>, FixedList32Bytes<EnumWrapper<TElement>>>(ref collection)
+            var collectionAsRef = UnsafeUtilityExtensions.AsRef(in collection);
+            return UnsafeUtility.As<NativeArray<TElement>.ReadOnly, NativeArray<EnumWrapper<TElement>>.ReadOnly>(ref collectionAsRef)
                 .ToFixedString<EnumWrapper<TElement>, FixedString32Bytes, TOutputString>();
         }
 
@@ -159,11 +142,12 @@ namespace Anvil.Unity.DOTS.Data
         /// <inheritdoc cref="EnumerableToFixedStringExtension.ToFixedString{TCollection, TElement, TElementString, TOutputString}"/>
         /// </returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static TOutputString ToFixedString<TElement, TOutputString>(ref this FixedList64Bytes<TElement> collection)
+        public static TOutputString ToFixedString<TElement, TOutputString>(in this FixedList32Bytes<TElement> collection)
             where TElement : unmanaged, Enum
             where TOutputString : struct, INativeList<byte>, IUTF8Bytes
         {
-            return UnsafeUtility.As<FixedList64Bytes<TElement>, FixedList64Bytes<EnumWrapper<TElement>>>(ref collection)
+            var collectionAsRef = UnsafeUtilityExtensions.AsRef(in collection);
+            return UnsafeUtility.As<FixedList32Bytes<TElement>, FixedList32Bytes<EnumWrapper<TElement>>>(ref collectionAsRef)
                 .ToFixedString<EnumWrapper<TElement>, FixedString32Bytes, TOutputString>();
         }
 
@@ -181,11 +165,12 @@ namespace Anvil.Unity.DOTS.Data
         /// <inheritdoc cref="EnumerableToFixedStringExtension.ToFixedString{TCollection, TElement, TElementString, TOutputString}"/>
         /// </returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static TOutputString ToFixedString<TElement, TOutputString>(ref this FixedList128Bytes<TElement> collection)
+        public static TOutputString ToFixedString<TElement, TOutputString>(in this FixedList64Bytes<TElement> collection)
             where TElement : unmanaged, Enum
             where TOutputString : struct, INativeList<byte>, IUTF8Bytes
         {
-            return UnsafeUtility.As<FixedList128Bytes<TElement>, FixedList128Bytes<EnumWrapper<TElement>>>(ref collection)
+            var collectionAsRef = UnsafeUtilityExtensions.AsRef(in collection);
+            return UnsafeUtility.As<FixedList64Bytes<TElement>, FixedList64Bytes<EnumWrapper<TElement>>>(ref collectionAsRef)
                 .ToFixedString<EnumWrapper<TElement>, FixedString32Bytes, TOutputString>();
         }
 
@@ -203,11 +188,12 @@ namespace Anvil.Unity.DOTS.Data
         /// <inheritdoc cref="EnumerableToFixedStringExtension.ToFixedString{TCollection, TElement, TElementString, TOutputString}"/>
         /// </returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static TOutputString ToFixedString<TElement, TOutputString>(ref this FixedList512Bytes<TElement> collection)
+        public static TOutputString ToFixedString<TElement, TOutputString>(in this FixedList128Bytes<TElement> collection)
             where TElement : unmanaged, Enum
             where TOutputString : struct, INativeList<byte>, IUTF8Bytes
         {
-            return UnsafeUtility.As<FixedList512Bytes<TElement>, FixedList512Bytes<EnumWrapper<TElement>>>(ref collection)
+            var collectionAsRef = UnsafeUtilityExtensions.AsRef(in collection);
+            return UnsafeUtility.As<FixedList128Bytes<TElement>, FixedList128Bytes<EnumWrapper<TElement>>>(ref collectionAsRef)
                 .ToFixedString<EnumWrapper<TElement>, FixedString32Bytes, TOutputString>();
         }
 
@@ -225,21 +211,48 @@ namespace Anvil.Unity.DOTS.Data
         /// <inheritdoc cref="EnumerableToFixedStringExtension.ToFixedString{TCollection, TElement, TElementString, TOutputString}"/>
         /// </returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static TOutputString ToFixedString<TElement, TOutputString>(ref this FixedList4096Bytes<TElement> collection)
+        public static TOutputString ToFixedString<TElement, TOutputString>(in this FixedList512Bytes<TElement> collection)
             where TElement : unmanaged, Enum
             where TOutputString : struct, INativeList<byte>, IUTF8Bytes
         {
-            return UnsafeUtility.As<FixedList4096Bytes<TElement>, FixedList4096Bytes<EnumWrapper<TElement>>>(ref collection)
+            var collectionAsRef = UnsafeUtilityExtensions.AsRef(in collection);
+            return UnsafeUtility.As<FixedList512Bytes<TElement>, FixedList512Bytes<EnumWrapper<TElement>>>(ref collectionAsRef)
+                .ToFixedString<EnumWrapper<TElement>, FixedString32Bytes, TOutputString>();
+        }
+
+        /// <summary>
+        /// Returns a burst compatible string of the collection using
+        /// <see cref="EnumerableToFixedStringExtension.ToFixedString{TCollection, TElement, TElementString, TOutputString}"/>.
+        /// </summary>
+        /// <param name="collection">The collection to generate the string from.</param>
+        /// <typeparam name="TElement">The element's type. Must be an enum.</typeparam>
+        /// <typeparam name="TOutputString">
+        /// The output's string type. This must be large enough to contain the strings of all elements plus one byte
+        /// per element for the comma.
+        /// </typeparam>
+        /// <returns>
+        /// <inheritdoc cref="EnumerableToFixedStringExtension.ToFixedString{TCollection, TElement, TElementString, TOutputString}"/>
+        /// </returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static TOutputString ToFixedString<TElement, TOutputString>(in this FixedList4096Bytes<TElement> collection)
+            where TElement : unmanaged, Enum
+            where TOutputString : struct, INativeList<byte>, IUTF8Bytes
+        {
+            var collectionAsRef = UnsafeUtilityExtensions.AsRef(in collection);
+            return UnsafeUtility.As<FixedList4096Bytes<TElement>, FixedList4096Bytes<EnumWrapper<TElement>>>(ref collectionAsRef)
                 .ToFixedString<EnumWrapper<TElement>, FixedString32Bytes, TOutputString>();
         }
 
         /// <summary>
         /// Wraps an enum of type <see cref="T"/> and implements <see cref="IToFixedString{T}"/>.
         /// </summary>
-        private struct EnumWrapper<T> : IToFixedString<FixedString32Bytes>, IEquatable<EnumWrapper<T>>
+        private readonly struct EnumWrapper<T> : IToFixedString<FixedString32Bytes>, IEquatable<EnumWrapper<T>>
             where T : unmanaged, Enum
         {
-            private T m_Value;
+            private readonly T m_Value;
+
+            // Constructor never used. Only ever used as a type alias for an Enum value.
+            // private EnumWrapper(T m_Value){}
 
             public FixedString32Bytes ToFixedString() => $"{m_Value.ToBurstValue()}";
 

--- a/Scripts/Runtime/Data/Collections/Util/EnumerableToFixedStringExtension.cs
+++ b/Scripts/Runtime/Data/Collections/Util/EnumerableToFixedStringExtension.cs
@@ -27,12 +27,13 @@ namespace Anvil.Unity.DOTS.Data
         /// </typeparam>
         /// <returns>The generated string instance.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static TOutputString ToFixedString<TElement, TElementString, TOutputString>(ref this UnsafeParallelHashSet<TElement> collection)
+        public static TOutputString ToFixedString<TElement, TElementString, TOutputString>(in this UnsafeParallelHashSet<TElement> collection)
             where TElement : unmanaged, IToFixedString<TElementString>, IEquatable<TElement>
             where TElementString : struct, INativeList<byte>, IUTF8Bytes
             where TOutputString : struct, INativeList<byte>, IUTF8Bytes
         {
-            UnsafeParallelHashSet<TElement>.Enumerator enumerator = collection.GetEnumerator();
+            ref var collectionAsRef = ref UnsafeUtilityExtensions.AsRef(in collection);
+            UnsafeParallelHashSet<TElement>.Enumerator enumerator = collectionAsRef.GetEnumerator();
             return enumerator.ToFixedString<UnsafeParallelHashSet<TElement>.Enumerator, TElement, TElementString, TOutputString>();
         }
 
@@ -49,12 +50,13 @@ namespace Anvil.Unity.DOTS.Data
         /// </typeparam>
         /// <returns>The generated string instance.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static TOutputString ToFixedString<TElement, TElementString, TOutputString>(ref this NativeParallelHashSet<TElement> collection)
+        public static TOutputString ToFixedString<TElement, TElementString, TOutputString>(in this NativeParallelHashSet<TElement> collection)
             where TElement : unmanaged, IToFixedString<TElementString>, IEquatable<TElement>
             where TElementString : struct, INativeList<byte>, IUTF8Bytes
             where TOutputString : struct, INativeList<byte>, IUTF8Bytes
         {
-            NativeParallelHashSet<TElement>.Enumerator enumerator = collection.GetEnumerator();
+            ref var collectionAsRef = ref UnsafeUtilityExtensions.AsRef(in collection);
+            NativeParallelHashSet<TElement>.Enumerator enumerator = collectionAsRef.GetEnumerator();
             return enumerator.ToFixedString<NativeParallelHashSet<TElement>.Enumerator, TElement, TElementString, TOutputString>();
         }
 
@@ -71,12 +73,13 @@ namespace Anvil.Unity.DOTS.Data
         /// </typeparam>
         /// <returns>The generated string instance.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static TOutputString ToFixedString<TElement, TElementString, TOutputString>(ref this UnsafeList<TElement> collection)
+        public static TOutputString ToFixedString<TElement, TElementString, TOutputString>(in this UnsafeList<TElement> collection)
             where TElement : unmanaged, IToFixedString<TElementString>
             where TElementString : struct, INativeList<byte>, IUTF8Bytes
             where TOutputString : struct, INativeList<byte>, IUTF8Bytes
         {
-            UnsafeList<TElement>.Enumerator enumerator = collection.GetEnumerator();
+            ref var collectionAsRef = ref UnsafeUtilityExtensions.AsRef(in collection);
+            UnsafeList<TElement>.Enumerator enumerator = collectionAsRef.GetEnumerator();
             return enumerator.ToFixedString<UnsafeList<TElement>.Enumerator, TElement, TElementString, TOutputString>();
         }
 
@@ -93,12 +96,13 @@ namespace Anvil.Unity.DOTS.Data
         /// </typeparam>
         /// <returns>The generated string instance.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static TOutputString ToFixedString<TElement, TElementString, TOutputString>(ref this NativeList<TElement> collection)
+        public static TOutputString ToFixedString<TElement, TElementString, TOutputString>(in this NativeList<TElement> collection)
             where TElement : unmanaged, IToFixedString<TElementString>
             where TElementString : struct, INativeList<byte>, IUTF8Bytes
             where TOutputString : struct, INativeList<byte>, IUTF8Bytes
         {
-            NativeArray<TElement>.Enumerator enumerator = collection.GetEnumerator();
+            ref var collectionAsRef = ref UnsafeUtilityExtensions.AsRef(in collection);
+            NativeArray<TElement>.Enumerator enumerator = collectionAsRef.GetEnumerator();
             return enumerator.ToFixedString<NativeArray<TElement>.Enumerator, TElement, TElementString, TOutputString>();
         }
 
@@ -115,12 +119,13 @@ namespace Anvil.Unity.DOTS.Data
         /// </typeparam>
         /// <returns>The generated string instance.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static TOutputString ToFixedString<TElement, TElementString, TOutputString>(ref this UnsafeArray<TElement> collection)
+        public static TOutputString ToFixedString<TElement, TElementString, TOutputString>(in this UnsafeArray<TElement> collection)
             where TElement : unmanaged, IToFixedString<TElementString>
             where TElementString : struct, INativeList<byte>, IUTF8Bytes
             where TOutputString : struct, INativeList<byte>, IUTF8Bytes
         {
-            UnsafeArray<TElement>.Enumerator enumerator = collection.GetEnumerator();
+            ref var collectionAsRef = ref UnsafeUtilityExtensions.AsRef(in collection);
+            UnsafeArray<TElement>.Enumerator enumerator = collectionAsRef.GetEnumerator();
             return enumerator.ToFixedString<UnsafeArray<TElement>.Enumerator, TElement, TElementString, TOutputString>();
         }
 
@@ -137,12 +142,13 @@ namespace Anvil.Unity.DOTS.Data
         /// </typeparam>
         /// <returns>The generated string instance.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static TOutputString ToFixedString<TElement, TElementString, TOutputString>(ref this NativeArray<TElement> collection)
+        public static TOutputString ToFixedString<TElement, TElementString, TOutputString>(in this NativeArray<TElement> collection)
             where TElement : unmanaged, IToFixedString<TElementString>
             where TElementString : struct, INativeList<byte>, IUTF8Bytes
             where TOutputString : struct, INativeList<byte>, IUTF8Bytes
         {
-            NativeArray<TElement>.Enumerator enumerator = collection.GetEnumerator();
+            ref var collectionAsRef = ref UnsafeUtilityExtensions.AsRef(in collection);
+            NativeArray<TElement>.Enumerator enumerator = collectionAsRef.GetEnumerator();
             return enumerator.ToFixedString<NativeArray<TElement>.Enumerator, TElement, TElementString, TOutputString>();
         }
 
@@ -159,12 +165,13 @@ namespace Anvil.Unity.DOTS.Data
         /// </typeparam>
         /// <returns>The generated string instance.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static TOutputString ToFixedString<TElement, TElementString, TOutputString>(ref this NativeArray<TElement>.ReadOnly collection)
+        public static TOutputString ToFixedString<TElement, TElementString, TOutputString>(in this NativeArray<TElement>.ReadOnly collection)
             where TElement : unmanaged, IToFixedString<TElementString>
             where TElementString : struct, INativeList<byte>, IUTF8Bytes
             where TOutputString : struct, INativeList<byte>, IUTF8Bytes
         {
-            NativeArray<TElement>.ReadOnly.Enumerator enumerator = collection.GetEnumerator();
+            ref var collectionAsRef = ref UnsafeUtilityExtensions.AsRef(in collection);
+            NativeArray<TElement>.ReadOnly.Enumerator enumerator = collectionAsRef.GetEnumerator();
             return enumerator.ToFixedString<NativeArray<TElement>.ReadOnly.Enumerator, TElement, TElementString, TOutputString>();
         }
 
@@ -181,12 +188,13 @@ namespace Anvil.Unity.DOTS.Data
         /// </typeparam>
         /// <returns>The generated string instance.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static TOutputString ToFixedString<TElement, TElementString, TOutputString>(ref this FixedList32Bytes<TElement> collection)
+        public static TOutputString ToFixedString<TElement, TElementString, TOutputString>(in this FixedList32Bytes<TElement> collection)
             where TElement : unmanaged, IToFixedString<TElementString>
             where TElementString : struct, INativeList<byte>, IUTF8Bytes
             where TOutputString : struct, INativeList<byte>, IUTF8Bytes
         {
-            FixedList32Bytes<TElement>.Enumerator enumerator = collection.GetEnumerator();
+            ref var collectionAsRef = ref UnsafeUtilityExtensions.AsRef(in collection);
+            FixedList32Bytes<TElement>.Enumerator enumerator = collectionAsRef.GetEnumerator();
             return enumerator.ToFixedString<FixedList32Bytes<TElement>.Enumerator, TElement, TElementString, TOutputString>();
         }
 
@@ -203,12 +211,13 @@ namespace Anvil.Unity.DOTS.Data
         /// </typeparam>
         /// <returns>The generated string instance.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static TOutputString ToFixedString<TElement, TElementString, TOutputString>(ref this FixedList64Bytes<TElement> collection)
+        public static TOutputString ToFixedString<TElement, TElementString, TOutputString>(in this FixedList64Bytes<TElement> collection)
             where TElement : unmanaged, IToFixedString<TElementString>
             where TElementString : struct, INativeList<byte>, IUTF8Bytes
             where TOutputString : struct, INativeList<byte>, IUTF8Bytes
         {
-            FixedList64Bytes<TElement>.Enumerator enumerator = collection.GetEnumerator();
+            ref var collectionAsRef = ref UnsafeUtilityExtensions.AsRef(in collection);
+            FixedList64Bytes<TElement>.Enumerator enumerator = collectionAsRef.GetEnumerator();
             return enumerator.ToFixedString<FixedList64Bytes<TElement>.Enumerator, TElement, TElementString, TOutputString>();
         }
 
@@ -225,12 +234,13 @@ namespace Anvil.Unity.DOTS.Data
         /// </typeparam>
         /// <returns>The generated string instance.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static TOutputString ToFixedString<TElement, TElementString, TOutputString>(ref this FixedList128Bytes<TElement> collection)
+        public static TOutputString ToFixedString<TElement, TElementString, TOutputString>(in this FixedList128Bytes<TElement> collection)
             where TElement : unmanaged, IToFixedString<TElementString>
             where TElementString : struct, INativeList<byte>, IUTF8Bytes
             where TOutputString : struct, INativeList<byte>, IUTF8Bytes
         {
-            FixedList128Bytes<TElement>.Enumerator enumerator = collection.GetEnumerator();
+            ref var collectionAsRef = ref UnsafeUtilityExtensions.AsRef(in collection);
+            FixedList128Bytes<TElement>.Enumerator enumerator = collectionAsRef.GetEnumerator();
             return enumerator.ToFixedString<FixedList128Bytes<TElement>.Enumerator, TElement, TElementString, TOutputString>();
         }
 
@@ -247,12 +257,13 @@ namespace Anvil.Unity.DOTS.Data
         /// </typeparam>
         /// <returns>The generated string instance.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static TOutputString ToFixedString<TElement, TElementString, TOutputString>(ref this FixedList512Bytes<TElement> collection)
+        public static TOutputString ToFixedString<TElement, TElementString, TOutputString>(in this FixedList512Bytes<TElement> collection)
             where TElement : unmanaged, IToFixedString<TElementString>
             where TElementString : struct, INativeList<byte>, IUTF8Bytes
             where TOutputString : struct, INativeList<byte>, IUTF8Bytes
         {
-            FixedList512Bytes<TElement>.Enumerator enumerator = collection.GetEnumerator();
+            ref var collectionAsRef = ref UnsafeUtilityExtensions.AsRef(in collection);
+            FixedList512Bytes<TElement>.Enumerator enumerator = collectionAsRef.GetEnumerator();
             return enumerator.ToFixedString<FixedList512Bytes<TElement>.Enumerator, TElement, TElementString, TOutputString>();
         }
 
@@ -269,12 +280,13 @@ namespace Anvil.Unity.DOTS.Data
         /// </typeparam>
         /// <returns>The generated string instance.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static TOutputString ToFixedString<TElement, TElementString, TOutputString>(ref this FixedList4096Bytes<TElement> collection)
+        public static TOutputString ToFixedString<TElement, TElementString, TOutputString>(in this FixedList4096Bytes<TElement> collection)
             where TElement : unmanaged, IToFixedString<TElementString>
             where TElementString : struct, INativeList<byte>, IUTF8Bytes
             where TOutputString : struct, INativeList<byte>, IUTF8Bytes
         {
-            FixedList4096Bytes<TElement>.Enumerator enumerator = collection.GetEnumerator();
+            ref var collectionAsRef = ref UnsafeUtilityExtensions.AsRef(in collection);
+            FixedList4096Bytes<TElement>.Enumerator enumerator = collectionAsRef.GetEnumerator();
             return enumerator.ToFixedString<FixedList4096Bytes<TElement>.Enumerator, TElement, TElementString, TOutputString>();
         }
 


### PR DESCRIPTION
Add readonly reference support for the ToFixedString extensions

### What is the current behaviour?

A collection must be passed with a `ref` which means that any readonly references cannot make use of these extension methods.

### What is the new behaviour?

Collections are now pass in with the readonly reference `in` so that readonly referenced collections can now leverage the extension methods.
 - References that were passed into the calling method with `in`
 - `readonly` fields

To accomplish this we're using Unity's dangerous `UnsafeUtilityExtensions.AsRef` to transform a readonly reference into a read/write reference. This is fine because none of our operations cause a mutation to the instance. We just create an enumerator and enumerate. This wouldn't be required if Unity marked their `GetEnumerator()` methods with `readonly`

### What issues does this resolve?
 - None

### What PRs does this depend on?
 - None

### Does this introduce a breaking change?
 - [ ] Yes <!-- If so, what are the migration considerations? -->
 - [x] No
