### PR TITLE
FixedListExtension - Add Remove for Enum lists

### DIFF
--- a/Scripts/Runtime/Data/Collections/Util/FixedListExtension.cs
+++ b/Scripts/Runtime/Data/Collections/Util/FixedListExtension.cs
@@ -103,6 +103,101 @@ namespace Anvil.Unity.DOTS.Data
             return UnsafeUtilityExtensions.AsRef(list).Contains(value);
         }
 
+        /// <inheritdoc cref="FixedList32BytesExtensions.Remove{T,U}"/>
+        /// <remarks>
+        /// A version of <see cref="FixedList32BytesExtensions.Remove{T,U}"/> that is compatible with Enums.
+        /// </remarks>
+        public static bool Remove<TEnum, TUnderlying>(this ref FixedList32Bytes<TEnum> list, TUnderlying value)
+            where TEnum : unmanaged, Enum
+            where TUnderlying : unmanaged, IEquatable<TUnderlying>
+        {
+            int index = list.IndexOf(value);
+            if (index == -1)
+            {
+                return false;
+            }
+
+            list.RemoveAt(index);
+
+            return true;
+        }
+
+        /// <inheritdoc cref="FixedList64BytesExtensions.Remove{T,U}"/>
+        /// <remarks>
+        /// A version of <see cref="FixedList64BytesExtensions.Remove{T,U}"/> that is compatible with Enums.
+        /// </remarks>
+        public static bool Remove<TEnum, TUnderlying>(this ref FixedList64Bytes<TEnum> list, TUnderlying value)
+            where TEnum : unmanaged, Enum
+            where TUnderlying : unmanaged, IEquatable<TUnderlying>
+        {
+            int index = list.IndexOf(value);
+            if (index == -1)
+            {
+                return false;
+            }
+
+            list.RemoveAt(index);
+
+            return true;
+        }
+
+        /// <inheritdoc cref="FixedList128BytesExtensions.Remove{T,U}"/>
+        /// <remarks>
+        /// A version of <see cref="FixedList128BytesExtensions.Remove{T,U}"/> that is compatible with Enums.
+        /// </remarks>
+        public static bool Remove<TEnum, TUnderlying>(this ref FixedList128Bytes<TEnum> list, TUnderlying value)
+            where TEnum : unmanaged, Enum
+            where TUnderlying : unmanaged, IEquatable<TUnderlying>
+        {
+            int index = list.IndexOf(value);
+            if (index == -1)
+            {
+                return false;
+            }
+
+            list.RemoveAt(index);
+
+            return true;
+        }
+
+        /// <inheritdoc cref="FixedList512BytesExtensions.Remove{T,U}"/>
+        /// <remarks>
+        /// A version of <see cref="FixedList512BytesExtensions.Remove{T,U}"/> that is compatible with Enums.
+        /// </remarks>
+        public static bool Remove<TEnum, TUnderlying>(this ref FixedList512Bytes<TEnum> list, TUnderlying value)
+            where TEnum : unmanaged, Enum
+            where TUnderlying : unmanaged, IEquatable<TUnderlying>
+        {
+            int index = list.IndexOf(value);
+            if (index == -1)
+            {
+                return false;
+            }
+
+            list.RemoveAt(index);
+
+            return true;
+        }
+
+        /// <inheritdoc cref="FixedList4096BytesExtensions.Remove{T,U}"/>
+        /// <remarks>
+        /// A version of <see cref="FixedList4096BytesExtensions.Remove{T,U}"/> that is compatible with Enums.
+        /// </remarks>
+        public static bool Remove<TEnum, TUnderlying>(this ref FixedList4096Bytes<TEnum> list, TUnderlying value)
+            where TEnum : unmanaged, Enum
+            where TUnderlying : unmanaged, IEquatable<TUnderlying>
+        {
+            int index = list.IndexOf(value);
+            if (index == -1)
+            {
+                return false;
+            }
+
+            list.RemoveAt(index);
+
+            return true;
+        }
+
         /// <inheritdoc cref="FixedList32BytesExtensions.RemoveSwapBack{T,U}"/>
         /// <remarks>
         /// A version of <see cref="FixedList32BytesExtensions.RemoveSwapBack{T,U}"/> that is compatible with Enums.


### PR DESCRIPTION
Add `Remove(value)` to `FixedListExtension` which helps developers more easily use `FixedList*<Enum>` instances.

### What is the current behaviour?

`FixedListExtension` implements a `RemoveAndSwapBack`, `Contains`, etc.. but no `Remove`

### What is the new behaviour?

`Remove(value)` is implemented.

### What issues does this resolve?
 - None

### What PRs does this depend on?
 - None

### Does this introduce a breaking change?
 - [ ] Yes <!-- If so, what are the migration considerations? -->
 - [x] No
