### PR TITLE
NativeArrayExtension - ElementAt(Readonly) Allow structs

### DIFF
--- a/Scripts/Runtime/Data/Collections/Util/NativeArrayExtension.cs
+++ b/Scripts/Runtime/Data/Collections/Util/NativeArrayExtension.cs
@@ -16,24 +16,24 @@ namespace Anvil.Unity.DOTS.Data
         /// <param name="nativeArray">The <see cref="NativeArray{T}"/></param>
         /// <param name="index">The index to access. Must be in the range of [0..Length).</param>
         /// <returns>A reference to the element at the index.</returns>
-        public static unsafe ref T ElementAt<T>(this NativeArray<T> nativeArray, int index) where T : unmanaged
+        public static unsafe ref T ElementAt<T>(this NativeArray<T> nativeArray, int index) where T : struct
         {
             Debug.Assert(index >= 0 && index < nativeArray.Length);
             return ref UnsafeUtility.ArrayElementAsRef<T>(nativeArray.GetUnsafePtr(), index);
         }
-        
+
         /// <summary>
         /// Returns a read only reference to the element at a given index.
         /// </summary>
         /// <param name="nativeArray">The <see cref="NativeArray{T}"/></param>
         /// <param name="index">The index to access. Must be in the range of [0..Length).</param>
         /// <returns>A reference to the element at the index.</returns>
-        public static unsafe ref readonly T ElementAtReadOnly<T>(this NativeArray<T> nativeArray, int index) where T : unmanaged
+        public static unsafe ref readonly T ElementAtReadOnly<T>(this NativeArray<T> nativeArray, int index) where T : struct
         {
             Debug.Assert(index >= 0 && index < nativeArray.Length);
             return ref UnsafeUtility.ArrayElementAsRef<T>(nativeArray.GetUnsafeReadOnlyPtr(), index);
         }
-        
+
         /// <summary>
         /// Sets all elements in a collection to their default value.
         /// </summary>


### PR DESCRIPTION
Allow the `EleementAt*` methods to accept `struct` types. Not just `unmanaged`

### What is the current behaviour?
Only primitive `unamanged` types are allowed.

### What is the new behaviour?

All `struct` types are allowed to be fetched by reference.

### What issues does this resolve?
 - None

### What PRs does this depend on?
 - None

### Does this introduce a breaking change?
 - [ ] Yes <!-- If so, what are the migration considerations? -->
 - [x] No
