### PR TITLE
AbstractTaskDriver - Assert invalid attributes

### DIFF
--- a/Scripts/Runtime/Entities/TaskDriver/AbstractTaskDriver.cs
+++ b/Scripts/Runtime/Entities/TaskDriver/AbstractTaskDriver.cs
@@ -117,6 +117,8 @@ namespace Anvil.Unity.DOTS.Entities.TaskDriver
         /// </param>
         protected AbstractTaskDriver(World world, AbstractTaskDriver parent = null, string uniqueContextIdentifier = null)
         {
+            DEBUG_EnsureValidAttributes();
+
             World = world;
             Parent = parent;
             //TODO: #241 - This is gross. Needs to be reworked.
@@ -327,6 +329,26 @@ namespace Anvil.Unity.DOTS.Entities.TaskDriver
         //*************************************************************************************************************
         // SAFETY
         //*************************************************************************************************************
+
+        [Conditional("DEBUG")]
+        private void DEBUG_EnsureValidAttributes()
+        {
+            Type type = GetType();
+
+            IEnumerable<string> invalidAttributeNames = type.GetCustomAttributes(true)
+                .Where(attribute => attribute is UpdateAfterAttribute or UpdateBeforeAttribute)
+                .Select(attribute => attribute.GetType().Name);
+
+            if (!invalidAttributeNames.Any())
+            {
+                return;
+            }
+
+            Logger.Error(
+                $"Unsupported Attributes. The following attributes are defined on the task driver but are not supported. (see below)"
+                + $"\n{string.Join(", ", invalidAttributeNames)}"
+                + $"\nNOTE: If the task driver must be ordered define a custom system type to place attributes on.");
+        }
 
         [Conditional("ENABLE_UNITY_COLLECTIONS_CHECKS")]
         private void Debug_EnsureNotHardened()


### PR DESCRIPTION
TaskDrivers only support a subset of Unity's system ordering/placement attributes. We now log errors if the the common ones that aren't supported are defined on a task driver.

I did explore the feasibility of supporting update after/before and it isn't realistic to support while still supporting the ability for other systems to configure their update relative to the task driver. The only solution I could come up with was to implement our own sort and use it instead of the one build into `ComponentSystemGroup`

### What is the current behaviour?

There is no warning when a developer uses `[UpdateAfter]` or`[UpdateBefore]` on their task driver. This can lead them to incorrectly believe that they have ordered their task driver against another system.

This is particularly confusing because ordering against a Task Driver System (Ex: `UpdateAfter(TaskDriverSystem<MyTaskDriver>)` is supported as well as placing `[UpdateInGroup]` on a task driver.

### What is the new behaviour?

If a developer defines `[UpdateAfter]` or`[UpdateBefore]` on their task driver and runs with `DEBUG` enabled an error message will be emitted.

### What issues does this resolve?
 - None

### What PRs does this depend on?
 - None

### Does this introduce a breaking change?
 - [ ] Yes <!-- If so, what are the migration considerations? -->
 - [x] No - Unless you were using these attributes on your TD! In which case just delete them...they weren't doing anything.
