### PR TITLE
`CDFEWriter` - Allow to masquerade as a reader

### DIFF
--- a/Scripts/Runtime/Entities/Data/CDFEReader.cs
+++ b/Scripts/Runtime/Entities/Data/CDFEReader.cs
@@ -28,6 +28,12 @@ namespace Anvil.Unity.DOTS.Entities
             m_CDFE = system.GetComponentDataFromEntity<T>(true);
         }
 
+        internal CDFEReader(ComponentDataFromEntity<T> rawCDFE)
+        {
+            m_CDFE = rawCDFE;
+        }
+
+
         /// <inheritdoc cref="ComponentDataFromEntity{T}.HasComponent"/>
         public bool HasComponent(Entity entity) => m_CDFE.HasComponent(entity);
 

--- a/Scripts/Runtime/Entities/Data/CDFEWriter.cs
+++ b/Scripts/Runtime/Entities/Data/CDFEWriter.cs
@@ -46,5 +46,14 @@ namespace Anvil.Unity.DOTS.Entities
 
         /// <inheritdoc cref="ComponentDataFromEntity{T}.TryGetComponent"/>
         public bool TryGetComponent(Entity entity, out T component) => m_CDFE.TryGetComponent(entity, out component);
+
+        /// <summary>
+        /// Create a <see cref="CDFEReader{T}"/> version of the writer.
+        /// </summary>
+        /// <returns>A <see cref="CDFEReader{T}"/> of the same type.</returns>
+        public CDFEReader<T> AsReader()
+        {
+            return new CDFEReader<T>(m_CDFE);
+        }
     }
 }


### PR DESCRIPTION
Add an `AsReadOnly()` method to `CDFEWriter`. This helps the instance conform to APIs that are expecting `CDFEReader`s.

### What is the current behaviour?

If the developer has a `CDFEWriter` there is no way to use it for APIs that require `CDFEReader` instances.

### What is the new behaviour?

Developers can call `AsReadOnly` on a `CDFEWriter` to have it be used purely as a reader.

### What issues does this resolve?
 - None

### What PRs does this depend on?
 - None

### Does this introduce a breaking change?
 - [ ] Yes <!-- If so, what are the migration considerations? -->
 - [x] No
