### PR TITLE
AbstractDataSystem - Add to a default group

### DIFF
--- a/Scripts/Runtime/Entities/AbstractDataSystem.cs
+++ b/Scripts/Runtime/Entities/AbstractDataSystem.cs
@@ -1,11 +1,18 @@
+using Unity.Entities;
+
 namespace Anvil.Unity.DOTS.Entities
 {
     /// <summary>
     /// A system that exists to take advantage of the lifecycle of a world but does not actually need to update.
     /// Used for lookups to get/store data.
     /// </summary>
+    [UpdateInGroup(typeof(Group))]
     public abstract partial class AbstractDataSystem : AbstractAnvilSystemBase
     {
+        //TODO: #172 - Temp to hold all AbstractDataSystem classes until we remove them from the PlayerLoop
+        [UpdateInGroup(typeof(InitializationSystemGroup))]
+        private partial class Group : ComponentSystemGroup { }
+
         //TODO: #172 - Remove from PlayerLoop
         protected override void OnCreate()
         {


### PR DESCRIPTION
Add all `AbstractDataSystem` instances to their own group until #172 is addressed.

This keeps all of the data systems together in the player loop until we have a chance to remove them.

### What is the current behaviour?

`AbstractDataSystem` instances get littered throughout `SimulationSystemGroup` cluttering the player loop with update order that really doesn't matter.

### What is the new behaviour?

`AbstractDataSystem` is now added to the group `AbstractDataSystem.Group` in the `InitializationSystemGroup`.

### What issues does this resolve?
 - None

### What PRs does this depend on?
 - None

### Does this introduce a breaking change?
 - [ ] Yes <!-- If so, what are the migration considerations? -->
 - [x] No
