### PR TITLE
UnsafeArray - Make AsReadOnly a pure method

### DIFF
--- a/Scripts/Runtime/Data/Collections/UnsafeArray.cs
+++ b/Scripts/Runtime/Data/Collections/UnsafeArray.cs
@@ -508,7 +508,7 @@ namespace Anvil.Unity.DOTS.Data
             return unsafeArray;
         }
 
-        public unsafe ReadOnly AsReadOnly() => new ReadOnly(m_Buffer, m_Length);
+        public readonly unsafe ReadOnly AsReadOnly() => new ReadOnly(m_Buffer, m_Length);
 
         [ExcludeFromDocs]
         public struct Enumerator : IEnumerator<T>, IEnumerator, IDisposable


### PR DESCRIPTION
Make `UnsafeArray.AsReadOnly` a pure method. This prevents a defensive copy when the instance is `readonly`

### What is the current behaviour?

`AsReadonly()` is not marked `readonly` even though it will never mutate the instance. This causes a defensive copy when the instance is readonly referenced (`readonly` field, `in`, `ref readonly`, etc...)

### What is the new behaviour?

`UnsafeArray.AsReadOnly` is marked as `readonly` indicating to the runtime that it's safe to call this method without creating a defensive copy.

### What issues does this resolve?
 - None

### What PRs does this depend on?
 - None

### Does this introduce a breaking change?
 - [ ] Yes <!-- If so, what are the migration considerations? -->
 - [x] No - "free" performance
