### PR TITLE
AbstractTaskDriver and ITaskDriver - Expand API

### DIFF
--- a/Scripts/Runtime/Entities/TaskDriver/AbstractTaskDriver.cs
+++ b/Scripts/Runtime/Entities/TaskDriver/AbstractTaskDriver.cs
@@ -60,7 +60,11 @@ namespace Anvil.Unity.DOTS.Entities.TaskDriver
 
         internal DataOwnerID WorldUniqueID { get; }
 
-        protected ITaskDriverSystem System
+        /// <summary>
+        /// Reference to the associated <see cref="TaskDriverSystem"/>.
+        /// Generally used to create <see cref="EntityQuery"/> instances.
+        /// </summary>
+        public ITaskDriverSystem System
         {
             get => new ContextTaskDriverSystemWrapper(TaskDriverSystem, this);
         }

--- a/Scripts/Runtime/Entities/TaskDriver/System/ContextTaskDriverSystemWrapper.cs
+++ b/Scripts/Runtime/Entities/TaskDriver/System/ContextTaskDriverSystemWrapper.cs
@@ -34,31 +34,31 @@ namespace Anvil.Unity.DOTS.Entities.TaskDriver
             m_ContextTaskDriver = contextTaskDriver;
         }
 
-        public ISystemDataStream<TInstance> CreateDataStream<TInstance>(CancelRequestBehaviour cancelRequestBehaviour = CancelRequestBehaviour.Delete, string uniqueContextIdentifier = null) 
+        public ISystemDataStream<TInstance> CreateDataStream<TInstance>(CancelRequestBehaviour cancelRequestBehaviour = CancelRequestBehaviour.Delete, string uniqueContextIdentifier = null)
             where TInstance : unmanaged, IEntityKeyedTask
         {
             return m_TaskDriverSystem.CreateDataStream<TInstance>(m_ContextTaskDriver, cancelRequestBehaviour, uniqueContextIdentifier);
         }
 
-        public ISystemEntityPersistentData<T> CreateEntityPersistentData<T>(string uniqueContextIdentifier = null) 
+        public ISystemEntityPersistentData<T> CreateEntityPersistentData<T>(string uniqueContextIdentifier = null)
             where T : unmanaged, IEntityPersistentDataInstance
         {
             return m_TaskDriverSystem.CreateEntityPersistentData<T>(uniqueContextIdentifier);
         }
 
         public IResolvableJobConfigRequirements ConfigureJobToUpdate<TInstance>(
-            ISystemDataStream<TInstance> dataStream, 
-            JobConfigScheduleDelegates.ScheduleUpdateJobDelegate<TInstance> scheduleJobFunction, 
-            BatchStrategy batchStrategy) 
+            ISystemDataStream<TInstance> dataStream,
+            JobConfigScheduleDelegates.ScheduleUpdateJobDelegate<TInstance> scheduleJobFunction,
+            BatchStrategy batchStrategy)
             where TInstance : unmanaged, IEntityKeyedTask
         {
             return m_TaskDriverSystem.ConfigureJobToUpdate(dataStream, scheduleJobFunction, batchStrategy);
         }
 
         public IResolvableJobConfigRequirements ConfigureJobToCancel<TInstance>(
-            ISystemDataStream<TInstance> dataStream, 
-            JobConfigScheduleDelegates.ScheduleCancelJobDelegate<TInstance> scheduleJobFunction, 
-            BatchStrategy batchStrategy) 
+            ISystemDataStream<TInstance> dataStream,
+            JobConfigScheduleDelegates.ScheduleCancelJobDelegate<TInstance> scheduleJobFunction,
+            BatchStrategy batchStrategy)
             where TInstance : unmanaged, IEntityKeyedTask
         {
             return m_TaskDriverSystem.ConfigureJobToCancel(dataStream, scheduleJobFunction, batchStrategy);
@@ -67,6 +67,11 @@ namespace Anvil.Unity.DOTS.Entities.TaskDriver
         public EntityQuery GetEntityQuery(params ComponentType[] componentTypes)
         {
             return m_TaskDriverSystem.GetEntityQuery(componentTypes);
+        }
+
+        public EntityQuery GetEntityQuery(EntityQueryDesc queryDesc)
+        {
+            return m_TaskDriverSystem.GetEntityQuery(queryDesc);
         }
 
         public override string ToString()

--- a/Scripts/Runtime/Entities/TaskDriver/System/ITaskDriverSystem.cs
+++ b/Scripts/Runtime/Entities/TaskDriver/System/ITaskDriverSystem.cs
@@ -81,5 +81,7 @@ namespace Anvil.Unity.DOTS.Entities.TaskDriver
         /// <param name="componentTypes">The <see cref="ComponentType"/>s to construct the query.</param>
         /// <returns>The <see cref="EntityQuery"/> instance</returns>
         public EntityQuery GetEntityQuery(params ComponentType[] componentTypes);
+
+        public EntityQuery GetEntityQuery(EntityQueryDesc queryDesc);
     }
 }


### PR DESCRIPTION
With Task Drivers, add the ability to:
 - Get a query from the Task Driver System from an `EntityQueryDesc`
 - publicly get the `System` off of a Task Driver instance

### What is the current behaviour?
 - On `ITaskDriverSystem`, there is a GetEntityQuery overload for a list of `ComponentType` but none that accept `EntityQueryDesc`
 - `AbstractTaskDriver` does not expose its backing system to the public context

### What is the new behaviour?
 - On `ITaskDriverSystem`, an overload for `GetEntityQuery(EntityQueryDesc)` has been added.
    - Implementations of the interface have been updated.
 - Change `AbstractTaskDriver.System` to `public`.

### What issues does this resolve?
 - None

### What PRs does this depend on?
 - None

### Does this introduce a breaking change?
 - [ ] Yes <!-- If so, what are the migration considerations? -->
 - [x] No
