### PR TITLE
EntityQueryDescriptionExtension - Add Concat method

### DIFF
--- a/Scripts/Runtime/Entities/Util/EntityQueryDescExtension.cs
+++ b/Scripts/Runtime/Entities/Util/EntityQueryDescExtension.cs
@@ -1,0 +1,29 @@
+using System.Linq;
+using Unity.Entities;
+
+namespace Anvil.Unity.DOTS.Entities
+{
+    /// <summary>
+    /// A collection of extension methods for <see cref="EntityQueryDesc"/>.
+    /// </summary>
+    public static class EntityQueryDescExtension
+    {
+        /// <summary>
+        /// Merge two <see cref="EntityQueryDesc"/> instances into a new instance by concatenating component lists and
+        /// OR merging the <see cref="EntityQueryOptions"/>.
+        /// </summary>
+        /// <param name="desc1">A query description to merge.</param>
+        /// <param name="desc2">A query description to merge.</param>
+        /// <returns>The merged query description (new instance).</returns>
+        public static EntityQueryDesc Concat(this EntityQueryDesc desc1, EntityQueryDesc desc2)
+        {
+            return new EntityQueryDesc()
+            {
+                All = desc1.All.Concat(desc2.All).ToReadOnly().ToArray(),
+                Any = desc1.Any.Concat(desc2.Any).ToReadOnly().ToArray(),
+                None = desc1.None.Concat(desc2.None).ToReadOnly().ToArray(),
+                Options = desc1.Options | desc2.Options
+            };
+        }
+    }
+}

--- a/Scripts/Runtime/Entities/Util/EntityQueryDescExtension.cs.meta
+++ b/Scripts/Runtime/Entities/Util/EntityQueryDescExtension.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 4c808c936e104375a887b175a404319c
+timeCreated: 1694575961


### PR DESCRIPTION
Add the ability to concatenate/merge two `EntityQueryDesc` instances.

### What is the current behaviour?

The developer must manually merge the parameters of two `EntityQueryDesc` instances if they'd like to combine them into a new `EntityQueryDesc`

### What is the new behaviour?

Calling `myEntityQueryDesc.Concat(myOtherEntityQueryDesc)` returns a new `EntityQueryDesc` instance that represents the two combined descriptions.
`EntityQueryOptions` on the instance are `OR` merged.

### What issues does this resolve?
 - None

### What PRs does this depend on?
 - None

### Does this introduce a breaking change?
 - [ ] Yes <!-- If so, what are the migration considerations? -->
 - [x] No
