### PR TITLE
`UnsafeArrayUtility` - Add `AsUnsafeArray` overloads

### DIFF
--- a/Scripts/Runtime/Data/Collections/Util/UnsafeArrayUtility.cs
+++ b/Scripts/Runtime/Data/Collections/Util/UnsafeArrayUtility.cs
@@ -3,6 +3,7 @@ using System;
 using System.Diagnostics;
 using Unity.Collections;
 using Unity.Collections.LowLevel.Unsafe;
+using Unity.Entities;
 
 namespace Anvil.Unity.DOTS.Data
 {
@@ -46,6 +47,22 @@ namespace Anvil.Unity.DOTS.Data
                 NativeArrayUnsafeUtility.GetUnsafeBufferPointerWithoutChecks(nativeArray),
                 nativeArray.Length,
                 nativeArray.GetAllocator());
+        }
+
+        public static unsafe UnsafeArray<T> AsUnsafeArray<T>(this DynamicBuffer<T> buffer, bool isReadOnly = false) where T : unmanaged
+        {
+#if ENABLE_UNITY_COLLECTIONS_CHECKS
+            void* ptr = isReadOnly ? buffer.GetUnsafeReadOnlyPtr() : buffer.GetUnsafePtr();
+#else
+            // Avoid the conditional when we're not enforcing safety. The way we get the pointer doesn't matter when
+            // safety is off.
+            void* ptr = buffer.GetUnsafePtr();
+#endif
+
+            return ConvertExistingDataToUnsafeArray<T>(
+                ptr,
+                buffer.Length,
+                Allocator.None);
         }
 
         public static unsafe void* GetUnsafePtr<T>(this UnsafeArray<T> nativeArray) where T : unmanaged

--- a/Scripts/Runtime/Data/Collections/Util/UnsafeArrayUtility.cs
+++ b/Scripts/Runtime/Data/Collections/Util/UnsafeArrayUtility.cs
@@ -65,6 +65,11 @@ namespace Anvil.Unity.DOTS.Data
                 Allocator.None);
         }
 
+        public static unsafe UnsafeArray<T> AsUnsafeArray<T>(this UnsafeList<T> list) where T : unmanaged
+        {
+            return ConvertExistingDataToUnsafeArray<T>(list.Ptr, list.Length, list.Allocator.ToAllocator);
+        }
+
         public static unsafe void* GetUnsafePtr<T>(this UnsafeArray<T> nativeArray) where T : unmanaged
         {
             return nativeArray.m_Buffer;


### PR DESCRIPTION
Add two more overloads for `UnsafeArrayUtility.AsUnsafeArray` that represent `DynamicBuffer<T>` and `UnsafeList<T>` as `UnsafeArray<T>` instances

### What is the current behaviour?
Users don't have a convenient way to represent a `DynamicBuffer<T>` or `UnsafeList<T>` as an `UnsafeArray<T>`.

### What is the new behaviour?
Users can now call `AsUnsafeArray` on both `DynamicBuffer<T>` and `UnsafeList<T>` instances.

### What issues does this resolve?
 - None

### What PRs does this depend on?
 - None

### Does this introduce a breaking change?
 - [ ] Yes <!-- If so, what are the migration considerations? -->
 - [x] No
